### PR TITLE
feat: provenance temporal lineage

### DIFF
--- a/src/main/kotlin/com/embabel/dice/projection/lineage/AlwaysCreateReconciler.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/AlwaysCreateReconciler.kt
@@ -18,11 +18,13 @@ package com.embabel.dice.projection.lineage
 import com.embabel.dice.proposition.Proposition
 
 /**
- * Trivial [Reconciler] that always creates a new artifact.
+ * [Reconciler] that always returns [ReconciliationDecision.CreateNew], the
+ * projection counterpart of
+ * [com.embabel.dice.common.resolver.AlwaysCreateEntityResolver].
  *
- * Mirrors `com.embabel.dice.common.resolver.AlwaysCreateEntityResolver`.
- * Useful as a default/stub; not appropriate for production where node
- * duplication against an existing domain graph is a concern.
+ * Useful as a default implementation and in tests. It performs no matching
+ * against existing artifacts, so it is not suitable where duplication within a
+ * target store must be avoided.
  */
 object AlwaysCreateReconciler : Reconciler {
 

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/AlwaysCreateReconciler.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/AlwaysCreateReconciler.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.lineage
+
+import com.embabel.dice.proposition.Proposition
+
+/**
+ * Trivial [Reconciler] that always creates a new artifact.
+ *
+ * Mirrors `com.embabel.dice.common.resolver.AlwaysCreateEntityResolver`.
+ * Useful as a default/stub; not appropriate for production where node
+ * duplication against an existing domain graph is a concern.
+ */
+object AlwaysCreateReconciler : Reconciler {
+
+    override fun reconcile(proposition: Proposition, target: String): ReconciliationDecision =
+        ReconciliationDecision.CreateNew
+}

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/InMemoryProjectionRecordStore.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/InMemoryProjectionRecordStore.kt
@@ -19,11 +19,12 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
- * Thread-safe in-memory implementation of [ProjectionRecordStore].
+ * Thread-safe in-memory [ProjectionRecordStore].
  *
- * Intended as a default/stub for demos and tests. Records are append-only and
- * returned in insertion order. Backed by a [CopyOnWriteArrayList] so reads never
- * block writes.
+ * Records are append-only and returned in insertion order. Backed by a
+ * [CopyOnWriteArrayList], so reads never block writes. Intended as a default
+ * implementation for tests and lightweight usage; production deployments should
+ * supply a persistent store.
  */
 class InMemoryProjectionRecordStore : ProjectionRecordStore {
 

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/InMemoryProjectionRecordStore.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/InMemoryProjectionRecordStore.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.lineage
+
+import org.slf4j.LoggerFactory
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Thread-safe in-memory implementation of [ProjectionRecordStore].
+ *
+ * Intended as a default/stub for demos and tests. Records are append-only and
+ * returned in insertion order. Backed by a [CopyOnWriteArrayList] so reads never
+ * block writes.
+ */
+class InMemoryProjectionRecordStore : ProjectionRecordStore {
+
+    private val logger = LoggerFactory.getLogger(InMemoryProjectionRecordStore::class.java)
+
+    private val records = CopyOnWriteArrayList<ProjectionRecord>()
+
+    override fun record(record: ProjectionRecord) {
+        records.add(record)
+        logger.debug(
+            "Recorded projection lineage: propositionId={}, target={}, lifecycle={}, runId={}",
+            record.propositionId, record.target, record.lifecycle, record.runId,
+        )
+    }
+
+    override fun all(): List<ProjectionRecord> = records.toList()
+}

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionLifecycle.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionLifecycle.kt
@@ -18,8 +18,8 @@ package com.embabel.dice.projection.lineage
 /**
  * Lifecycle state of a single proposition-to-target projection.
  *
- * These states let consumers keep graph/Prolog/memory/report views aligned with
- * proposition truth and answer "what projected where, and is it still valid?".
+ * Allows consumers to keep projected views aligned with the current state of a
+ * proposition and to determine whether a given projection is still valid.
  */
 enum class ProjectionLifecycle {
 

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionLifecycle.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionLifecycle.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.lineage
+
+/**
+ * Lifecycle state of a single proposition-to-target projection.
+ *
+ * These states let consumers keep graph/Prolog/memory/report views aligned with
+ * proposition truth and answer "what projected where, and is it still valid?".
+ */
+enum class ProjectionLifecycle {
+
+    /** The proposition was projected to the target as a newly created artifact. */
+    PROJECTED,
+
+    /** The projection was aligned onto / adopted an existing artifact in the target. */
+    ADOPTED,
+
+    /** The proposition was intentionally not projected (did not meet criteria). */
+    SKIPPED,
+
+    /** Projection to the target failed (error or incompatibility). */
+    FAILED,
+
+    /**
+     * A previously valid projection is now out of date because the underlying
+     * proposition changed (e.g. superseded, contradicted, or re-extracted).
+     */
+    STALE
+}

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRecord.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRecord.kt
@@ -18,15 +18,15 @@ package com.embabel.dice.projection.lineage
 import java.time.Instant
 
 /**
- * A record of one proposition being projected to one target.
+ * A record of a single proposition projected to a single target.
  *
- * Collectively these records form a generic inverse index — "which propositions
- * projected where" — so a reviewer can trace a graph node, Prolog fact, or report
- * line back to the propositions that produced it, and can tell whether an
- * artifact was created, adopted/aligned, skipped, failed, or has gone stale.
+ * Collectively these records form an inverse index of which propositions
+ * projected to which targets, allowing a projected artifact to be traced back to
+ * the propositions that produced it and its current [ProjectionLifecycle] to be
+ * inspected.
  *
  * @property propositionId ID of the proposition that was projected
- * @property target The projection target (e.g. "neo4j", "prolog", "report")
+ * @property target The projection target (e.g. "graph", "prolog", "report")
  * @property targetRef Optional reference to the produced/adopted artifact in the target
  *   (e.g. a node ID), or null when none applies
  * @property lifecycle Lifecycle state of this projection

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRecord.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRecord.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.lineage
+
+import java.time.Instant
+
+/**
+ * A record of one proposition being projected to one target.
+ *
+ * Collectively these records form a generic inverse index — "which propositions
+ * projected where" — so a reviewer can trace a graph node, Prolog fact, or report
+ * line back to the propositions that produced it, and can tell whether an
+ * artifact was created, adopted/aligned, skipped, failed, or has gone stale.
+ *
+ * @property propositionId ID of the proposition that was projected
+ * @property target The projection target (e.g. "neo4j", "prolog", "report")
+ * @property targetRef Optional reference to the produced/adopted artifact in the target
+ *   (e.g. a node ID), or null when none applies
+ * @property lifecycle Lifecycle state of this projection
+ * @property runId ID of the projection run that produced this record
+ * @property at When this record was created
+ * @property reason Optional explanation (e.g. skip/failure reason)
+ */
+data class ProjectionRecord @JvmOverloads constructor(
+    val propositionId: String,
+    val target: String,
+    val targetRef: String? = null,
+    val lifecycle: ProjectionLifecycle,
+    val runId: String,
+    val at: Instant = Instant.now(),
+    val reason: String? = null,
+) {
+
+    init {
+        require(propositionId.isNotBlank()) { "propositionId must not be blank" }
+        require(target.isNotBlank()) { "target must not be blank" }
+        require(runId.isNotBlank()) { "runId must not be blank" }
+    }
+
+    companion object {
+
+        /**
+         * Java-friendly factory method to create a [ProjectionRecord].
+         *
+         * @param propositionId ID of the projected proposition
+         * @param target The projection target
+         * @param lifecycle Lifecycle state of this projection
+         * @param runId ID of the projection run
+         * @param targetRef Optional reference to the produced/adopted artifact
+         * @param at When this record was created
+         * @param reason Optional explanation
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun of(
+            propositionId: String,
+            target: String,
+            lifecycle: ProjectionLifecycle,
+            runId: String,
+            targetRef: String? = null,
+            at: Instant = Instant.now(),
+            reason: String? = null,
+        ): ProjectionRecord = ProjectionRecord(
+            propositionId = propositionId,
+            target = target,
+            targetRef = targetRef,
+            lifecycle = lifecycle,
+            runId = runId,
+            at = at,
+            reason = reason,
+        )
+    }
+}

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRecordStore.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRecordStore.kt
@@ -16,11 +16,12 @@
 package com.embabel.dice.projection.lineage
 
 /**
- * Store of [ProjectionRecord]s — the inverse index of "what projected where".
+ * Store of [ProjectionRecord]s: an inverse index of which propositions projected
+ * to which targets.
  *
- * Implementations may be in-memory, graph-backed, or relational. The default
- * query methods are expressed in terms of [all] so that simple implementations
- * only need to supply [record] and [all].
+ * The query methods are defined in terms of [all], so an implementation need only
+ * provide [record] and [all]. Backing stores may be in-memory, graph-backed, or
+ * relational.
  */
 interface ProjectionRecordStore {
 
@@ -43,7 +44,7 @@ interface ProjectionRecordStore {
     /**
      * Find all records for a given target.
      *
-     * @param target The projection target (e.g. "neo4j")
+     * @param target The projection target (e.g. "graph")
      * @return records whose [ProjectionRecord.target] matches
      */
     fun findByTarget(target: String): List<ProjectionRecord> =

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRecordStore.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRecordStore.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.lineage
+
+/**
+ * Store of [ProjectionRecord]s — the inverse index of "what projected where".
+ *
+ * Implementations may be in-memory, graph-backed, or relational. The default
+ * query methods are expressed in terms of [all] so that simple implementations
+ * only need to supply [record] and [all].
+ */
+interface ProjectionRecordStore {
+
+    /**
+     * Record a projection outcome.
+     *
+     * @param record The projection record to store
+     */
+    fun record(record: ProjectionRecord)
+
+    /**
+     * Find all records for a given proposition.
+     *
+     * @param propositionId ID of the proposition
+     * @return records whose [ProjectionRecord.propositionId] matches
+     */
+    fun findByProposition(propositionId: String): List<ProjectionRecord> =
+        all().filter { it.propositionId == propositionId }
+
+    /**
+     * Find all records for a given target.
+     *
+     * @param target The projection target (e.g. "neo4j")
+     * @return records whose [ProjectionRecord.target] matches
+     */
+    fun findByTarget(target: String): List<ProjectionRecord> =
+        all().filter { it.target == target }
+
+    /**
+     * Find all records produced by a given run.
+     *
+     * @param runId ID of the projection run
+     * @return records whose [ProjectionRecord.runId] matches
+     */
+    fun findByRun(runId: String): List<ProjectionRecord> =
+        all().filter { it.runId == runId }
+
+    /**
+     * Find all records currently in the [ProjectionLifecycle.STALE] state.
+     *
+     * @return records whose lifecycle is STALE
+     */
+    fun findStale(): List<ProjectionRecord> =
+        all().filter { it.lifecycle == ProjectionLifecycle.STALE }
+
+    /**
+     * @return all records held by this store
+     */
+    fun all(): List<ProjectionRecord>
+}

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRun.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRun.kt
@@ -18,18 +18,16 @@ package com.embabel.dice.projection.lineage
 import java.time.Instant
 
 /**
- * A record of a projection run — a single batch of projection work against a target.
+ * A single batch of projection work against a target.
  *
- * Inspired by consolidation/audit-run records: a run groups many
- * [ProjectionRecord]s under a shared [runId] so projection, collector, and
- * reconciliation jobs have generic run history.
- *
- * Computed counts are intentionally out of scope; this is a plain record.
+ * A run groups its [ProjectionRecord]s under a shared [runId], giving projection
+ * and reconciliation jobs a common run history. This is a plain record; aggregate
+ * counts are out of scope.
  *
  * @property runId Unique identifier for this run (matches [ProjectionRecord.runId])
  * @property startedAt When the run started
  * @property finishedAt When the run finished, or null if still running
- * @property target The projection target this run wrote to (e.g. "neo4j")
+ * @property target The projection target this run wrote to (e.g. "graph")
  */
 data class ProjectionRun @JvmOverloads constructor(
     val runId: String,

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRun.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/ProjectionRun.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.lineage
+
+import java.time.Instant
+
+/**
+ * A record of a projection run — a single batch of projection work against a target.
+ *
+ * Inspired by consolidation/audit-run records: a run groups many
+ * [ProjectionRecord]s under a shared [runId] so projection, collector, and
+ * reconciliation jobs have generic run history.
+ *
+ * Computed counts are intentionally out of scope; this is a plain record.
+ *
+ * @property runId Unique identifier for this run (matches [ProjectionRecord.runId])
+ * @property startedAt When the run started
+ * @property finishedAt When the run finished, or null if still running
+ * @property target The projection target this run wrote to (e.g. "neo4j")
+ */
+data class ProjectionRun @JvmOverloads constructor(
+    val runId: String,
+    val startedAt: Instant,
+    val finishedAt: Instant? = null,
+    val target: String,
+) {
+
+    init {
+        require(runId.isNotBlank()) { "runId must not be blank" }
+        require(target.isNotBlank()) { "target must not be blank" }
+        require(finishedAt == null || !finishedAt.isBefore(startedAt)) {
+            "finishedAt must be null or >= startedAt"
+        }
+    }
+
+    /**
+     * Create a copy marked finished at the given instant.
+     *
+     * @param at When the run finished (defaults to now)
+     * @return a copy with [finishedAt] set
+     */
+    fun finished(at: Instant = Instant.now()): ProjectionRun = copy(finishedAt = at)
+}

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/Reconciler.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/Reconciler.kt
@@ -18,15 +18,14 @@ package com.embabel.dice.projection.lineage
 import com.embabel.dice.proposition.Proposition
 
 /**
- * SPI for reconciling a proposition's projection against existing artifacts in
- * a target backend — deciding whether to create new, adopt, or align.
+ * Strategy for reconciling a proposition's projection against artifacts that
+ * already exist in a target backend, deciding whether to create a new artifact,
+ * adopt an existing one, or align with it.
  *
- * Implementations encode backend-specific matching strategy (exact key, fuzzy
- * name, vector similarity, etc.), but the contract itself is backend-agnostic:
- * given a proposition and a target name, return a [ReconciliationDecision].
- *
- * Mirrors the existing entity-resolution SPI pattern (see
- * `com.embabel.dice.common.EntityResolver`), but for projection targets rather
+ * Implementations encode the backend-specific matching strategy (for example
+ * exact key, fuzzy name, or vector similarity); the contract itself is
+ * backend-agnostic. This mirrors the entity-resolution contract defined by
+ * [com.embabel.dice.common.EntityResolver], applied to projection targets rather
  * than entity mentions.
  */
 interface Reconciler {
@@ -35,7 +34,7 @@ interface Reconciler {
      * Decide how [proposition] should be projected to [target].
      *
      * @param proposition The proposition being projected
-     * @param target The projection target (e.g. "neo4j")
+     * @param target The projection target (e.g. "graph")
      * @return whether to create new, adopt, or align with an existing artifact
      */
     fun reconcile(proposition: Proposition, target: String): ReconciliationDecision

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/Reconciler.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/Reconciler.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.lineage
+
+import com.embabel.dice.proposition.Proposition
+
+/**
+ * SPI for reconciling a proposition's projection against existing artifacts in
+ * a target backend — deciding whether to create new, adopt, or align.
+ *
+ * Implementations encode backend-specific matching strategy (exact key, fuzzy
+ * name, vector similarity, etc.), but the contract itself is backend-agnostic:
+ * given a proposition and a target name, return a [ReconciliationDecision].
+ *
+ * Mirrors the existing entity-resolution SPI pattern (see
+ * `com.embabel.dice.common.EntityResolver`), but for projection targets rather
+ * than entity mentions.
+ */
+interface Reconciler {
+
+    /**
+     * Decide how [proposition] should be projected to [target].
+     *
+     * @param proposition The proposition being projected
+     * @param target The projection target (e.g. "neo4j")
+     * @return whether to create new, adopt, or align with an existing artifact
+     */
+    fun reconcile(proposition: Proposition, target: String): ReconciliationDecision
+}

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/ReconciliationDecision.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/ReconciliationDecision.kt
@@ -16,14 +16,14 @@
 package com.embabel.dice.projection.lineage
 
 /**
- * Decision about how a proposition should be projected relative to existing
- * artifacts in a target backend — i.e. how to reconcile the projection with
- * what is already there.
+ * How a proposition should be projected relative to artifacts that already exist
+ * in a target backend: create a new artifact, adopt an existing one, or align
+ * with it.
  *
- * This is the backend-agnostic seam for "project onto an existing domain node
- * vs create new vs align", letting DICE avoid duplicating nodes in a domain
- * graph it does not own. (Conceptually the get-or-create/MERGE choice a target
- * store like Neo4j makes, surfaced as an explicit SPI result.)
+ * Returned by a [Reconciler] so that projection logic can avoid duplicating
+ * artifacts in a target store that DICE does not own. The reconciliation choice
+ * is expressed as an explicit result rather than being hidden inside
+ * backend-specific code.
  */
 sealed interface ReconciliationDecision {
 

--- a/src/main/kotlin/com/embabel/dice/projection/lineage/ReconciliationDecision.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/lineage/ReconciliationDecision.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.lineage
+
+/**
+ * Decision about how a proposition should be projected relative to existing
+ * artifacts in a target backend — i.e. how to reconcile the projection with
+ * what is already there.
+ *
+ * This is the backend-agnostic seam for "project onto an existing domain node
+ * vs create new vs align", letting DICE avoid duplicating nodes in a domain
+ * graph it does not own. (Conceptually the get-or-create/MERGE choice a target
+ * store like Neo4j makes, surfaced as an explicit SPI result.)
+ */
+sealed interface ReconciliationDecision {
+
+    /**
+     * No matching artifact exists; create a new one in the target.
+     */
+    object CreateNew : ReconciliationDecision
+
+    /**
+     * Adopt an existing target artifact as the projection of this proposition.
+     * The proposition's projected identity becomes [targetRef].
+     *
+     * @property targetRef Reference to the existing artifact to adopt
+     */
+    data class Adopt(val targetRef: String) : ReconciliationDecision {
+        init {
+            require(targetRef.isNotBlank()) { "targetRef must not be blank" }
+        }
+    }
+
+    /**
+     * Align this proposition with an existing target artifact without fully
+     * adopting it — e.g. add/merge attributes while keeping distinct identity.
+     *
+     * @property targetRef Reference to the existing artifact to align with
+     */
+    data class Align(val targetRef: String) : ReconciliationDecision {
+        init {
+            require(targetRef.isNotBlank()) { "targetRef must not be blank" }
+        }
+    }
+}

--- a/src/main/kotlin/com/embabel/dice/proposition/Proposition.kt
+++ b/src/main/kotlin/com/embabel/dice/proposition/Proposition.kt
@@ -70,10 +70,10 @@ enum class PropositionStatus {
  * @property reinforceCount How many times this proposition has been merged or reinforced.
  *   Provides a frequency/importance signal complementary to confidence and decay.
  * @property temporal Optional bitemporal metadata (observed/valid time, supersession,
- *   contradiction). Null when temporal correctness is not tracked for this proposition.
- * @property groundingEntries Rich grounding entries linking this proposition to source
- *   material via [com.embabel.dice.provenance.SourceLocator]. Complements the legacy
- *   chunk-id-only [grounding] list.
+ *   contradiction). Null when temporal information is not tracked for this proposition.
+ * @property groundingEntries Grounding entries linking this proposition to source
+ *   material via [com.embabel.dice.provenance.SourceLocator]. Carries more detail
+ *   than the chunk-id-only [grounding] list.
  */
 data class Proposition(
     override val id: String = UUID.randomUUID().toString(),
@@ -222,7 +222,7 @@ data class Proposition(
         copy(temporal = temporal, revised = Instant.now())
 
     /**
-     * Create a copy with additional rich grounding entries.
+     * Create a copy with the given grounding entries appended (de-duplicated).
      */
     fun withGroundingEntries(entries: List<GroundingEntry>): Proposition =
         copy(groundingEntries = (groundingEntries + entries).distinct(), revised = Instant.now())

--- a/src/main/kotlin/com/embabel/dice/proposition/Proposition.kt
+++ b/src/main/kotlin/com/embabel/dice/proposition/Proposition.kt
@@ -18,7 +18,7 @@ package com.embabel.dice.proposition
 import com.embabel.agent.core.ContextId
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.common.core.types.ZeroToOne
-import com.embabel.dice.provenance.GroundingEntry
+import com.embabel.dice.provenance.ProvenanceEntry
 import com.embabel.dice.temporal.TemporalMetadata
 import java.time.Instant
 import java.util.*
@@ -71,9 +71,10 @@ enum class PropositionStatus {
  *   Provides a frequency/importance signal complementary to confidence and decay.
  * @property temporal Optional bitemporal metadata (observed/valid time, supersession,
  *   contradiction). Null when temporal information is not tracked for this proposition.
- * @property groundingEntries Grounding entries linking this proposition to source
- *   material via [com.embabel.dice.provenance.SourceLocator]. Carries more detail
- *   than the chunk-id-only [grounding] list.
+ * @property provenanceEntries Rich source-material provenance for this proposition
+ *   (locator, originating chunk, character offsets, content hash) via
+ *   [com.embabel.dice.provenance.SourceLocator]. Independent of the [grounding]
+ *   field's chunk/entity ids.
  */
 data class Proposition(
     override val id: String = UUID.randomUUID().toString(),
@@ -95,7 +96,7 @@ data class Proposition(
     override val metadata: Map<String, Any> = emptyMap(),
     override val uri: String? = null,
     val temporal: TemporalMetadata? = null,
-    val groundingEntries: List<GroundingEntry> = emptyList(),
+    val provenanceEntries: List<ProvenanceEntry> = emptyList(),
 ) : Derivation, ReferencesEntities, Retrievable {
 
     /**
@@ -142,7 +143,7 @@ data class Proposition(
             metadata: Map<String, Any> = emptyMap(),
             uri: String? = null,
             temporal: TemporalMetadata? = null,
-            groundingEntries: List<GroundingEntry> = emptyList(),
+            provenanceEntries: List<ProvenanceEntry> = emptyList(),
         ): Proposition = Proposition(
             id = id,
             contextId = ContextId(contextIdValue),
@@ -163,7 +164,7 @@ data class Proposition(
             metadata = metadata,
             uri = uri,
             temporal = temporal,
-            groundingEntries = groundingEntries,
+            provenanceEntries = provenanceEntries,
         )
     }
 
@@ -222,10 +223,10 @@ data class Proposition(
         copy(temporal = temporal, revised = Instant.now())
 
     /**
-     * Create a copy with the given grounding entries appended (de-duplicated).
+     * Create a copy with the given provenance entries appended (de-duplicated).
      */
-    fun withGroundingEntries(entries: List<GroundingEntry>): Proposition =
-        copy(groundingEntries = (groundingEntries + entries).distinct(), revised = Instant.now())
+    fun withProvenanceEntries(entries: List<ProvenanceEntry>): Proposition =
+        copy(provenanceEntries = (provenanceEntries + entries).distinct(), revised = Instant.now())
 
     /**
      * Calculate the effective confidence after applying time-based decay.

--- a/src/main/kotlin/com/embabel/dice/proposition/Proposition.kt
+++ b/src/main/kotlin/com/embabel/dice/proposition/Proposition.kt
@@ -18,6 +18,8 @@ package com.embabel.dice.proposition
 import com.embabel.agent.core.ContextId
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.common.core.types.ZeroToOne
+import com.embabel.dice.provenance.GroundingEntry
+import com.embabel.dice.temporal.TemporalMetadata
 import java.time.Instant
 import java.util.*
 
@@ -67,6 +69,11 @@ enum class PropositionStatus {
  * @property sourceIds IDs of propositions this was abstracted from (empty for level 0)
  * @property reinforceCount How many times this proposition has been merged or reinforced.
  *   Provides a frequency/importance signal complementary to confidence and decay.
+ * @property temporal Optional bitemporal metadata (observed/valid time, supersession,
+ *   contradiction). Null when temporal correctness is not tracked for this proposition.
+ * @property groundingEntries Rich grounding entries linking this proposition to source
+ *   material via [com.embabel.dice.provenance.SourceLocator]. Complements the legacy
+ *   chunk-id-only [grounding] list.
  */
 data class Proposition(
     override val id: String = UUID.randomUUID().toString(),
@@ -87,6 +94,8 @@ data class Proposition(
     val reinforceCount: Int = 0,
     override val metadata: Map<String, Any> = emptyMap(),
     override val uri: String? = null,
+    val temporal: TemporalMetadata? = null,
+    val groundingEntries: List<GroundingEntry> = emptyList(),
 ) : Derivation, ReferencesEntities, Retrievable {
 
     /**
@@ -132,6 +141,8 @@ data class Proposition(
             reinforceCount: Int = 0,
             metadata: Map<String, Any> = emptyMap(),
             uri: String? = null,
+            temporal: TemporalMetadata? = null,
+            groundingEntries: List<GroundingEntry> = emptyList(),
         ): Proposition = Proposition(
             id = id,
             contextId = ContextId(contextIdValue),
@@ -151,6 +162,8 @@ data class Proposition(
             reinforceCount = reinforceCount,
             metadata = metadata,
             uri = uri,
+            temporal = temporal,
+            groundingEntries = groundingEntries,
         )
     }
 
@@ -201,6 +214,18 @@ data class Proposition(
      */
     fun withGrounding(chunkIds: List<String>): Proposition =
         copy(grounding = (grounding + chunkIds).distinct(), revised = Instant.now())
+
+    /**
+     * Create a copy with the given temporal metadata.
+     */
+    fun withTemporal(temporal: TemporalMetadata): Proposition =
+        copy(temporal = temporal, revised = Instant.now())
+
+    /**
+     * Create a copy with additional rich grounding entries.
+     */
+    fun withGroundingEntries(entries: List<GroundingEntry>): Proposition =
+        copy(groundingEntries = (groundingEntries + entries).distinct(), revised = Instant.now())
 
     /**
      * Calculate the effective confidence after applying time-based decay.

--- a/src/main/kotlin/com/embabel/dice/provenance/GroundingEntry.kt
+++ b/src/main/kotlin/com/embabel/dice/provenance/GroundingEntry.kt
@@ -16,24 +16,23 @@
 package com.embabel.dice.provenance
 
 /**
- * A rich grounding entry linking a proposition back to its source material.
+ * Links a proposition to the source material that grounds it.
  *
- * This is the richer replacement for bare chunk-id grounding (the legacy
- * `grounding: List<String>` of chunk IDs). A [GroundingEntry] carries a
- * [SourceLocator] (where the material lives), plus optional locating details
- * within that source: the originating chunk, an offset range, and a content
- * hash captured at extraction time.
+ * Each entry carries a [SourceLocator] identifying where the material lives,
+ * together with optional detail locating the content within that source: the
+ * originating chunk, a character offset range, and a content hash. This carries
+ * more detail than a bare list of chunk IDs.
  *
- * All locating detail beyond the [locator] is optional, so coarse grounding
- * ("this came from that document") and precise grounding ("characters 120-180
- * of chunk 4") share the same shape.
+ * All detail beyond the [locator] is optional, so coarse grounding (the source
+ * document) and precise grounding (a character range within a chunk) share a
+ * single representation.
  *
  * @property locator Reference to where the source material lives
  * @property chunkId Optional ID of the chunk this grounding came from
  * @property startOffset Optional inclusive start character offset within the source/chunk
  * @property endOffset Optional exclusive end character offset within the source/chunk
- * @property contentHash Optional hash of the grounding content captured at extraction time,
- *   useful for detecting source drift
+ * @property contentHash Optional hash of the grounded content. Comparing it against the
+ *   source later can reveal that the source has since changed.
  */
 data class GroundingEntry @JvmOverloads constructor(
     val locator: SourceLocator,

--- a/src/main/kotlin/com/embabel/dice/provenance/GroundingEntry.kt
+++ b/src/main/kotlin/com/embabel/dice/provenance/GroundingEntry.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+/**
+ * A rich grounding entry linking a proposition back to its source material.
+ *
+ * This is the richer replacement for bare chunk-id grounding (the legacy
+ * `grounding: List<String>` of chunk IDs). A [GroundingEntry] carries a
+ * [SourceLocator] (where the material lives), plus optional locating details
+ * within that source: the originating chunk, an offset range, and a content
+ * hash captured at extraction time.
+ *
+ * All locating detail beyond the [locator] is optional, so coarse grounding
+ * ("this came from that document") and precise grounding ("characters 120-180
+ * of chunk 4") share the same shape.
+ *
+ * @property locator Reference to where the source material lives
+ * @property chunkId Optional ID of the chunk this grounding came from
+ * @property startOffset Optional inclusive start character offset within the source/chunk
+ * @property endOffset Optional exclusive end character offset within the source/chunk
+ * @property contentHash Optional hash of the grounding content captured at extraction time,
+ *   useful for detecting source drift
+ */
+data class GroundingEntry @JvmOverloads constructor(
+    val locator: SourceLocator,
+    val chunkId: String? = null,
+    val startOffset: Int? = null,
+    val endOffset: Int? = null,
+    val contentHash: String? = null,
+) {
+
+    init {
+        require(startOffset == null || startOffset >= 0) { "startOffset must be non-negative" }
+        require(endOffset == null || endOffset >= 0) { "endOffset must be non-negative" }
+        require(
+            startOffset == null || endOffset == null || endOffset >= startOffset
+        ) { "endOffset must be >= startOffset" }
+    }
+}

--- a/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEntry.kt
+++ b/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEntry.kt
@@ -16,25 +16,25 @@
 package com.embabel.dice.provenance
 
 /**
- * Links a proposition to the source material that grounds it.
+ * Links a proposition to the source material it was derived from.
  *
  * Each entry carries a [SourceLocator] identifying where the material lives,
  * together with optional detail locating the content within that source: the
- * originating chunk, a character offset range, and a content hash. This carries
- * more detail than a bare list of chunk IDs.
+ * originating chunk, a character offset range, and a content hash. This rich
+ * provenance carries more detail than a bare list of chunk IDs.
  *
- * All detail beyond the [locator] is optional, so coarse grounding (the source
- * document) and precise grounding (a character range within a chunk) share a
+ * All detail beyond the [locator] is optional, so coarse provenance (the source
+ * document) and precise provenance (a character range within a chunk) share a
  * single representation.
  *
  * @property locator Reference to where the source material lives
- * @property chunkId Optional ID of the chunk this grounding came from
+ * @property chunkId Optional ID of the chunk this provenance came from
  * @property startOffset Optional inclusive start character offset within the source/chunk
  * @property endOffset Optional exclusive end character offset within the source/chunk
- * @property contentHash Optional hash of the grounded content. Comparing it against the
+ * @property contentHash Optional hash of the source content. Comparing it against the
  *   source later can reveal that the source has since changed.
  */
-data class GroundingEntry @JvmOverloads constructor(
+data class ProvenanceEntry @JvmOverloads constructor(
     val locator: SourceLocator,
     val chunkId: String? = null,
     val startOffset: Int? = null,

--- a/src/main/kotlin/com/embabel/dice/provenance/SourceLocator.kt
+++ b/src/main/kotlin/com/embabel/dice/provenance/SourceLocator.kt
@@ -21,14 +21,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 /**
  * A reference to where source material lives.
  *
- * DICE holds the *reference* to source material, never the bytes themselves.
- * A [SourceLocator] is the library-appropriate provenance primitive: it tells a
- * consumer how to find (or re-fetch) the original material that grounds a
- * proposition, without DICE taking on storage, credentials, or connector
- * responsibilities.
+ * A [SourceLocator] holds a reference to source material rather than the material
+ * itself. It tells a consumer how to locate or re-fetch the original material
+ * that grounds a proposition, without assuming responsibility for storage,
+ * credentials, or connector access.
  *
- * Implementations form a discriminated union so consumers can pattern-match on
- * the kind of reference (URI, file path, content hash, or connector reference).
+ * Implementations form a discriminated union, allowing consumers to match on the
+ * kind of reference: URI, file path, content hash, or connector reference.
  *
  * @property display Optional human-readable label for UIs and reports
  *   (e.g. "Meeting notes 2026-05-21"). Never used for identity.
@@ -52,9 +51,9 @@ sealed interface SourceLocator {
      * A stable, comparable key identifying this locator.
      *
      * Keys are prefixed by locator kind so that distinct kinds never collide
-     * (e.g. `uri:...`, `file:...`, `content:...`, `connector:...`). Use this for
-     * deduplication, indexing, and equality of references rather than relying on
-     * the [display] label.
+     * (`uri:...`, `file:...`, `content:...`, `connector:...`). Use this for
+     * deduplication, indexing, and reference equality rather than the [display]
+     * label.
      *
      * @return a stable key string for this locator
      */
@@ -113,8 +112,8 @@ data class FileLocator @JvmOverloads constructor(
 /**
  * A locator that identifies source material by its content hash.
  *
- * This is the most portable locator because it is independent of location: any
- * store holding matching bytes satisfies the reference.
+ * Because it identifies material by content rather than location, any store
+ * holding matching bytes satisfies the reference.
  *
  * @property contentHash The hash of the source content (e.g. a SHA-256 hex string)
  * @property display Optional human-readable label

--- a/src/main/kotlin/com/embabel/dice/provenance/SourceLocator.kt
+++ b/src/main/kotlin/com/embabel/dice/provenance/SourceLocator.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+
+/**
+ * A reference to where source material lives.
+ *
+ * DICE holds the *reference* to source material, never the bytes themselves.
+ * A [SourceLocator] is the library-appropriate provenance primitive: it tells a
+ * consumer how to find (or re-fetch) the original material that grounds a
+ * proposition, without DICE taking on storage, credentials, or connector
+ * responsibilities.
+ *
+ * Implementations form a discriminated union so consumers can pattern-match on
+ * the kind of reference (URI, file path, content hash, or connector reference).
+ *
+ * @property display Optional human-readable label for UIs and reports
+ *   (e.g. "Meeting notes 2026-05-21"). Never used for identity.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+@JsonSubTypes(
+    JsonSubTypes.Type(UriLocator::class, name = "uri"),
+    JsonSubTypes.Type(FileLocator::class, name = "file"),
+    JsonSubTypes.Type(ContentAddressedLocator::class, name = "content"),
+    JsonSubTypes.Type(ConnectorRef::class, name = "connector"),
+)
+sealed interface SourceLocator {
+
+    /**
+     * Optional human-readable label for display in UIs and reports.
+     * This is presentation-only and never participates in identity.
+     */
+    val display: String?
+
+    /**
+     * A stable, comparable key identifying this locator.
+     *
+     * Keys are prefixed by locator kind so that distinct kinds never collide
+     * (e.g. `uri:...`, `file:...`, `content:...`, `connector:...`). Use this for
+     * deduplication, indexing, and equality of references rather than relying on
+     * the [display] label.
+     *
+     * @return a stable key string for this locator
+     */
+    fun key(): String
+}
+
+/**
+ * A locator that points at a resource by URI (e.g. `https://...`, `s3://...`).
+ *
+ * @property uri The URI referencing the source resource
+ * @property display Optional human-readable label
+ */
+data class UriLocator @JvmOverloads constructor(
+    val uri: String,
+    override val display: String? = null,
+) : SourceLocator {
+
+    init {
+        require(uri.isNotBlank()) { "uri must not be blank" }
+    }
+
+    override fun key(): String = "uri:$uri"
+
+    // Identity is [key]; [display] is presentation-only and excluded (see SourceLocator contract).
+    override fun equals(other: Any?): Boolean = other is SourceLocator && other.key() == key()
+
+    override fun hashCode(): Int = key().hashCode()
+}
+
+/**
+ * A locator that points at a resource by file path.
+ *
+ * Note that raw paths are environment-specific; prefer [ContentAddressedLocator]
+ * for shareable outputs where a path would not be portable.
+ *
+ * @property path The file system path referencing the source resource
+ * @property display Optional human-readable label
+ */
+data class FileLocator @JvmOverloads constructor(
+    val path: String,
+    override val display: String? = null,
+) : SourceLocator {
+
+    init {
+        require(path.isNotBlank()) { "path must not be blank" }
+    }
+
+    override fun key(): String = "file:$path"
+
+    // Identity is [key]; [display] is presentation-only and excluded (see SourceLocator contract).
+    override fun equals(other: Any?): Boolean = other is SourceLocator && other.key() == key()
+
+    override fun hashCode(): Int = key().hashCode()
+}
+
+/**
+ * A locator that identifies source material by its content hash.
+ *
+ * This is the most portable locator because it is independent of location: any
+ * store holding matching bytes satisfies the reference.
+ *
+ * @property contentHash The hash of the source content (e.g. a SHA-256 hex string)
+ * @property display Optional human-readable label
+ */
+data class ContentAddressedLocator @JvmOverloads constructor(
+    val contentHash: String,
+    override val display: String? = null,
+) : SourceLocator {
+
+    init {
+        require(contentHash.isNotBlank()) { "contentHash must not be blank" }
+    }
+
+    override fun key(): String = "content:$contentHash"
+
+    // Identity is [key]; [display] is presentation-only and excluded (see SourceLocator contract).
+    override fun equals(other: Any?): Boolean = other is SourceLocator && other.key() == key()
+
+    override fun hashCode(): Int = key().hashCode()
+}
+
+/**
+ * A locator that references material owned by an external connector.
+ *
+ * The connector (a private/product concern) knows how to resolve
+ * [externalId] within the system identified by [connectorId]. DICE only holds
+ * the identifiers needed to ask the connector for the material later.
+ *
+ * @property connectorId Identifier of the connector that owns the material
+ *   (e.g. "slack", "notion", "gmail")
+ * @property externalId Identifier of the material within that connector
+ * @property display Optional human-readable label
+ */
+data class ConnectorRef @JvmOverloads constructor(
+    val connectorId: String,
+    val externalId: String,
+    override val display: String? = null,
+) : SourceLocator {
+
+    init {
+        require(connectorId.isNotBlank()) { "connectorId must not be blank" }
+        require(externalId.isNotBlank()) { "externalId must not be blank" }
+    }
+
+    override fun key(): String = "connector:$connectorId:$externalId"
+
+    // Identity is [key]; [display] is presentation-only and excluded (see SourceLocator contract).
+    override fun equals(other: Any?): Boolean = other is SourceLocator && other.key() == key()
+
+    override fun hashCode(): Int = key().hashCode()
+}

--- a/src/main/kotlin/com/embabel/dice/temporal/TemporalMetadata.kt
+++ b/src/main/kotlin/com/embabel/dice/temporal/TemporalMetadata.kt
@@ -18,14 +18,13 @@ package com.embabel.dice.temporal
 import java.time.Instant
 
 /**
- * Bitemporal-style metadata describing when a fact was observed and when it is
- * (or was) valid in the world.
+ * Bitemporal metadata describing when a fact was observed and when it is, or
+ * was, valid in the world.
  *
- * This prepares DICE for Zep/Graphiti-class temporal correctness: a reviewer can
- * distinguish *current truth* from *historical truth*, and propositions can record
- * that they supersede or contradict earlier ones.
+ * Distinguishes current truth from historical truth, and allows a proposition to
+ * record that it supersedes or contradicts earlier propositions.
  *
- * - **Observed time** ([observedAt]): when DICE learned the fact.
+ * - **Observed time** ([observedAt]): when DICE recorded the fact.
  * - **Valid time** ([validFrom] / [validTo]): the window during which the fact
  *   holds in the world. A null [validTo] means "still valid / open-ended".
  * - **Invalidation** ([invalidatedAt]): when the fact was explicitly invalidated,

--- a/src/main/kotlin/com/embabel/dice/temporal/TemporalMetadata.kt
+++ b/src/main/kotlin/com/embabel/dice/temporal/TemporalMetadata.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.temporal
+
+import java.time.Instant
+
+/**
+ * Bitemporal-style metadata describing when a fact was observed and when it is
+ * (or was) valid in the world.
+ *
+ * This prepares DICE for Zep/Graphiti-class temporal correctness: a reviewer can
+ * distinguish *current truth* from *historical truth*, and propositions can record
+ * that they supersede or contradict earlier ones.
+ *
+ * - **Observed time** ([observedAt]): when DICE learned the fact.
+ * - **Valid time** ([validFrom] / [validTo]): the window during which the fact
+ *   holds in the world. A null [validTo] means "still valid / open-ended".
+ * - **Invalidation** ([invalidatedAt]): when the fact was explicitly invalidated,
+ *   independent of its valid window (e.g. it was retracted).
+ *
+ * @property observedAt When this fact was observed/recorded by DICE
+ * @property validFrom When this fact began to be true in the world
+ * @property validTo When this fact stopped being true in the world, or null if open-ended
+ * @property invalidatedAt When this fact was explicitly invalidated, or null if not invalidated
+ * @property supersedes IDs of propositions this fact supersedes (replaces with newer truth)
+ * @property contradicts IDs of propositions this fact contradicts
+ */
+data class TemporalMetadata @JvmOverloads constructor(
+    val observedAt: Instant,
+    val validFrom: Instant,
+    val validTo: Instant? = null,
+    val invalidatedAt: Instant? = null,
+    val supersedes: List<String> = emptyList(),
+    val contradicts: List<String> = emptyList(),
+) {
+
+    init {
+        require(validTo == null || !validTo.isBefore(validFrom)) {
+            "validTo must be null or >= validFrom"
+        }
+    }
+
+    /**
+     * Whether this fact is current as of the given instant.
+     *
+     * A fact is current when [at] falls within its valid window
+     * (`validFrom <= at`, and `at < validTo` when [validTo] is set) and the fact
+     * has not been invalidated at or before [at].
+     *
+     * @param at The instant to evaluate currency against
+     * @return true if the fact is valid and not invalidated as of [at]
+     */
+    fun isCurrentAsOf(at: Instant): Boolean {
+        if (invalidatedAt != null && !invalidatedAt.isAfter(at)) return false
+        if (at.isBefore(validFrom)) return false
+        if (validTo != null && !at.isBefore(validTo)) return false
+        return true
+    }
+
+    /**
+     * Whether this fact is current as of now.
+     *
+     * @return true if the fact is valid and not invalidated at the present instant
+     */
+    fun isCurrent(): Boolean = isCurrentAsOf(Instant.now())
+}

--- a/src/test/kotlin/com/embabel/dice/projection/lineage/InMemoryProjectionRecordStoreTest.kt
+++ b/src/test/kotlin/com/embabel/dice/projection/lineage/InMemoryProjectionRecordStoreTest.kt
@@ -42,9 +42,9 @@ class InMemoryProjectionRecordStoreTest {
 
     @Test
     fun `record and findByProposition`() {
-        store.record(record("p1", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p1", "graph", "run-1", ProjectionLifecycle.PROJECTED))
         store.record(record("p1", "prolog", "run-1", ProjectionLifecycle.PROJECTED))
-        store.record(record("p2", "neo4j", "run-1", ProjectionLifecycle.SKIPPED))
+        store.record(record("p2", "graph", "run-1", ProjectionLifecycle.SKIPPED))
 
         val p1 = store.findByProposition("p1")
         assertEquals(2, p1.size)
@@ -53,19 +53,19 @@ class InMemoryProjectionRecordStoreTest {
     }
 
     @Test
-    fun `findByTarget`() {
-        store.record(record("p1", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
-        store.record(record("p2", "neo4j", "run-1", ProjectionLifecycle.ADOPTED))
+    fun findByTarget() {
+        store.record(record("p1", "graph", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p2", "graph", "run-1", ProjectionLifecycle.ADOPTED))
         store.record(record("p3", "prolog", "run-1", ProjectionLifecycle.PROJECTED))
 
-        assertEquals(2, store.findByTarget("neo4j").size)
+        assertEquals(2, store.findByTarget("graph").size)
         assertEquals(1, store.findByTarget("prolog").size)
     }
 
     @Test
-    fun `findByRun`() {
-        store.record(record("p1", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
-        store.record(record("p2", "neo4j", "run-2", ProjectionLifecycle.PROJECTED))
+    fun findByRun() {
+        store.record(record("p1", "graph", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p2", "graph", "run-2", ProjectionLifecycle.PROJECTED))
 
         assertEquals(1, store.findByRun("run-1").size)
         assertEquals(1, store.findByRun("run-2").size)
@@ -74,8 +74,8 @@ class InMemoryProjectionRecordStoreTest {
 
     @Test
     fun `findStale returns only stale`() {
-        store.record(record("p1", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
-        store.record(record("p2", "neo4j", "run-1", ProjectionLifecycle.STALE))
+        store.record(record("p1", "graph", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p2", "graph", "run-1", ProjectionLifecycle.STALE))
         store.record(record("p3", "prolog", "run-1", ProjectionLifecycle.FAILED))
         store.record(record("p4", "report", "run-1", ProjectionLifecycle.STALE))
 
@@ -87,8 +87,8 @@ class InMemoryProjectionRecordStoreTest {
 
     @Test
     fun `all returns insertion order`() {
-        store.record(record("p1", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
-        store.record(record("p2", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p1", "graph", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p2", "graph", "run-1", ProjectionLifecycle.PROJECTED))
 
         val all = store.all()
         assertEquals(2, all.size)

--- a/src/test/kotlin/com/embabel/dice/projection/lineage/InMemoryProjectionRecordStoreTest.kt
+++ b/src/test/kotlin/com/embabel/dice/projection/lineage/InMemoryProjectionRecordStoreTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.lineage
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class InMemoryProjectionRecordStoreTest {
+
+    private lateinit var store: InMemoryProjectionRecordStore
+
+    @BeforeEach
+    fun setUp() {
+        store = InMemoryProjectionRecordStore()
+    }
+
+    private fun record(
+        propositionId: String,
+        target: String,
+        runId: String,
+        lifecycle: ProjectionLifecycle,
+    ) = ProjectionRecord(
+        propositionId = propositionId,
+        target = target,
+        runId = runId,
+        lifecycle = lifecycle,
+    )
+
+    @Test
+    fun `record and findByProposition`() {
+        store.record(record("p1", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p1", "prolog", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p2", "neo4j", "run-1", ProjectionLifecycle.SKIPPED))
+
+        val p1 = store.findByProposition("p1")
+        assertEquals(2, p1.size)
+        assertTrue(p1.all { it.propositionId == "p1" })
+        assertTrue(store.findByProposition("missing").isEmpty())
+    }
+
+    @Test
+    fun `findByTarget`() {
+        store.record(record("p1", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p2", "neo4j", "run-1", ProjectionLifecycle.ADOPTED))
+        store.record(record("p3", "prolog", "run-1", ProjectionLifecycle.PROJECTED))
+
+        assertEquals(2, store.findByTarget("neo4j").size)
+        assertEquals(1, store.findByTarget("prolog").size)
+    }
+
+    @Test
+    fun `findByRun`() {
+        store.record(record("p1", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p2", "neo4j", "run-2", ProjectionLifecycle.PROJECTED))
+
+        assertEquals(1, store.findByRun("run-1").size)
+        assertEquals(1, store.findByRun("run-2").size)
+        assertTrue(store.findByRun("run-3").isEmpty())
+    }
+
+    @Test
+    fun `findStale returns only stale`() {
+        store.record(record("p1", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p2", "neo4j", "run-1", ProjectionLifecycle.STALE))
+        store.record(record("p3", "prolog", "run-1", ProjectionLifecycle.FAILED))
+        store.record(record("p4", "report", "run-1", ProjectionLifecycle.STALE))
+
+        val stale = store.findStale()
+        assertEquals(2, stale.size)
+        assertTrue(stale.all { it.lifecycle == ProjectionLifecycle.STALE })
+        assertEquals(setOf("p2", "p4"), stale.map { it.propositionId }.toSet())
+    }
+
+    @Test
+    fun `all returns insertion order`() {
+        store.record(record("p1", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
+        store.record(record("p2", "neo4j", "run-1", ProjectionLifecycle.PROJECTED))
+
+        val all = store.all()
+        assertEquals(2, all.size)
+        assertEquals("p1", all[0].propositionId)
+        assertEquals("p2", all[1].propositionId)
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/projection/lineage/ProjectionRecordTest.kt
+++ b/src/test/kotlin/com/embabel/dice/projection/lineage/ProjectionRecordTest.kt
@@ -26,12 +26,12 @@ class ProjectionRecordTest {
     fun `construction with defaults`() {
         val record = ProjectionRecord(
             propositionId = "p1",
-            target = "neo4j",
+            target = "graph",
             lifecycle = ProjectionLifecycle.PROJECTED,
             runId = "run-1",
         )
         assertEquals("p1", record.propositionId)
-        assertEquals("neo4j", record.target)
+        assertEquals("graph", record.target)
         assertNull(record.targetRef)
         assertNull(record.reason)
         assertNotNull(record.at)
@@ -58,13 +58,13 @@ class ProjectionRecordTest {
     @Test
     fun `blank required fields rejected`() {
         assertThrows<IllegalArgumentException> {
-            ProjectionRecord(propositionId = "", target = "neo4j", lifecycle = ProjectionLifecycle.PROJECTED, runId = "r")
+            ProjectionRecord(propositionId = "", target = "graph", lifecycle = ProjectionLifecycle.PROJECTED, runId = "r")
         }
         assertThrows<IllegalArgumentException> {
             ProjectionRecord(propositionId = "p", target = " ", lifecycle = ProjectionLifecycle.PROJECTED, runId = "r")
         }
         assertThrows<IllegalArgumentException> {
-            ProjectionRecord(propositionId = "p", target = "neo4j", lifecycle = ProjectionLifecycle.PROJECTED, runId = "")
+            ProjectionRecord(propositionId = "p", target = "graph", lifecycle = ProjectionLifecycle.PROJECTED, runId = "")
         }
     }
 }

--- a/src/test/kotlin/com/embabel/dice/projection/lineage/ProjectionRecordTest.kt
+++ b/src/test/kotlin/com/embabel/dice/projection/lineage/ProjectionRecordTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.lineage
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+
+class ProjectionRecordTest {
+
+    @Test
+    fun `construction with defaults`() {
+        val record = ProjectionRecord(
+            propositionId = "p1",
+            target = "neo4j",
+            lifecycle = ProjectionLifecycle.PROJECTED,
+            runId = "run-1",
+        )
+        assertEquals("p1", record.propositionId)
+        assertEquals("neo4j", record.target)
+        assertNull(record.targetRef)
+        assertNull(record.reason)
+        assertNotNull(record.at)
+    }
+
+    @Test
+    fun `factory of populates fields`() {
+        val at = Instant.parse("2026-01-01T00:00:00Z")
+        val record = ProjectionRecord.of(
+            propositionId = "p2",
+            target = "prolog",
+            lifecycle = ProjectionLifecycle.ADOPTED,
+            runId = "run-2",
+            targetRef = "node-99",
+            at = at,
+            reason = "matched existing node",
+        )
+        assertEquals("node-99", record.targetRef)
+        assertEquals(ProjectionLifecycle.ADOPTED, record.lifecycle)
+        assertEquals(at, record.at)
+        assertEquals("matched existing node", record.reason)
+    }
+
+    @Test
+    fun `blank required fields rejected`() {
+        assertThrows<IllegalArgumentException> {
+            ProjectionRecord(propositionId = "", target = "neo4j", lifecycle = ProjectionLifecycle.PROJECTED, runId = "r")
+        }
+        assertThrows<IllegalArgumentException> {
+            ProjectionRecord(propositionId = "p", target = " ", lifecycle = ProjectionLifecycle.PROJECTED, runId = "r")
+        }
+        assertThrows<IllegalArgumentException> {
+            ProjectionRecord(propositionId = "p", target = "neo4j", lifecycle = ProjectionLifecycle.PROJECTED, runId = "")
+        }
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/projection/lineage/ReconciliationDecisionTest.kt
+++ b/src/test/kotlin/com/embabel/dice/projection/lineage/ReconciliationDecisionTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.lineage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class ReconciliationDecisionTest {
+
+    @Test
+    fun `Adopt and Align reject blank targetRef`() {
+        assertThrows(IllegalArgumentException::class.java) { ReconciliationDecision.Adopt("") }
+        assertThrows(IllegalArgumentException::class.java) { ReconciliationDecision.Adopt("   ") }
+        assertThrows(IllegalArgumentException::class.java) { ReconciliationDecision.Align("") }
+        assertThrows(IllegalArgumentException::class.java) { ReconciliationDecision.Align("   ") }
+    }
+
+    @Test
+    fun `Adopt and Align accept a non-blank targetRef`() {
+        assertEquals("node-42", ReconciliationDecision.Adopt("node-42").targetRef)
+        assertEquals("node-77", ReconciliationDecision.Align("node-77").targetRef)
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/proposition/PropositionProvenanceTest.kt
+++ b/src/test/kotlin/com/embabel/dice/proposition/PropositionProvenanceTest.kt
@@ -125,7 +125,7 @@ class PropositionProvenanceTest {
         assertEquals(listOf(entry), promoted.groundingEntries)
         assertEquals(PropositionStatus.PROMOTED, promoted.status)
 
-        // Legacy chunk-id grounding still independent and intact.
+        // Chunk-id grounding list is independent of groundingEntries and unaffected.
         assertTrue(promoted.grounding.isEmpty())
     }
 

--- a/src/test/kotlin/com/embabel/dice/proposition/PropositionProvenanceTest.kt
+++ b/src/test/kotlin/com/embabel/dice/proposition/PropositionProvenanceTest.kt
@@ -17,7 +17,7 @@ package com.embabel.dice.proposition
 
 import com.embabel.agent.core.ContextId
 import com.embabel.dice.provenance.ContentAddressedLocator
-import com.embabel.dice.provenance.GroundingEntry
+import com.embabel.dice.provenance.ProvenanceEntry
 import com.embabel.dice.provenance.UriLocator
 import com.embabel.dice.temporal.TemporalMetadata
 import org.junit.jupiter.api.Assertions.*
@@ -32,7 +32,7 @@ class PropositionProvenanceTest {
     fun `new fields default to null and empty`() {
         val prop = Proposition(contextId = ctx, text = "Alice knows Bob", mentions = emptyList(), confidence = 0.9)
         assertNull(prop.temporal)
-        assertTrue(prop.groundingEntries.isEmpty())
+        assertTrue(prop.provenanceEntries.isEmpty())
     }
 
     @Test
@@ -52,30 +52,30 @@ class PropositionProvenanceTest {
     }
 
     @Test
-    fun `withGroundingEntries appends and dedups`() {
-        val e1 = GroundingEntry(locator = UriLocator("https://example.com/doc"), chunkId = "c1")
-        val e2 = GroundingEntry(locator = ContentAddressedLocator("abc123"), startOffset = 0, endOffset = 10)
+    fun `withProvenanceEntries appends and dedups`() {
+        val e1 = ProvenanceEntry(locator = UriLocator("https://example.com/doc"), chunkId = "c1")
+        val e2 = ProvenanceEntry(locator = ContentAddressedLocator("abc123"), startOffset = 0, endOffset = 10)
 
         val original = Proposition(
             contextId = ctx,
             text = "Test",
             mentions = emptyList(),
             confidence = 0.7,
-            groundingEntries = listOf(e1),
+            provenanceEntries = listOf(e1),
         )
 
-        val updated = original.withGroundingEntries(listOf(e1, e2))
+        val updated = original.withProvenanceEntries(listOf(e1, e2))
 
-        assertEquals(1, original.groundingEntries.size)
-        assertEquals(2, updated.groundingEntries.size)
-        assertTrue(updated.groundingEntries.containsAll(listOf(e1, e2)))
+        assertEquals(1, original.provenanceEntries.size)
+        assertEquals(2, updated.provenanceEntries.size)
+        assertTrue(updated.provenanceEntries.containsAll(listOf(e1, e2)))
     }
 
     @Test
     fun `grounding dedup ignores display label per SourceLocator identity contract`() {
         // Same underlying source, different presentation-only display labels.
-        val labeled = GroundingEntry(locator = UriLocator("https://example.com/doc", display = "Doc A"))
-        val relabeled = GroundingEntry(locator = UriLocator("https://example.com/doc", display = "Doc B"))
+        val labeled = ProvenanceEntry(locator = UriLocator("https://example.com/doc", display = "Doc A"))
+        val relabeled = ProvenanceEntry(locator = UriLocator("https://example.com/doc", display = "Doc B"))
 
         // Locators (and so grounding entries) are equal: identity is key(), not display.
         assertEquals(labeled.locator, relabeled.locator)
@@ -86,12 +86,12 @@ class PropositionProvenanceTest {
             text = "Test",
             mentions = emptyList(),
             confidence = 0.7,
-            groundingEntries = listOf(labeled),
+            provenanceEntries = listOf(labeled),
         )
 
         // Re-adding the same source with a different label must NOT create a duplicate.
-        val updated = prop.withGroundingEntries(listOf(relabeled))
-        assertEquals(1, updated.groundingEntries.size)
+        val updated = prop.withProvenanceEntries(listOf(relabeled))
+        assertEquals(1, updated.provenanceEntries.size)
     }
 
     @Test
@@ -102,7 +102,7 @@ class PropositionProvenanceTest {
             validTo = Instant.parse("2026-06-01T00:00:00Z"),
             supersedes = listOf("old-prop"),
         )
-        val entry = GroundingEntry(
+        val entry = ProvenanceEntry(
             locator = UriLocator("https://example.com/doc", display = "Doc"),
             chunkId = "c1",
             startOffset = 5,
@@ -116,16 +116,16 @@ class PropositionProvenanceTest {
             mentions = emptyList(),
             confidence = 0.9,
             temporal = tm,
-            groundingEntries = listOf(entry),
+            provenanceEntries = listOf(entry),
         )
 
         // Existing mutation helper still works and keeps provenance.
         val promoted = prop.withStatus(PropositionStatus.PROMOTED)
         assertEquals(tm, promoted.temporal)
-        assertEquals(listOf(entry), promoted.groundingEntries)
+        assertEquals(listOf(entry), promoted.provenanceEntries)
         assertEquals(PropositionStatus.PROMOTED, promoted.status)
 
-        // Chunk-id grounding list is independent of groundingEntries and unaffected.
+        // Chunk-id grounding list is independent of provenanceEntries and unaffected.
         assertTrue(promoted.grounding.isEmpty())
     }
 
@@ -133,7 +133,7 @@ class PropositionProvenanceTest {
     fun `factory wires temporal and grounding entries`() {
         val now = Instant.now()
         val tm = TemporalMetadata(observedAt = now, validFrom = now)
-        val entry = GroundingEntry(locator = ContentAddressedLocator("hash"))
+        val entry = ProvenanceEntry(locator = ContentAddressedLocator("hash"))
 
         val prop = Proposition.create(
             id = "p1",
@@ -148,10 +148,10 @@ class PropositionProvenanceTest {
             revised = now,
             status = PropositionStatus.ACTIVE,
             temporal = tm,
-            groundingEntries = listOf(entry),
+            provenanceEntries = listOf(entry),
         )
 
         assertEquals(tm, prop.temporal)
-        assertEquals(listOf(entry), prop.groundingEntries)
+        assertEquals(listOf(entry), prop.provenanceEntries)
     }
 }

--- a/src/test/kotlin/com/embabel/dice/proposition/PropositionProvenanceTest.kt
+++ b/src/test/kotlin/com/embabel/dice/proposition/PropositionProvenanceTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.proposition
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.provenance.ContentAddressedLocator
+import com.embabel.dice.provenance.GroundingEntry
+import com.embabel.dice.provenance.UriLocator
+import com.embabel.dice.temporal.TemporalMetadata
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class PropositionProvenanceTest {
+
+    private val ctx = ContextId("test-context")
+
+    @Test
+    fun `new fields default to null and empty`() {
+        val prop = Proposition(contextId = ctx, text = "Alice knows Bob", mentions = emptyList(), confidence = 0.9)
+        assertNull(prop.temporal)
+        assertTrue(prop.groundingEntries.isEmpty())
+    }
+
+    @Test
+    fun `withTemporal attaches metadata and bumps revised`() {
+        val original = Proposition(contextId = ctx, text = "Alice prefers tea", mentions = emptyList(), confidence = 0.8)
+        val tm = TemporalMetadata(
+            observedAt = Instant.parse("2026-01-01T00:00:00Z"),
+            validFrom = Instant.parse("2026-01-01T00:00:00Z"),
+        )
+
+        val updated = original.withTemporal(tm)
+
+        assertNull(original.temporal)
+        assertEquals(tm, updated.temporal)
+        assertEquals(original.id, updated.id)
+        assertTrue(updated.revised >= original.revised)
+    }
+
+    @Test
+    fun `withGroundingEntries appends and dedups`() {
+        val e1 = GroundingEntry(locator = UriLocator("https://example.com/doc"), chunkId = "c1")
+        val e2 = GroundingEntry(locator = ContentAddressedLocator("abc123"), startOffset = 0, endOffset = 10)
+
+        val original = Proposition(
+            contextId = ctx,
+            text = "Test",
+            mentions = emptyList(),
+            confidence = 0.7,
+            groundingEntries = listOf(e1),
+        )
+
+        val updated = original.withGroundingEntries(listOf(e1, e2))
+
+        assertEquals(1, original.groundingEntries.size)
+        assertEquals(2, updated.groundingEntries.size)
+        assertTrue(updated.groundingEntries.containsAll(listOf(e1, e2)))
+    }
+
+    @Test
+    fun `grounding dedup ignores display label per SourceLocator identity contract`() {
+        // Same underlying source, different presentation-only display labels.
+        val labeled = GroundingEntry(locator = UriLocator("https://example.com/doc", display = "Doc A"))
+        val relabeled = GroundingEntry(locator = UriLocator("https://example.com/doc", display = "Doc B"))
+
+        // Locators (and so grounding entries) are equal: identity is key(), not display.
+        assertEquals(labeled.locator, relabeled.locator)
+        assertEquals(labeled, relabeled)
+
+        val prop = Proposition(
+            contextId = ctx,
+            text = "Test",
+            mentions = emptyList(),
+            confidence = 0.7,
+            groundingEntries = listOf(labeled),
+        )
+
+        // Re-adding the same source with a different label must NOT create a duplicate.
+        val updated = prop.withGroundingEntries(listOf(relabeled))
+        assertEquals(1, updated.groundingEntries.size)
+    }
+
+    @Test
+    fun `proposition roundtrips through copy preserving provenance and existing invariants`() {
+        val tm = TemporalMetadata(
+            observedAt = Instant.parse("2026-01-01T00:00:00Z"),
+            validFrom = Instant.parse("2026-01-01T00:00:00Z"),
+            validTo = Instant.parse("2026-06-01T00:00:00Z"),
+            supersedes = listOf("old-prop"),
+        )
+        val entry = GroundingEntry(
+            locator = UriLocator("https://example.com/doc", display = "Doc"),
+            chunkId = "c1",
+            startOffset = 5,
+            endOffset = 25,
+            contentHash = "deadbeef",
+        )
+
+        val prop = Proposition(
+            contextId = ctx,
+            text = "Alice works at Acme",
+            mentions = emptyList(),
+            confidence = 0.9,
+            temporal = tm,
+            groundingEntries = listOf(entry),
+        )
+
+        // Existing mutation helper still works and keeps provenance.
+        val promoted = prop.withStatus(PropositionStatus.PROMOTED)
+        assertEquals(tm, promoted.temporal)
+        assertEquals(listOf(entry), promoted.groundingEntries)
+        assertEquals(PropositionStatus.PROMOTED, promoted.status)
+
+        // Legacy chunk-id grounding still independent and intact.
+        assertTrue(promoted.grounding.isEmpty())
+    }
+
+    @Test
+    fun `factory wires temporal and grounding entries`() {
+        val now = Instant.now()
+        val tm = TemporalMetadata(observedAt = now, validFrom = now)
+        val entry = GroundingEntry(locator = ContentAddressedLocator("hash"))
+
+        val prop = Proposition.create(
+            id = "p1",
+            contextIdValue = "ctx",
+            text = "Test",
+            mentions = emptyList(),
+            confidence = 0.5,
+            decay = 0.0,
+            reasoning = null,
+            grounding = emptyList(),
+            created = now,
+            revised = now,
+            status = PropositionStatus.ACTIVE,
+            temporal = tm,
+            groundingEntries = listOf(entry),
+        )
+
+        assertEquals(tm, prop.temporal)
+        assertEquals(listOf(entry), prop.groundingEntries)
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/provenance/SourceLocatorTest.kt
+++ b/src/test/kotlin/com/embabel/dice/provenance/SourceLocatorTest.kt
@@ -60,12 +60,12 @@ class SourceLocatorTest {
     }
 
     @Test
-    fun `GroundingEntry rejects negative and inverted offsets`() {
+    fun `ProvenanceEntry rejects negative and inverted offsets`() {
         val loc = UriLocator("https://example.com/doc")
-        assertThrows(IllegalArgumentException::class.java) { GroundingEntry(loc, startOffset = -1) }
-        assertThrows(IllegalArgumentException::class.java) { GroundingEntry(loc, endOffset = -1) }
+        assertThrows(IllegalArgumentException::class.java) { ProvenanceEntry(loc, startOffset = -1) }
+        assertThrows(IllegalArgumentException::class.java) { ProvenanceEntry(loc, endOffset = -1) }
         assertThrows(IllegalArgumentException::class.java) {
-            GroundingEntry(loc, startOffset = 10, endOffset = 5)
+            ProvenanceEntry(loc, startOffset = 10, endOffset = 5)
         }
     }
 
@@ -88,15 +88,15 @@ class SourceLocatorTest {
     }
 
     @Test
-    fun `GroundingEntry round-trips through Jackson with polymorphic locator`() {
-        val entry = GroundingEntry(
+    fun `ProvenanceEntry round-trips through Jackson with polymorphic locator`() {
+        val entry = ProvenanceEntry(
             locator = ConnectorRef("notion", "page-1", display = "Spec"),
             chunkId = "c1",
             startOffset = 5,
             endOffset = 25,
             contentHash = "deadbeef",
         )
-        val back = mapper.readValue<GroundingEntry>(mapper.writeValueAsString(entry))
+        val back = mapper.readValue<ProvenanceEntry>(mapper.writeValueAsString(entry))
         assertEquals(entry, back)
     }
 }

--- a/src/test/kotlin/com/embabel/dice/provenance/SourceLocatorTest.kt
+++ b/src/test/kotlin/com/embabel/dice/provenance/SourceLocatorTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SourceLocatorTest {
+
+    private val mapper = jacksonObjectMapper()
+
+    @Test
+    fun `subtypes reject blank required fields`() {
+        assertThrows(IllegalArgumentException::class.java) { UriLocator("") }
+        assertThrows(IllegalArgumentException::class.java) { FileLocator(" ") }
+        assertThrows(IllegalArgumentException::class.java) { ContentAddressedLocator("") }
+        assertThrows(IllegalArgumentException::class.java) { ConnectorRef("", "x") }
+        assertThrows(IllegalArgumentException::class.java) { ConnectorRef("slack", " ") }
+    }
+
+    @Test
+    fun `key is kind-prefixed and stable`() {
+        assertEquals("uri:https://example.com/doc", UriLocator("https://example.com/doc").key())
+        assertEquals("file:/tmp/notes.txt", FileLocator("/tmp/notes.txt").key())
+        assertEquals("content:abc123", ContentAddressedLocator("abc123").key())
+        assertEquals("connector:slack:C123", ConnectorRef("slack", "C123").key())
+    }
+
+    @Test
+    fun `display does not participate in identity`() {
+        val a = UriLocator("https://example.com/doc", display = "Doc A")
+        val b = UriLocator("https://example.com/doc", display = "Doc B")
+        assertEquals(a.key(), b.key())
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+
+        // Different identity is still distinct.
+        assertNotEquals(a, UriLocator("https://example.com/other"))
+
+        // Same payload, different kind → distinct, because key() is kind-prefixed.
+        assertNotEquals(FileLocator("x"), ContentAddressedLocator("x"))
+    }
+
+    @Test
+    fun `GroundingEntry rejects negative and inverted offsets`() {
+        val loc = UriLocator("https://example.com/doc")
+        assertThrows(IllegalArgumentException::class.java) { GroundingEntry(loc, startOffset = -1) }
+        assertThrows(IllegalArgumentException::class.java) { GroundingEntry(loc, endOffset = -1) }
+        assertThrows(IllegalArgumentException::class.java) {
+            GroundingEntry(loc, startOffset = 10, endOffset = 5)
+        }
+    }
+
+    @Test
+    fun `SourceLocator round-trips through Jackson by kind discriminator`() {
+        val locators: List<SourceLocator> = listOf(
+            UriLocator("https://example.com/doc", display = "Doc"),
+            FileLocator("/tmp/notes.txt"),
+            ContentAddressedLocator("deadbeef"),
+            ConnectorRef("slack", "C123"),
+        )
+        for (original in locators) {
+            val json = mapper.writeValueAsString(original)
+            assertTrue(json.contains("\"kind\""), "expected a kind discriminator in $json")
+            val back = mapper.readValue<SourceLocator>(json)
+            assertEquals(original, back)
+            // equals() ignores display, so assert it explicitly — it is data that must survive.
+            assertEquals(original.display, back.display, "display must survive the JSON round-trip")
+        }
+    }
+
+    @Test
+    fun `GroundingEntry round-trips through Jackson with polymorphic locator`() {
+        val entry = GroundingEntry(
+            locator = ConnectorRef("notion", "page-1", display = "Spec"),
+            chunkId = "c1",
+            startOffset = 5,
+            endOffset = 25,
+            contentHash = "deadbeef",
+        )
+        val back = mapper.readValue<GroundingEntry>(mapper.writeValueAsString(entry))
+        assertEquals(entry, back)
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/temporal/TemporalMetadataTest.kt
+++ b/src/test/kotlin/com/embabel/dice/temporal/TemporalMetadataTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.temporal
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class TemporalMetadataTest {
+
+    private val t0 = Instant.parse("2026-01-01T00:00:00Z")
+    private val t1 = Instant.parse("2026-02-01T00:00:00Z")
+    private val t2 = Instant.parse("2026-03-01T00:00:00Z")
+    private val t3 = Instant.parse("2026-04-01T00:00:00Z")
+
+    @Test
+    fun `isCurrentAsOf true inside open-ended window`() {
+        val tm = TemporalMetadata(observedAt = t0, validFrom = t1)
+        assertTrue(tm.isCurrentAsOf(t1))
+        assertTrue(tm.isCurrentAsOf(t2))
+    }
+
+    @Test
+    fun `isCurrentAsOf false before validFrom`() {
+        val tm = TemporalMetadata(observedAt = t0, validFrom = t1)
+        assertFalse(tm.isCurrentAsOf(t0))
+    }
+
+    @Test
+    fun `isCurrentAsOf respects closed window`() {
+        val tm = TemporalMetadata(observedAt = t0, validFrom = t1, validTo = t2)
+        assertTrue(tm.isCurrentAsOf(t1))
+        assertFalse(tm.isCurrentAsOf(t2), "validTo is exclusive")
+        assertFalse(tm.isCurrentAsOf(t3))
+    }
+
+    @Test
+    fun `invalidatedAt short-circuits currency`() {
+        val tm = TemporalMetadata(observedAt = t0, validFrom = t1, invalidatedAt = t2)
+        assertTrue(tm.isCurrentAsOf(t1))
+        assertFalse(tm.isCurrentAsOf(t2), "at the invalidation instant it is no longer current")
+        assertFalse(tm.isCurrentAsOf(t3))
+    }
+
+    @Test
+    fun `isCurrent uses now`() {
+        val tm = TemporalMetadata(
+            observedAt = t0,
+            validFrom = Instant.now().minus(1, ChronoUnit.DAYS),
+        )
+        assertTrue(tm.isCurrent())
+    }
+
+    @Test
+    fun `validTo before validFrom rejected`() {
+        assertThrows<IllegalArgumentException> {
+            TemporalMetadata(observedAt = t0, validFrom = t2, validTo = t1)
+        }
+    }
+
+    @Test
+    fun `validTo equal to validFrom allowed`() {
+        val tm = TemporalMetadata(observedAt = t0, validFrom = t1, validTo = t1)
+        assertEquals(t1, tm.validTo)
+    }
+}


### PR DESCRIPTION
# Provenance, Temporal Metadata, and Projection Lineage

This introduces primitives for tracking where propositions come from, when they are true, and how they move through projection pipelines.

Nothing here is wired into extraction or projection execution yet. This is infrastructure: the data model and extension points that future work will build on.

## Provenance

Adds `SourceLocator` and `ProvenanceEntry`.

`SourceLocator` identifies where source material lives. DICE stores references to source material, not the source material itself. Supported locator types include:

- `UriLocator`
- `FileLocator`
- `ContentAddressedLocator`
- `ConnectorRef`

Locator identity is based on `key()`, not the human-readable display value. This allows the same source to be referenced under different labels without affecting equality, hashing, or deduplication behavior.

`ProvenanceEntry` provides a richer provenance model than the existing chunk-id grounding list by linking propositions back to a source locator with optional metadata such as:

- chunk identifier
- offset range
- content hash

The existing grounding field remains unchanged.

Polymorphic locator types are serialized using Jackson `@JsonTypeInfo` and `@JsonSubTypes` with a `kind` discriminator.

## Temporal Metadata

Adds `TemporalMetadata` to represent:

- when information was observed
- when information is valid
- supersession relationships
- contradiction relationships

Temporal metadata is optional and remains null for propositions where temporal correctness is not being tracked.

## Projection Lineage

Adds the primitives required to track projection lifecycle and reconciliation.

`Reconciler` and `ReconciliationDecision` make projection identity explicit by describing how a projected proposition relates to existing artifacts in a target system.

Supported decisions are:

- `CreateNew`
- `Adopt`
- `Align`

This externalizes the "get-or-create" behavior that projection backends such as Neo4j typically perform internally.

Also introduces:

- `ProjectionRecord`
- `ProjectionRecordStore`
- `ProjectionRun`
- `ProjectionLifecycle`

Together these provide a generic mechanism for recording what was projected, where it was projected, and how that projection was resolved.

An in-memory implementation is included along with an `AlwaysCreateReconciler` default implementation.

## Changes to Existing Types

Only Proposition is modified.

New optional fields:

- temporal: `TemporalMetadata`?
- provenanceEntries: `List<ProvenanceEntry>`

Both fields are defaulted and include corresponding:

- `withTemporal(...)`
- `withProvenanceEntries(...)`

copy helpers.

The fields are also exposed through the `create(...)` factory.

These changes are source- and binary-compatible. All new parameters are appended and defaulted, so existing call sites continue to work unchanged.

## Observability

`InMemoryProjectionRecordStore.record(...)` emits debug logging for lineage writes.

No additional runtime behavior is introduced yet. More meaningful observability, including reconciliation decisions and projection run summaries, will come online when the projection SPI is integrated into the execution path.

## Testing

`./mvnw test` passes.

New test coverage includes:

- temporal metadata
- projection records
- projection record storage
- source locator identity and key behavior
- source locator JSON serialization round-trips
- offset validation invariants
- proposition provenance integration
