### PR TITLE
Enhance CI with Discord notifications

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,3 +35,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -U -B test verify
+
+  notify:
+    needs: [build]
+    if: failure() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/discord-notify.yml@main
+    secrets: inherit
+
+  notify-recovery:
+    needs: [build]
+    if: success() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/notify-recovery.yml@main
+    with:
+      branch: main
+    secrets: inherit


### PR DESCRIPTION
This pull request adds automated Discord notifications to the Maven workflow to improve visibility of build failures and recoveries on the `main` branch. Two new jobs are introduced: one to alert when the build fails, and another to notify when the build recovers.

**Notification workflow enhancements:**

* Added a `notify` job that triggers a Discord notification if the `build` job fails on the `main` branch, using the shared `discord-notify.yml` workflow.
* Added a `notify-recovery` job that sends a recovery notification to Discord when the `build` job succeeds after a failure on the `main` branch, using the shared `notify-recovery.yml` workflow and passing the branch name as a parameter.Add notification steps for build success and failure.