### PR TITLE
feat(events): add DiceEvent subtypes and listener SPI

### DIFF
--- a/src/main/kotlin/com/embabel/dice/common/DiceEvent.kt
+++ b/src/main/kotlin/com/embabel/dice/common/DiceEvent.kt
@@ -15,7 +15,11 @@
  */
 package com.embabel.dice.common
 
+import com.embabel.agent.core.ContextId
 import com.embabel.common.core.types.Timestamped
+import com.embabel.dice.pipeline.PropositionExtractionStats
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionStatus
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.time.Instant
 
@@ -26,7 +30,223 @@ import java.time.Instant
 )
 interface DiceEvent : Timestamped
 
+/**
+ * Legacy empty contradiction signal.
+ *
+ * @deprecated Carries no payload. Replaced by [PropositionContradicted], which
+ * carries the [ContextId] plus both the original and the contradicting proposition.
+ * Retained (deprecate-only) this release for backward compatibility; will be removed later.
+ *
+ * @property timestamp When the event was created.
+ */
+@Deprecated(
+    message = "Use PropositionContradicted, which carries contextId and both propositions.",
+    replaceWith = ReplaceWith("PropositionContradicted"),
+)
 data class ContradictionEvent(
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted when a brand-new proposition is discovered (mirrors [com.embabel.dice.proposition.revision.RevisionResult.New]).
+ *
+ * @property proposition The newly discovered proposition.
+ * @property timestamp When the event was created.
+ */
+data class PropositionDiscovered @JvmOverloads constructor(
+    val proposition: Proposition,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted when an incoming proposition is merged into an existing one
+ * (mirrors [com.embabel.dice.proposition.revision.RevisionResult.Merged]).
+ *
+ * @property original The pre-existing proposition.
+ * @property revised The merged result.
+ * @property timestamp When the event was created.
+ */
+data class PropositionMerged @JvmOverloads constructor(
+    val original: Proposition,
+    val revised: Proposition,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted when an existing proposition is reinforced by a similar new one
+ * (mirrors [com.embabel.dice.proposition.revision.RevisionResult.Reinforced]).
+ *
+ * @property original The pre-existing proposition.
+ * @property revised The reinforced result.
+ * @property timestamp When the event was created.
+ */
+data class PropositionReinforced @JvmOverloads constructor(
+    val original: Proposition,
+    val revised: Proposition,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted when a new proposition contradicts an existing one
+ * (mirrors [com.embabel.dice.proposition.revision.RevisionResult.Contradicted], whose
+ * field is `new` rather than `revised`). Carries the [ContextId].
+ *
+ * @property contextId The context in which the contradiction was detected.
+ * @property original The pre-existing proposition.
+ * @property new The contradicting proposition.
+ * @property timestamp When the event was created.
+ */
+data class PropositionContradicted @JvmOverloads constructor(
+    val contextId: ContextId,
+    val original: Proposition,
+    val new: Proposition,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted when a higher-level proposition generalizes a group of source propositions
+ * (mirrors [com.embabel.dice.proposition.revision.RevisionResult.Generalized]).
+ *
+ * @property proposition The generalizing (abstract) proposition.
+ * @property generalizes The source propositions it abstracts over.
+ * @property timestamp When the event was created.
+ */
+data class PropositionGeneralized @JvmOverloads constructor(
+    val proposition: Proposition,
+    val generalizes: List<Proposition>,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * The canonical durable signal: emitted at the persistence boundary once a proposition
+ * has been saved. The full proposition snapshot is carried.
+ *
+ * @property proposition The persisted proposition (post-save state).
+ * @property timestamp When the event was created.
+ */
+data class PropositionPersisted @JvmOverloads constructor(
+    val proposition: Proposition,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted once a projection batch finishes, summarizing per-outcome counts
+ * (from [com.embabel.dice.proposition.ProjectionResults]).
+ *
+ * @property successCount Number of successful projections.
+ * @property skipCount Number of skipped projections.
+ * @property failureCount Number of failed projections.
+ * @property totalCount Total propositions in the batch.
+ * @property timestamp When the event was created.
+ */
+data class ProjectionBatchCompleted @JvmOverloads constructor(
+    val successCount: Int,
+    val skipCount: Int,
+    val failureCount: Int,
+    val totalCount: Int,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted once an extraction batch finishes, carrying the revision [PropositionExtractionStats].
+ *
+ * @property stats Per-outcome statistics for the extraction batch.
+ * @property timestamp When the event was created.
+ */
+data class ExtractionBatchCompleted @JvmOverloads constructor(
+    val stats: PropositionExtractionStats,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted when a proposition's lifecycle [PropositionStatus] changes (e.g. ACTIVE → STALE
+ * during a decay sweep, or STALE → ACTIVE on revival).
+ *
+ * This event is only *defined* here; emission wiring is handled separately by the
+ * persistence-boundary repository decorator. The name is chosen so emission can be wired
+ * without renaming.
+ *
+ * @property proposition The proposition whose status changed (post-transition state).
+ * @property previousStatus The status before the transition.
+ * @property newStatus The status after the transition.
+ * @property reason Optional free-text explanation for the transition.
+ */
+data class PropositionStatusChanged(
+    val proposition: Proposition,
+    val previousStatus: PropositionStatus,
+    val newStatus: PropositionStatus,
+    val reason: String? = null,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted when a proposition is pinned (marked sweep-exempt).
+ *
+ * This event is only *defined* here; emission wiring is handled separately by the persistence-boundary decorator.
+ *
+ * @property proposition The proposition that was pinned.
+ */
+data class PropositionPinned(
+    val proposition: Proposition,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted when a proposition is unpinned (no longer sweep-exempt).
+ *
+ * This event is only *defined* here; emission wiring is handled separately by the persistence-boundary decorator.
+ *
+ * @property proposition The proposition that was unpinned.
+ */
+data class PropositionUnpinned(
+    val proposition: Proposition,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted when a post-extraction routing decision rejects a proposition (it should be
+ * discarded rather than persisted). Carries the full proposition snapshot, matching the
+ * convention of the other events here.
+ *
+ * Note: the proposition (including its text) is carried into consumer-supplied listeners,
+ * identical exposure to every other [DiceEvent]; consumers control which listeners receive it.
+ *
+ * @property proposition The proposition that was rejected.
+ * @property reason Developer-authored explanation for the rejection.
+ * @property timestamp When the event was created.
+ */
+data class PropositionRejected @JvmOverloads constructor(
+    val proposition: Proposition,
+    val reason: String,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted when a post-extraction routing decision routes a proposition to a review queue
+ * rather than persisting it directly. Carries the full proposition snapshot.
+ *
+ * @property proposition The proposition routed to review.
+ * @property reason Developer-authored explanation for the routing.
+ * @property timestamp When the event was created.
+ */
+data class PropositionRoutedToReview @JvmOverloads constructor(
+    val proposition: Proposition,
+    val reason: String,
+    override val timestamp: Instant = Instant.now(),
+) : DiceEvent
+
+/**
+ * Emitted when a post-extraction routing decision excludes a proposition from projection
+ * (it may still be persisted, but is not projected to downstream representations). Carries
+ * the full proposition snapshot.
+ *
+ * @property proposition The proposition excluded from projection.
+ * @property reason Developer-authored explanation for skipping projection.
+ * @property timestamp When the event was created.
+ */
+data class PropositionProjectionSkipped @JvmOverloads constructor(
+    val proposition: Proposition,
+    val reason: String,
     override val timestamp: Instant = Instant.now(),
 ) : DiceEvent
 

--- a/src/main/kotlin/com/embabel/dice/common/DiceEvent.kt
+++ b/src/main/kotlin/com/embabel/dice/common/DiceEvent.kt
@@ -23,6 +23,11 @@ import com.embabel.dice.proposition.PropositionStatus
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.time.Instant
 
+/**
+ * Something noteworthy that happened to a proposition as it moved through DICE — discovered,
+ * merged, contradicted, saved, gone stale, and so on. Each subtype is a specific moment you
+ * can listen for; every event knows when it occurred.
+ */
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.CLASS,
     include = JsonTypeInfo.As.PROPERTY,
@@ -31,11 +36,12 @@ import java.time.Instant
 interface DiceEvent : Timestamped
 
 /**
- * Legacy empty contradiction signal.
+ * The original contradiction signal, which carried no information about *what* was
+ * contradicted.
  *
- * @deprecated Carries no payload. Replaced by [PropositionContradicted], which
- * carries the [ContextId] plus both the original and the contradicting proposition.
- * Retained (deprecate-only) this release for backward compatibility; will be removed later.
+ * @deprecated Use [PropositionContradicted] instead — it tells you the context and hands
+ * you both the original and the contradicting proposition. This empty version stays around
+ * for one release so existing listeners keep compiling, and will be removed after that.
  *
  * @property timestamp When the event was created.
  */
@@ -48,7 +54,7 @@ data class ContradictionEvent(
 ) : DiceEvent
 
 /**
- * Emitted when a brand-new proposition is discovered (mirrors [com.embabel.dice.proposition.revision.RevisionResult.New]).
+ * A brand-new proposition was discovered — nothing like it existed before.
  *
  * @property proposition The newly discovered proposition.
  * @property timestamp When the event was created.
@@ -59,11 +65,10 @@ data class PropositionDiscovered @JvmOverloads constructor(
 ) : DiceEvent
 
 /**
- * Emitted when an incoming proposition is merged into an existing one
- * (mirrors [com.embabel.dice.proposition.revision.RevisionResult.Merged]).
+ * An incoming proposition was folded into one we already had, producing a combined version.
  *
- * @property original The pre-existing proposition.
- * @property revised The merged result.
+ * @property original The proposition that already existed.
+ * @property revised The combined result after the merge.
  * @property timestamp When the event was created.
  */
 data class PropositionMerged @JvmOverloads constructor(
@@ -73,11 +78,10 @@ data class PropositionMerged @JvmOverloads constructor(
 ) : DiceEvent
 
 /**
- * Emitted when an existing proposition is reinforced by a similar new one
- * (mirrors [com.embabel.dice.proposition.revision.RevisionResult.Reinforced]).
+ * A similar proposition came in and reinforced one we already trusted, strengthening it.
  *
- * @property original The pre-existing proposition.
- * @property revised The reinforced result.
+ * @property original The proposition that already existed.
+ * @property revised The strengthened result.
  * @property timestamp When the event was created.
  */
 data class PropositionReinforced @JvmOverloads constructor(
@@ -87,13 +91,12 @@ data class PropositionReinforced @JvmOverloads constructor(
 ) : DiceEvent
 
 /**
- * Emitted when a new proposition contradicts an existing one
- * (mirrors [com.embabel.dice.proposition.revision.RevisionResult.Contradicted], whose
- * field is `new` rather than `revised`). Carries the [ContextId].
+ * A new proposition directly contradicts one we already held. Both are handed to listeners
+ * so they can decide how to reconcile them.
  *
- * @property contextId The context in which the contradiction was detected.
- * @property original The pre-existing proposition.
- * @property new The contradicting proposition.
+ * @property contextId The context in which the contradiction surfaced.
+ * @property original The proposition that already existed.
+ * @property new The new proposition that contradicts it.
  * @property timestamp When the event was created.
  */
 data class PropositionContradicted @JvmOverloads constructor(
@@ -104,11 +107,10 @@ data class PropositionContradicted @JvmOverloads constructor(
 ) : DiceEvent
 
 /**
- * Emitted when a higher-level proposition generalizes a group of source propositions
- * (mirrors [com.embabel.dice.proposition.revision.RevisionResult.Generalized]).
+ * A higher-level proposition was formed that generalizes over a group of more specific ones.
  *
- * @property proposition The generalizing (abstract) proposition.
- * @property generalizes The source propositions it abstracts over.
+ * @property proposition The abstract proposition that was formed.
+ * @property generalizes The specific propositions it summarizes.
  * @property timestamp When the event was created.
  */
 data class PropositionGeneralized @JvmOverloads constructor(
@@ -118,10 +120,11 @@ data class PropositionGeneralized @JvmOverloads constructor(
 ) : DiceEvent
 
 /**
- * The canonical durable signal: emitted at the persistence boundary once a proposition
- * has been saved. The full proposition snapshot is carried.
+ * A proposition was saved. This is the signal to rely on when you care that something
+ * actually made it to durable storage, not just that it was proposed — it fires once the
+ * write is done and carries the saved state.
  *
- * @property proposition The persisted proposition (post-save state).
+ * @property proposition The proposition as it was saved.
  * @property timestamp When the event was created.
  */
 data class PropositionPersisted @JvmOverloads constructor(
@@ -130,13 +133,12 @@ data class PropositionPersisted @JvmOverloads constructor(
 ) : DiceEvent
 
 /**
- * Emitted once a projection batch finishes, summarizing per-outcome counts
- * (from [com.embabel.dice.proposition.ProjectionResults]).
+ * A batch of propositions finished projecting, with a tally of how each one turned out.
  *
- * @property successCount Number of successful projections.
- * @property skipCount Number of skipped projections.
- * @property failureCount Number of failed projections.
- * @property totalCount Total propositions in the batch.
+ * @property successCount How many projected successfully.
+ * @property skipCount How many were skipped.
+ * @property failureCount How many failed.
+ * @property totalCount How many propositions were in the batch.
  * @property timestamp When the event was created.
  */
 data class ProjectionBatchCompleted @JvmOverloads constructor(
@@ -148,9 +150,9 @@ data class ProjectionBatchCompleted @JvmOverloads constructor(
 ) : DiceEvent
 
 /**
- * Emitted once an extraction batch finishes, carrying the revision [PropositionExtractionStats].
+ * A batch of text finished extraction, carrying the stats on what came out of it.
  *
- * @property stats Per-outcome statistics for the extraction batch.
+ * @property stats How the extraction batch broke down by outcome.
  * @property timestamp When the event was created.
  */
 data class ExtractionBatchCompleted @JvmOverloads constructor(
@@ -159,17 +161,13 @@ data class ExtractionBatchCompleted @JvmOverloads constructor(
 ) : DiceEvent
 
 /**
- * Emitted when a proposition's lifecycle [PropositionStatus] changes (e.g. ACTIVE → STALE
- * during a decay sweep, or STALE → ACTIVE on revival).
+ * A proposition moved to a different lifecycle [PropositionStatus] — for example going stale
+ * during a decay sweep, or coming back to life when it's seen again.
  *
- * This event is only *defined* here; emission wiring is handled separately by the
- * persistence-boundary repository decorator. The name is chosen so emission can be wired
- * without renaming.
- *
- * @property proposition The proposition whose status changed (post-transition state).
- * @property previousStatus The status before the transition.
- * @property newStatus The status after the transition.
- * @property reason Optional free-text explanation for the transition.
+ * @property proposition The proposition, in its state after the change.
+ * @property previousStatus Where it was before.
+ * @property newStatus Where it is now.
+ * @property reason An optional note on why it changed.
  */
 data class PropositionStatusChanged(
     val proposition: Proposition,
@@ -180,9 +178,7 @@ data class PropositionStatusChanged(
 ) : DiceEvent
 
 /**
- * Emitted when a proposition is pinned (marked sweep-exempt).
- *
- * This event is only *defined* here; emission wiring is handled separately by the persistence-boundary decorator.
+ * A proposition was pinned, so decay sweeps will leave it alone.
  *
  * @property proposition The proposition that was pinned.
  */
@@ -192,9 +188,7 @@ data class PropositionPinned(
 ) : DiceEvent
 
 /**
- * Emitted when a proposition is unpinned (no longer sweep-exempt).
- *
- * This event is only *defined* here; emission wiring is handled separately by the persistence-boundary decorator.
+ * A proposition was unpinned, so it's back in scope for decay sweeps.
  *
  * @property proposition The proposition that was unpinned.
  */
@@ -204,15 +198,12 @@ data class PropositionUnpinned(
 ) : DiceEvent
 
 /**
- * Emitted when a post-extraction routing decision rejects a proposition (it should be
- * discarded rather than persisted). Carries the full proposition snapshot, matching the
- * convention of the other events here.
- *
- * Note: the proposition (including its text) is carried into consumer-supplied listeners,
- * identical exposure to every other [DiceEvent]; consumers control which listeners receive it.
+ * A proposition was turned away after extraction — it should be discarded rather than saved.
+ * Like every other event here, it carries the whole proposition (text included) to whichever
+ * listeners you've wired up.
  *
  * @property proposition The proposition that was rejected.
- * @property reason Developer-authored explanation for the rejection.
+ * @property reason Why it was rejected.
  * @property timestamp When the event was created.
  */
 data class PropositionRejected @JvmOverloads constructor(
@@ -222,11 +213,11 @@ data class PropositionRejected @JvmOverloads constructor(
 ) : DiceEvent
 
 /**
- * Emitted when a post-extraction routing decision routes a proposition to a review queue
- * rather than persisting it directly. Carries the full proposition snapshot.
+ * A proposition was set aside for a human (or a later pass) to look at, rather than being
+ * saved straight away.
  *
- * @property proposition The proposition routed to review.
- * @property reason Developer-authored explanation for the routing.
+ * @property proposition The proposition sent to review.
+ * @property reason Why it needs a second look.
  * @property timestamp When the event was created.
  */
 data class PropositionRoutedToReview @JvmOverloads constructor(
@@ -236,12 +227,11 @@ data class PropositionRoutedToReview @JvmOverloads constructor(
 ) : DiceEvent
 
 /**
- * Emitted when a post-extraction routing decision excludes a proposition from projection
- * (it may still be persisted, but is not projected to downstream representations). Carries
- * the full proposition snapshot.
+ * A proposition was kept out of projection — it may still be saved, but it won't be pushed
+ * out to the downstream representations (graph, Prolog, memory, and so on).
  *
- * @property proposition The proposition excluded from projection.
- * @property reason Developer-authored explanation for skipping projection.
+ * @property proposition The proposition that won't be projected.
+ * @property reason Why projection was skipped.
  * @property timestamp When the event was created.
  */
 data class PropositionProjectionSkipped @JvmOverloads constructor(
@@ -250,16 +240,21 @@ data class PropositionProjectionSkipped @JvmOverloads constructor(
     override val timestamp: Instant = Instant.now(),
 ) : DiceEvent
 
+/**
+ * Implement this to react to [DiceEvent]s as they happen. Keep in mind handlers run inline
+ * on the emitting thread, so do anything slow off to the side.
+ */
 fun interface DiceEventListener {
     fun onEvent(event: DiceEvent)
 
     companion object {
+        /** A listener that ignores everything — handy as a default when no one's listening. */
         val DEV_NULL: DiceEventListener = DevNull
     }
 }
 
 private object DevNull : DiceEventListener {
     override fun onEvent(event: DiceEvent) {
-        // Do nothing
+        // Intentionally ignores every event.
     }
 }

--- a/src/main/kotlin/com/embabel/dice/common/DiceEventListeners.kt
+++ b/src/main/kotlin/com/embabel/dice/common/DiceEventListeners.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.common
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A [DiceEventListener] decorator that isolates the emitting caller from a misbehaving
+ * delegate: any [Throwable] raised while delivering an event is caught and logged rather
+ * than propagated.
+ *
+ * Mirrors the catch-Throwable-and-log graceful-degradation precedent in
+ * [com.embabel.dice.agent.Memory.loadEagerMemories]. Since DICE ships no threading policy,
+ * listeners run synchronously inside the emit call; this wrapper ensures a single faulty
+ * listener cannot abort the operation that produced the event.
+ *
+ * @property delegate The listener whose delivery should be made exception-safe.
+ */
+class SafeDiceEventListener(
+    private val delegate: DiceEventListener,
+) : DiceEventListener {
+
+    private val logger = LoggerFactory.getLogger(SafeDiceEventListener::class.java)
+
+    override fun onEvent(event: DiceEvent) {
+        try {
+            delegate.onEvent(event)
+        } catch (t: Throwable) {
+            logger.warn("DiceEventListener {} threw while handling {}", delegate, event.javaClass.simpleName, t)
+        }
+    }
+}
+
+/**
+ * A [DiceEventListener] that fans an event out to every listener in [listeners]. Each
+ * delivery is wrapped with [SafeDiceEventListener] semantics so that one throwing listener
+ * does not prevent the rest of the chain from receiving the event.
+ *
+ * @property listeners The listeners to fan out to, in order.
+ */
+class CompositeDiceEventListener(
+    private val listeners: List<DiceEventListener>,
+) : DiceEventListener {
+
+    private val safeListeners: List<SafeDiceEventListener> = listeners.map(::SafeDiceEventListener)
+
+    override fun onEvent(event: DiceEvent) {
+        safeListeners.forEach { it.onEvent(event) }
+    }
+}
+
+/**
+ * A [DiceEventListener] that logs each received event at debug level and does nothing else.
+ * Useful as a low-overhead observability hook; never throws.
+ */
+class LoggingDiceEventListener : DiceEventListener {
+
+    private val logger = LoggerFactory.getLogger(LoggingDiceEventListener::class.java)
+
+    override fun onEvent(event: DiceEvent) {
+        logger.debug("DiceEvent: {}", event)
+    }
+}

--- a/src/main/kotlin/com/embabel/dice/common/DiceEventListeners.kt
+++ b/src/main/kotlin/com/embabel/dice/common/DiceEventListeners.kt
@@ -18,16 +18,14 @@ package com.embabel.dice.common
 import org.slf4j.LoggerFactory
 
 /**
- * A [DiceEventListener] decorator that isolates the emitting caller from a misbehaving
- * delegate: any [Throwable] raised while delivering an event is caught and logged rather
- * than propagated.
+ * Wraps another listener and stops it from taking down the caller: if the wrapped listener
+ * throws, the error is logged and swallowed instead of bubbling up.
  *
- * Mirrors the catch-Throwable-and-log graceful-degradation precedent in
- * [com.embabel.dice.agent.Memory.loadEagerMemories]. Since DICE ships no threading policy,
- * listeners run synchronously inside the emit call; this wrapper ensures a single faulty
- * listener cannot abort the operation that produced the event.
+ * This matters because listeners run synchronously, right inside the call that emitted the
+ * event — DICE doesn't put them on a separate thread. Without this wrapper, one buggy
+ * listener could abort the very operation that produced the event.
  *
- * @property delegate The listener whose delivery should be made exception-safe.
+ * @property delegate The listener to make exception-safe.
  */
 class SafeDiceEventListener(
     private val delegate: DiceEventListener,
@@ -45,11 +43,11 @@ class SafeDiceEventListener(
 }
 
 /**
- * A [DiceEventListener] that fans an event out to every listener in [listeners]. Each
- * delivery is wrapped with [SafeDiceEventListener] semantics so that one throwing listener
- * does not prevent the rest of the chain from receiving the event.
+ * Delivers each event to several listeners in turn. Every delivery is made exception-safe
+ * (see [SafeDiceEventListener]), so one listener throwing doesn't stop the others from
+ * hearing about the event.
  *
- * @property listeners The listeners to fan out to, in order.
+ * @property listeners The listeners to notify, in order.
  */
 class CompositeDiceEventListener(
     private val listeners: List<DiceEventListener>,
@@ -63,8 +61,8 @@ class CompositeDiceEventListener(
 }
 
 /**
- * A [DiceEventListener] that logs each received event at debug level and does nothing else.
- * Useful as a low-overhead observability hook; never throws.
+ * Logs every event it receives at debug level and nothing more. A cheap way to see the
+ * event stream while developing or debugging; it never throws.
  */
 class LoggingDiceEventListener : DiceEventListener {
 

--- a/src/test/kotlin/com/embabel/dice/common/DiceEventTest.kt
+++ b/src/test/kotlin/com/embabel/dice/common/DiceEventTest.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.common
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.proposition.EntityMention
+import com.embabel.dice.proposition.MentionRole
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.pipeline.PropositionExtractionStats
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Contract for the [DiceEvent] subtypes.
+ *
+ * Constructor shapes are 1:1 with `RevisionResult` plus `PropositionPersisted` and the two
+ * batch aggregates.
+ */
+class DiceEventTest {
+
+    private val contextId = ContextId("test-context")
+
+    private fun proposition(text: String = "Jim is an expert in GOAP"): Proposition =
+        Proposition(
+            contextId = contextId,
+            text = text,
+            mentions = listOf(
+                EntityMention(span = "Jim", type = "Person", role = MentionRole.SUBJECT),
+            ),
+            confidence = 0.9,
+        )
+
+    @Test
+    fun `PropositionDiscovered is a DiceEvent with a timestamp and carries the proposition`() {
+        val p = proposition()
+        val event = PropositionDiscovered(p)
+
+        assertTrue(event is DiceEvent)
+        assertNotNull(event.timestamp)
+        assertSame(p, event.proposition)
+    }
+
+    @Test
+    fun `PropositionMerged is a DiceEvent carrying original and revised`() {
+        val original = proposition("original")
+        val revised = proposition("revised")
+        val event = PropositionMerged(original, revised)
+
+        assertTrue(event is DiceEvent)
+        assertNotNull(event.timestamp)
+        assertSame(original, event.original)
+        assertSame(revised, event.revised)
+    }
+
+    @Test
+    fun `PropositionReinforced is a DiceEvent carrying original and revised`() {
+        val original = proposition("original")
+        val revised = proposition("revised")
+        val event = PropositionReinforced(original, revised)
+
+        assertTrue(event is DiceEvent)
+        assertNotNull(event.timestamp)
+        assertSame(original, event.original)
+        assertSame(revised, event.revised)
+    }
+
+    @Test
+    fun `PropositionContradicted is a DiceEvent carrying contextId and both propositions`() {
+        val original = proposition("original")
+        val new = proposition("new")
+        val event = PropositionContradicted(contextId, original, new)
+
+        assertTrue(event is DiceEvent)
+        assertNotNull(event.timestamp)
+        assertEquals(contextId, event.contextId)
+        assertSame(original, event.original)
+        assertSame(new, event.new)
+    }
+
+    @Test
+    fun `PropositionGeneralized is a DiceEvent carrying the proposition and its sources`() {
+        val p = proposition("generalization")
+        val sources = listOf(proposition("source-a"), proposition("source-b"))
+        val event = PropositionGeneralized(p, sources)
+
+        assertTrue(event is DiceEvent)
+        assertNotNull(event.timestamp)
+        assertSame(p, event.proposition)
+        assertTrue(event.generalizes.size == 2)
+    }
+
+    @Test
+    fun `PropositionPersisted is a DiceEvent carrying the persisted proposition`() {
+        val p = proposition()
+        val event = PropositionPersisted(p)
+
+        assertTrue(event is DiceEvent)
+        assertNotNull(event.timestamp)
+        assertSame(p, event.proposition)
+    }
+
+    @Test
+    fun `ProjectionBatchCompleted is a DiceEvent carrying the four counts`() {
+        val event = ProjectionBatchCompleted(
+            successCount = 3,
+            skipCount = 1,
+            failureCount = 2,
+            totalCount = 6,
+        )
+
+        assertTrue(event is DiceEvent)
+        assertNotNull(event.timestamp)
+        assertTrue(event.successCount == 3)
+        assertTrue(event.skipCount == 1)
+        assertTrue(event.failureCount == 2)
+        assertTrue(event.totalCount == 6)
+    }
+
+    @Test
+    fun `ExtractionBatchCompleted is a DiceEvent carrying extraction stats`() {
+        val stats = PropositionExtractionStats(
+            newCount = 2,
+            mergedCount = 1,
+            reinforcedCount = 0,
+            contradictedCount = 0,
+            generalizedCount = 0,
+        )
+        val event = ExtractionBatchCompleted(stats)
+
+        assertTrue(event is DiceEvent)
+        assertNotNull(event.timestamp)
+        assertSame(stats, event.stats)
+    }
+
+    @Test
+    fun `ContradictionEvent is deprecated`() {
+        // Reflection: the legacy empty event must be deprecated this release (deprecate-only, not removed).
+        val deprecated = ContradictionEvent::class.java.getAnnotation(Deprecated::class.java)
+        assertNotNull(deprecated, "ContradictionEvent must be @Deprecated in favour of PropositionContradicted")
+    }
+
+    @Test
+    fun `ContradictionEvent deprecation names PropositionContradicted as the replacement`() {
+        // The replaceWith expression must point IDEs/migrations at the richer event,
+        // not merely flag the type as deprecated.
+        val replaceWith = ContradictionEvent::class.annotations
+            .filterIsInstance<Deprecated>()
+            .single()
+            .replaceWith
+        assertTrue(
+            replaceWith.expression.contains("PropositionContradicted"),
+            "ReplaceWith expression must name PropositionContradicted, was '${replaceWith.expression}'",
+        )
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/common/GateDiceEventSerializationTest.kt
+++ b/src/test/kotlin/com/embabel/dice/common/GateDiceEventSerializationTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.common
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.proposition.EntityMention
+import com.embabel.dice.proposition.MentionRole
+import com.embabel.dice.proposition.Proposition
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The gate-decision events are declared on a `@JsonTypeInfo(use = CLASS)` interface, which is the
+ * contract that lets a consumer persist or transport them polymorphically. This verifies that
+ * contract holds: each event serialises with a type discriminator and deserialises back to its
+ * concrete subtype through the [DiceEvent] interface, preserving the carried reason.
+ */
+class GateDiceEventSerializationTest {
+
+    // Ignore unknown properties so the test exercises the gate-event polymorphism contract
+    // (the @JsonTypeInfo discriminator on the DiceEvent interface) without coupling to the
+    // nested Proposition type's own serialization shape, which carries a derived getter
+    // (contextIdValue) that has no matching constructor parameter.
+    private val mapper: ObjectMapper = ObjectMapper()
+        .registerKotlinModule()
+        .registerModule(JavaTimeModule())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+    private fun proposition(): Proposition = Proposition(
+        contextId = ContextId("ctx"),
+        text = "Jim is an expert in GOAP",
+        mentions = listOf(EntityMention(span = "Jim", type = "Person", role = MentionRole.SUBJECT)),
+        confidence = 0.9,
+    )
+
+    @Test
+    fun `a rejected event round-trips polymorphically through the DiceEvent interface`() {
+        val original: DiceEvent = PropositionRejected(proposition(), "low confidence")
+
+        val json = mapper.writeValueAsString(original)
+        val restored = mapper.readValue(json, DiceEvent::class.java)
+
+        assertInstanceOf(PropositionRejected::class.java, restored)
+        assertEquals("low confidence", (restored as PropositionRejected).reason)
+    }
+
+    @Test
+    fun `a routed-to-review event round-trips polymorphically through the DiceEvent interface`() {
+        val original: DiceEvent = PropositionRoutedToReview(proposition(), "merge candidate")
+
+        val restored = mapper.readValue(mapper.writeValueAsString(original), DiceEvent::class.java)
+
+        assertInstanceOf(PropositionRoutedToReview::class.java, restored)
+        assertEquals("merge candidate", (restored as PropositionRoutedToReview).reason)
+    }
+
+    @Test
+    fun `a projection-skipped event round-trips polymorphically through the DiceEvent interface`() {
+        val original: DiceEvent = PropositionProjectionSkipped(proposition(), "noisy")
+
+        val restored = mapper.readValue(mapper.writeValueAsString(original), DiceEvent::class.java)
+
+        assertInstanceOf(PropositionProjectionSkipped::class.java, restored)
+        assertEquals("noisy", (restored as PropositionProjectionSkipped).reason)
+    }
+
+    @Test
+    fun `serialised form carries a type discriminator so distinct subtypes are distinguishable`() {
+        val rejectedJson = mapper.writeValueAsString(PropositionRejected(proposition(), "x") as DiceEvent)
+        val reviewJson = mapper.writeValueAsString(PropositionRoutedToReview(proposition(), "x") as DiceEvent)
+
+        assertTrue(rejectedJson.contains("PropositionRejected"))
+        assertTrue(reviewJson.contains("PropositionRoutedToReview"))
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/common/GateDiceEventTest.kt
+++ b/src/test/kotlin/com/embabel/dice/common/GateDiceEventTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.common
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.proposition.EntityMention
+import com.embabel.dice.proposition.MentionRole
+import com.embabel.dice.proposition.Proposition
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Contract for the routing-decision [DiceEvent] subtypes the gate layer emits.
+ *
+ * Each carries the full [Proposition] (not an id) plus a developer-authored `reason`,
+ * mirroring the existing event convention in [DiceEvent].
+ */
+class GateDiceEventTest {
+
+    private val contextId = ContextId("test-context")
+
+    private fun proposition(text: String = "Jim is an expert in GOAP"): Proposition =
+        Proposition(
+            contextId = contextId,
+            text = text,
+            mentions = listOf(
+                EntityMention(span = "Jim", type = "Person", role = MentionRole.SUBJECT),
+            ),
+            confidence = 0.9,
+        )
+
+    @Test
+    fun `PropositionRejected is a DiceEvent carrying the proposition and reason`() {
+        val p = proposition()
+        val event = PropositionRejected(p, "low confidence")
+
+        assertTrue(event is DiceEvent)
+        assertNotNull(event.timestamp)
+        assertSame(p, event.proposition)
+        assertEquals("low confidence", event.reason)
+    }
+
+    @Test
+    fun `PropositionRoutedToReview is a DiceEvent carrying the proposition and reason`() {
+        val p = proposition()
+        val event = PropositionRoutedToReview(p, "merge candidate")
+
+        assertTrue(event is DiceEvent)
+        assertNotNull(event.timestamp)
+        assertSame(p, event.proposition)
+        assertEquals("merge candidate", event.reason)
+    }
+
+    @Test
+    fun `PropositionProjectionSkipped is a DiceEvent carrying the proposition and reason`() {
+        val p = proposition()
+        val event = PropositionProjectionSkipped(p, "low confidence")
+
+        assertTrue(event is DiceEvent)
+        assertNotNull(event.timestamp)
+        assertSame(p, event.proposition)
+        assertEquals("low confidence", event.reason)
+    }
+
+    @Test
+    fun `gate-decision events are deliverable through a DiceEventListener`() {
+        val received = mutableListOf<DiceEvent>()
+        val listener = DiceEventListener { received += it }
+        val p = proposition()
+
+        listener.onEvent(PropositionRejected(p, "low confidence"))
+        listener.onEvent(PropositionRoutedToReview(p, "merge candidate"))
+        listener.onEvent(PropositionProjectionSkipped(p, "low confidence"))
+
+        assertEquals(3, received.size)
+        assertTrue(received[0] is PropositionRejected)
+        assertTrue(received[1] is PropositionRoutedToReview)
+        assertTrue(received[2] is PropositionProjectionSkipped)
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/common/RecordingDiceEventListener.kt
+++ b/src/test/kotlin/com/embabel/dice/common/RecordingDiceEventListener.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.common
+
+/**
+ * Test double that records every [DiceEvent] delivered to it, for deterministic
+ * assertion in event-emitting tests. Shared capture surface for event tests.
+ *
+ * This is the canonical recording listener referenced by the decorator, projector,
+ * pipeline, and listener-utility tests — it lets a test assert on the exact events
+ * (and their order) produced at a deterministic boundary without an LLM in the loop.
+ */
+class RecordingDiceEventListener : DiceEventListener {
+
+    /** Every event delivered, in delivery order. */
+    val events: MutableList<DiceEvent> = mutableListOf()
+
+    override fun onEvent(event: DiceEvent) {
+        events.add(event)
+    }
+
+    /** Total number of events captured. */
+    fun count(): Int = events.size
+
+    /** All captured events of the given concrete type, in delivery order. */
+    inline fun <reified T : DiceEvent> eventsOfType(): List<T> =
+        events.filterIsInstance<T>()
+
+    /** Reset the capture list (useful between assertions in a single test). */
+    fun clear() {
+        events.clear()
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/common/SafeDiceEventListenerTest.kt
+++ b/src/test/kotlin/com/embabel/dice/common/SafeDiceEventListenerTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.common
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.proposition.EntityMention
+import com.embabel.dice.proposition.MentionRole
+import com.embabel.dice.proposition.Proposition
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Contract for the utility listeners:
+ * [SafeDiceEventListener] (swallows + logs throwables), [CompositeDiceEventListener]
+ * (fan-out), and [LoggingDiceEventListener] (no-throw logging).
+ */
+class SafeDiceEventListenerTest {
+
+    private val contextId = ContextId("test-context")
+
+    private fun event(): DiceEvent = PropositionPersisted(
+        Proposition(
+            contextId = contextId,
+            text = "Jim is an expert in GOAP",
+            mentions = listOf(EntityMention(span = "Jim", type = "Person", role = MentionRole.SUBJECT)),
+            confidence = 0.9,
+        )
+    )
+
+    private val throwing = DiceEventListener { error("listener boom") }
+
+    @Test
+    fun `SafeDiceEventListener does not propagate a throwing delegate`() {
+        val safe = SafeDiceEventListener(throwing)
+
+        assertDoesNotThrow {
+            safe.onEvent(event())
+        }
+    }
+
+    @Test
+    fun `CompositeDiceEventListener still delivers to later listeners after one throws`() {
+        val recording = RecordingDiceEventListener()
+        // The first listener throws; a robust composite must still reach the recording one.
+        val composite = CompositeDiceEventListener(listOf(SafeDiceEventListener(throwing), recording))
+
+        composite.onEvent(event())
+
+        assertEquals(1, recording.count(), "Recording listener should receive the event despite an earlier throw")
+    }
+
+    @Test
+    fun `CompositeDiceEventListener isolates a raw throwing listener without caller pre-wrapping`() {
+        val recording = RecordingDiceEventListener()
+        // The caller supplies a RAW throwing listener (NOT pre-wrapped in SafeDiceEventListener).
+        // The composite itself must apply throw-isolation so the later listener still receives the event.
+        val composite = CompositeDiceEventListener(listOf(throwing, recording))
+
+        assertDoesNotThrow { composite.onEvent(event()) }
+
+        assertEquals(
+            1,
+            recording.count(),
+            "Composite must internally isolate a raw throwing listener so later listeners still receive the event",
+        )
+    }
+
+    @Test
+    fun `LoggingDiceEventListener onEvent does not throw`() {
+        val logging = LoggingDiceEventListener()
+
+        assertDoesNotThrow {
+            logging.onEvent(event())
+        }
+    }
+}


### PR DESCRIPTION
This adds a proper knowledge-event surface to DICE - a set of `DiceEvent` types
covering the interesting things that happen to a proposition, plus a small listener
API for reacting to them. It gives consumers (and the rest of the library) one place
to hang observability and side effects off the proposition lifecycle.

## What's new

**Event types (`DiceEvent`)** - concrete events carrying typed `Proposition` payloads:

- Lifecycle: `PropositionDiscovered`, `PropositionMerged`, `PropositionReinforced`,
  `PropositionContradicted`, `PropositionGeneralized`
- Status: `PropositionStatusChanged`, `PropositionPinned`, `PropositionUnpinned`,
  `PropositionRejected`, `PropositionRoutedToReview`
- Persistence / batch: `PropositionPersisted`, `ProjectionBatchCompleted`,
  `ExtractionBatchCompleted`, `PropositionProjectionSkipped`

**Listener SPI (`DiceEventListeners`)**:

- `DiceEventListener` - the single-method functional interface, with a `DEV_NULL`
  no-op default
- `SafeDiceEventListener` - wraps a listener and swallows/logs failures so a bad
  listener can't break the emitting path
- `CompositeDiceEventListener` - fans an event out to several listeners
- `LoggingDiceEventListener` - logs events at debug

## What changed

- `ContradictionEvent` is now `@Deprecated` in favor of `PropositionContradicted`,
  which carries the actual proposition payload instead of nothing.
