### PR TITLE
Fix missing Message method.

### DIFF
--- a/src/main/kotlin/com/embabel/dice/incremental/ConversationSource.kt
+++ b/src/main/kotlin/com/embabel/dice/incremental/ConversationSource.kt
@@ -48,7 +48,7 @@ class MessageFormatter : IncrementalSourceFormatter<Message> {
 
     override fun format(items: List<Message>): String {
         return items.joinToString("\n\n") { message ->
-            val sender = message.sender ?: message.role.name
+            val sender = message.role.displayName
             "$sender: ${message.content}"
         }
     }


### PR DESCRIPTION
 # Fix compilation against embabel-agent 0.3.4

##  Summary

  - Message.sender was never part of the Message interface — it only existed on BaseMessage. After the chat-store integration into embabel-agent,
  Conversation.messages returns Message instances, causing a compilation failure.
  - Use the new MessageRole.displayName property instead.

##  Changes

  - ConversationSource.kt: Replace message.sender ?: message.role.name with message.role.displayName
