### PR TITLE
feat(lifecycle): proposition lifecycle status, pinning, and decay

### DIFF
--- a/src/main/kotlin/com/embabel/dice/common/StatusTransitionPolicy.kt
+++ b/src/main/kotlin/com/embabel/dice/common/StatusTransitionPolicy.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.common
+
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionStatus
+
+/**
+ * Policy SPI: determines whether a proposition should transition lifecycle status.
+ *
+ * Lifecycle state is the *output* of a policy evaluation over proposition signals
+ * (effective confidence, importance, reinforcement, pinned). The [PropositionStatus]
+ * enum is a label applied after the policy runs; this interface separates "what state
+ * should this proposition be in?" (policy) from "what is its current state?" (the label).
+ *
+ * Implementations are stateless and are invoked per-proposition by a sweep
+ * (see [com.embabel.dice.proposition.DecaySweeper], implemented in a later phase).
+ * Return `null` to indicate that no transition is needed.
+ *
+ * Consumers may supply their own implementations to handle domain-specific staleness
+ * signals (e.g. a schema-version policy) without editing DICE core.
+ *
+ * Example usage:
+ * ```kotlin
+ * val policy: StatusTransitionPolicy = DecayStatusPolicy()
+ * val target = policy.evaluate(proposition)
+ * if (target != null) {
+ *     // proposition.withStatus(target)
+ * }
+ * ```
+ */
+fun interface StatusTransitionPolicy {
+
+    /**
+     * Evaluate the target lifecycle status for a proposition.
+     *
+     * @param proposition The proposition to evaluate
+     * @return The [PropositionStatus] the proposition should transition to, or `null`
+     *   if no transition is needed.
+     */
+    fun evaluate(proposition: Proposition): PropositionStatus?
+}
+
+/**
+ * Default [StatusTransitionPolicy]: transitions ACTIVE → STALE when a proposition's
+ * decayed utility drops below [stalenessThreshold], and STALE → ACTIVE when utility
+ * recovers above [recoveryThreshold].
+ *
+ * The two thresholds form a hysteresis band: a proposition whose utility sits between
+ * [stalenessThreshold] and [recoveryThreshold] does not transition, which prevents
+ * oscillation around a single cut-off. Pinned propositions are sweep-exempt and always
+ * return `null`.
+ *
+ * Utility composite:
+ * ```
+ * utility = effectiveConfidence(kMultiplier)
+ *         * (1 + importanceWeight  * importance)
+ *         * (1 + reinforceWeight   * ln1p(reinforceCount))
+ * ```
+ * With the default weights of 0.0, utility reduces to plain decayed effective confidence.
+ *
+ * Note: this is a sweep-time approximation. Folding `reinforceCount` into
+ * decay attenuation inside the reviser is the longer-term fix; until then the composite
+ * above lets a consumer opt into reinforcement/importance weighting at sweep time.
+ *
+ * **Recovery (STALE → ACTIVE) requires re-anchoring, which ships in a later phase.** Utility
+ * is driven by [Proposition.effectiveConfidence], which decays monotonically against the
+ * `contentRevised` anchor. With status transitions alone nothing re-anchors that timestamp, so the
+ * recovery branch below cannot fire from the passage of time — it becomes reachable only
+ * once the reviser's STALE-revival path refreshes `contentRevised` (and/or
+ * raises confidence) on reinforcement. The branch is retained now so the policy contract
+ * is complete and revival works without editing this class once that path lands.
+ *
+ * @property stalenessThreshold ACTIVE propositions with utility strictly below this become STALE.
+ * @property recoveryThreshold STALE propositions with utility strictly above this become ACTIVE.
+ * @property kMultiplier Decay-rate multiplier passed to [Proposition.effectiveConfidence].
+ * @property importanceWeight Weight applied to importance in the utility composite (0.0 = ignore).
+ * @property reinforceWeight Weight applied to ln1p(reinforceCount) in the utility composite (0.0 = ignore).
+ */
+class DecayStatusPolicy(
+    val stalenessThreshold: Double = 0.1,
+    val recoveryThreshold: Double = 0.2,
+    val kMultiplier: Double = 2.0,
+    val importanceWeight: Double = 0.0,
+    val reinforceWeight: Double = 0.0,
+) : StatusTransitionPolicy {
+
+    override fun evaluate(proposition: Proposition): PropositionStatus? {
+        if (proposition.pinned) return null
+        val utility = proposition.effectiveConfidence(kMultiplier) *
+            (1 + importanceWeight * proposition.importance) *
+            (1 + reinforceWeight * kotlin.math.ln(1.0 + proposition.reinforceCount.toDouble()))
+        return when {
+            proposition.status == PropositionStatus.ACTIVE && utility < stalenessThreshold ->
+                PropositionStatus.STALE
+            proposition.status == PropositionStatus.STALE && utility > recoveryThreshold ->
+                PropositionStatus.ACTIVE
+            else -> null
+        }
+    }
+}

--- a/src/main/kotlin/com/embabel/dice/common/StatusTransitionPolicy.kt
+++ b/src/main/kotlin/com/embabel/dice/common/StatusTransitionPolicy.kt
@@ -27,8 +27,8 @@ import com.embabel.dice.proposition.PropositionStatus
  * should this proposition be in?" (policy) from "what is its current state?" (the label).
  *
  * Implementations are stateless and are invoked per-proposition by a sweep
- * (see [com.embabel.dice.proposition.DecaySweeper], implemented in a later phase).
- * Return `null` to indicate that no transition is needed.
+ * (see [com.embabel.dice.proposition.DecaySweeper]). Return `null` to indicate
+ * that no transition is needed.
  *
  * Consumers may supply their own implementations to handle domain-specific staleness
  * signals (e.g. a schema-version policy) without editing DICE core.
@@ -72,17 +72,15 @@ fun interface StatusTransitionPolicy {
  * ```
  * With the default weights of 0.0, utility reduces to plain decayed effective confidence.
  *
- * Note: this is a sweep-time approximation. Folding `reinforceCount` into
- * decay attenuation inside the reviser is the longer-term fix; until then the composite
- * above lets a consumer opt into reinforcement/importance weighting at sweep time.
+ * This composite is a sweep-time approximation: it lets a consumer opt into
+ * reinforcement/importance weighting at sweep time.
  *
- * **Recovery (STALE → ACTIVE) requires re-anchoring, which ships in a later phase.** Utility
+ * Recovery (STALE → ACTIVE) only fires when something re-anchors the proposition. Utility
  * is driven by [Proposition.effectiveConfidence], which decays monotonically against the
- * `contentRevised` anchor. With status transitions alone nothing re-anchors that timestamp, so the
- * recovery branch below cannot fire from the passage of time — it becomes reachable only
- * once the reviser's STALE-revival path refreshes `contentRevised` (and/or
- * raises confidence) on reinforcement. The branch is retained now so the policy contract
- * is complete and revival works without editing this class once that path lands.
+ * `contentRevised` anchor, so the recovery branch below cannot fire from the passage of time
+ * alone — it becomes reachable when a reviser refreshes `contentRevised` (and/or raises
+ * confidence) on reinforcement. The branch is included so the policy contract is complete:
+ * revival works as soon as such a re-anchoring path runs.
  *
  * @property stalenessThreshold ACTIVE propositions with utility strictly below this become STALE.
  * @property recoveryThreshold STALE propositions with utility strictly above this become ACTIVE.

--- a/src/main/kotlin/com/embabel/dice/projection/memory/MemoryConsolidator.kt
+++ b/src/main/kotlin/com/embabel/dice/projection/memory/MemoryConsolidator.kt
@@ -188,7 +188,7 @@ class DefaultMemoryConsolidator(
         return existing.copy(
             confidence = newConfidence,
             grounding = newGrounding,
-            revised = Instant.now(),
+            contentRevised = Instant.now(),
         )
     }
 
@@ -206,7 +206,7 @@ class DefaultMemoryConsolidator(
             confidence = avgConfidence,
             grounding = allGrounding,
             created = Instant.now(),
-            revised = Instant.now(),
+            contentRevised = Instant.now(),
         )
     }
 }

--- a/src/main/kotlin/com/embabel/dice/proposition/DecaySweeper.kt
+++ b/src/main/kotlin/com/embabel/dice/proposition/DecaySweeper.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.proposition
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.common.DecayStatusPolicy
+import com.embabel.dice.common.StatusTransitionPolicy
+
+/**
+ * Evaluates propositions for lifecycle transitions and applies them according to a
+ * [StatusTransitionPolicy].
+ *
+ * Scheduling the sweep (cron, `@Scheduled`, manual trigger) is the consuming
+ * application's responsibility — DICE ships no scheduler of its own.
+ *
+ * To customize forgetting or consolidation behavior, supply a different policy via
+ * [DecaySweepConfig.policy] rather than subclassing the sweeper.
+ */
+interface DecaySweeper {
+
+    /**
+     * Sweep the propositions in a single context for lifecycle transitions.
+     *
+     * @param contextId The context whose propositions should be evaluated
+     * @param config The sweep configuration (policy, target statuses, pruning)
+     * @return The sweep result (swept, no-op, or failed)
+     */
+    fun sweep(contextId: ContextId, config: DecaySweepConfig): DecaySweepResult
+
+    /**
+     * Sweep the propositions across all contexts for lifecycle transitions.
+     *
+     * @param config The sweep configuration (policy, target statuses, pruning)
+     * @return The sweep result (swept, no-op, or failed)
+     */
+    fun sweepAll(config: DecaySweepConfig): DecaySweepResult
+}
+
+/**
+ * Configuration for a [DecaySweeper] run.
+ *
+ * @property policy The transition policy applied per-proposition. Defaults to [DecayStatusPolicy].
+ * @property targetStatuses Which statuses the sweep considers for evaluation. Defaults to
+ *   `{ACTIVE}`, which deliberately excludes `PROMOTED` — propositions already projected to the
+ *   typed graph are not swept to STALE unless a consumer explicitly widens this set.
+ * @property pruneStale When true, STALE propositions may be hard-deleted by the sweep. Defaults
+ *   to false so stale propositions remain queryable for audit and potential revival.
+ */
+data class DecaySweepConfig @JvmOverloads constructor(
+    val policy: StatusTransitionPolicy = DecayStatusPolicy(),
+    val targetStatuses: Set<PropositionStatus> = setOf(PropositionStatus.ACTIVE),
+    val pruneStale: Boolean = false,
+)
+
+/**
+ * Result of a [DecaySweeper] run.
+ */
+sealed class DecaySweepResult {
+
+    /**
+     * The sweep ran and (potentially) transitioned propositions.
+     *
+     * @property transitioned Propositions moved to STALE.
+     * @property revived Propositions moved back to ACTIVE.
+     * @property pruned Propositions hard-pruned (only when `pruneStale` is enabled).
+     * @property skipped Count of propositions evaluated but left unchanged.
+     */
+    data class Swept(
+        val transitioned: List<Proposition>,
+        val revived: List<Proposition>,
+        val pruned: List<Proposition>,
+        val skipped: Int,
+    ) : DecaySweepResult()
+
+    /**
+     * The sweep had nothing to do.
+     *
+     * @property reason Human-readable explanation.
+     */
+    data class NoOp(val reason: String) : DecaySweepResult()
+
+    /**
+     * The sweep failed.
+     *
+     * @property cause The failure cause.
+     */
+    data class Failed(val cause: Throwable) : DecaySweepResult()
+}

--- a/src/main/kotlin/com/embabel/dice/proposition/EntityMention.kt
+++ b/src/main/kotlin/com/embabel/dice/proposition/EntityMention.kt
@@ -35,7 +35,12 @@ enum class MentionRole {
  * A reference to an entity within a proposition.
  *
  * @property span The text as it appears in the proposition (e.g., "Jim")
- * @property type The entity type label from schema (e.g., "Person", "Technology")
+ * @property type The entity type label from schema (e.g., "Person", "Technology").
+ *   For graph projection, this must match the relation's expected subject/object
+ *   type — which is derived from the Kotlin class `simpleName` (or a Neo4j
+ *   `ownLabel`) — for an edge to be produced. Matching is tolerant of case and of
+ *   label-ish hints, but a genuine mismatch yields a failure whose reason names
+ *   both the actual and expected type rather than silently producing no edge.
  * @property resolvedId Entity ID if resolved, null if unresolved
  * @property role The role this entity plays in the proposition
  * @property hints Additional context for future resolution (e.g., aliases, titles)

--- a/src/main/kotlin/com/embabel/dice/proposition/Proposition.kt
+++ b/src/main/kotlin/com/embabel/dice/proposition/Proposition.kt
@@ -15,11 +15,13 @@
  */
 package com.embabel.dice.proposition
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.embabel.agent.core.ContextId
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.common.core.types.ZeroToOne
 import com.embabel.dice.provenance.ProvenanceEntry
 import com.embabel.dice.temporal.TemporalMetadata
+import org.jetbrains.annotations.ApiStatus
 import java.time.Instant
 import java.util.*
 
@@ -38,7 +40,23 @@ enum class PropositionStatus {
     CONTRADICTED,
 
     /** Successfully projected to typed graph (Neo4j/Prolog) */
-    PROMOTED
+    PROMOTED,
+
+    /**
+     * Effective confidence has decayed below the staleness threshold.
+     *
+     * STALE propositions are excluded from standard retrieval but are preserved
+     * for inspection and potential revival; staleness does NOT imply contradicting
+     * evidence (use [CONTRADICTED] for that). Re-reinforcement can lift a STALE
+     * proposition back to [ACTIVE].
+     *
+     * Migration note: this constant is newly introduced. Any future exhaustive
+     * `when (status)` over [PropositionStatus] must add a `STALE` branch. The
+     * library currently has no exhaustive `when` over this enum, so the addition
+     * is source-compatible today.
+     */
+    @ApiStatus.Experimental
+    STALE
 }
 
 /**
@@ -63,19 +81,24 @@ enum class PropositionStatus {
  * @property reasoning LLM explanation for why this was extracted
  * @property grounding Chunk IDs that support this proposition
  * @property created When the proposition was first created
- * @property revised When the proposition was last updated
+ * @property contentRevised When the proposition's content last changed (text, mentions,
+ *   confidence). This is the decay anchor: [effectiveConfidence] measures age from here.
+ * @property metadataRevised When the proposition's administrative metadata last changed
+ *   (status, grounding, temporal, pinned). Does NOT reset the decay clock.
+ * @property pinned When true, the proposition is exempt from decay-driven sweeps
+ *   (a sweep-protected tier). Defaults to false.
  * @property status Current lifecycle status
  * @property level Abstraction level: 0 = raw observation, 1+ = derived abstraction
  * @property sourceIds IDs of propositions this was abstracted from (empty for level 0)
  * @property reinforceCount How many times this proposition has been merged or reinforced.
  *   Provides a frequency/importance signal complementary to confidence and decay.
  * @property temporal Optional bitemporal metadata (observed/valid time, supersession,
- *   contradiction). Null when temporal information is not tracked for this proposition.
- * @property provenanceEntries Rich source-material provenance for this proposition
- *   (locator, originating chunk, character offsets, content hash) via
- *   [com.embabel.dice.provenance.SourceLocator]. Independent of the [grounding]
- *   field's chunk/entity ids.
+ *   contradiction). Null when temporal correctness is not tracked for this proposition.
+ * @property provenanceEntries Rich grounding entries linking this proposition to source
+ *   material via [com.embabel.dice.provenance.SourceLocator]. Complements the legacy
+ *   chunk-id-only [grounding] list.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Proposition(
     override val id: String = UUID.randomUUID().toString(),
     val contextId: ContextId,
@@ -87,7 +110,9 @@ data class Proposition(
     val reasoning: String? = null,
     override val grounding: List<String> = emptyList(),
     val created: Instant = Instant.now(),
-    val revised: Instant = Instant.now(),
+    val contentRevised: Instant = Instant.now(),
+    val metadataRevised: Instant = Instant.now(),
+    val pinned: Boolean = false,
     val lastAccessed: Instant = Instant.now(),
     val status: PropositionStatus = PropositionStatus.ACTIVE,
     val level: Int = 0,
@@ -105,10 +130,32 @@ data class Proposition(
     @get:JvmName("getContextIdValue")
     val contextIdValue: String get() = contextId.value
 
-    /** Create a copy with updated text and revised timestamp. */
+    /**
+     * Legacy alias for the last-updated timestamp. Retained for backward
+     * compatibility (existing readers and JSON serialization) as a read-only
+     * computed property equal to [contentRevised]. Because it is a body-level
+     * getter, it is excluded from `copy()`/`equals`/`hashCode`.
+     */
+    @Deprecated(
+        "Use contentRevised (decay anchor) or metadataRevised (admin touch)",
+        ReplaceWith("contentRevised"),
+    )
+    val revised: Instant get() = contentRevised
+
+    /**
+     * The most recent update of any kind — the later of [contentRevised] and
+     * [metadataRevised]. Use this for "last touched / recently updated" recency
+     * queries and ordering, where an administrative touch (status change, pin,
+     * re-grounding) must still count as activity. Distinct from [contentRevised],
+     * which is the decay anchor and deliberately ignores administrative touches.
+     * Body-level getter: excluded from `copy()`/`equals`/`hashCode`.
+     */
+    val lastTouched: Instant get() = maxOf(contentRevised, metadataRevised)
+
+    /** Create a copy with updated text. Resets the decay clock (content anchor). */
     fun withText(newText: String): Proposition = copy(
         text = newText,
-        revised = Instant.now(),
+        contentRevised = Instant.now(),
     )
 
     companion object {
@@ -144,6 +191,9 @@ data class Proposition(
             uri: String? = null,
             temporal: TemporalMetadata? = null,
             provenanceEntries: List<ProvenanceEntry> = emptyList(),
+            contentRevised: Instant = revised,
+            metadataRevised: Instant = revised,
+            pinned: Boolean = false,
         ): Proposition = Proposition(
             id = id,
             contextId = ContextId(contextIdValue),
@@ -155,7 +205,9 @@ data class Proposition(
             reasoning = reasoning,
             grounding = grounding,
             created = created,
-            revised = revised,
+            contentRevised = contentRevised,
+            metadataRevised = metadataRevised,
+            pinned = pinned,
             lastAccessed = lastAccessed,
             status = status,
             level = level,
@@ -194,39 +246,57 @@ data class Proposition(
      * Create a copy with updated mentions.
      */
     fun withResolvedMentions(resolvedMentions: List<EntityMention>): Proposition =
-        copy(mentions = resolvedMentions, revised = Instant.now())
+        copy(mentions = resolvedMentions, contentRevised = Instant.now())
 
     /**
-     * Create a copy with updated status.
+     * Create a copy with updated status. Administrative change: touches only
+     * metadataRevised and preserves the decay clock (contentRevised).
      */
     fun withStatus(newStatus: PropositionStatus): Proposition =
-        copy(status = newStatus, revised = Instant.now())
+        copy(status = newStatus, metadataRevised = Instant.now())
+
+    /**
+     * Create a copy with the pin flag set. Administrative change: touches only
+     * metadataRevised and preserves the decay clock (contentRevised).
+     */
+    fun withPinned(pinned: Boolean): Proposition =
+        copy(pinned = pinned, metadataRevised = Instant.now())
 
     /**
      * Create a copy with adjusted confidence.
      */
     fun withConfidence(newConfidence: Double): Proposition {
         require(newConfidence in 0.0..1.0) { "Confidence must be between 0.0 and 1.0" }
-        return copy(confidence = newConfidence, revised = Instant.now())
+        return copy(confidence = newConfidence, contentRevised = Instant.now())
     }
 
     /**
      * Create a copy with additional grounding.
      */
     fun withGrounding(chunkIds: List<String>): Proposition =
-        copy(grounding = (grounding + chunkIds).distinct(), revised = Instant.now())
+        copy(grounding = (grounding + chunkIds).distinct(), metadataRevised = Instant.now())
 
     /**
      * Create a copy with the given temporal metadata.
      */
     fun withTemporal(temporal: TemporalMetadata): Proposition =
-        copy(temporal = temporal, revised = Instant.now())
+        copy(temporal = temporal, metadataRevised = Instant.now())
 
     /**
-     * Create a copy with the given provenance entries appended (de-duplicated).
+     * Create a copy with additional rich grounding entries.
      */
     fun withProvenanceEntries(entries: List<ProvenanceEntry>): Proposition =
-        copy(provenanceEntries = (provenanceEntries + entries).distinct(), revised = Instant.now())
+        copy(provenanceEntries = (provenanceEntries + entries).distinct(), metadataRevised = Instant.now())
+
+    /**
+     * Create a copy with an additional (or replaced) metadata entry.
+     *
+     * Administrative change: touches only [metadataRevised] and deliberately
+     * preserves the decay clock ([contentRevised]). Use this to cache derived
+     * annotations (e.g. a trust score) without re-anchoring decay.
+     */
+    fun withMetadataValue(key: String, value: Any): Proposition =
+        copy(metadata = metadata + (key to value), metadataRevised = Instant.now())
 
     /**
      * Calculate the effective confidence after applying time-based decay.
@@ -252,9 +322,9 @@ data class Proposition(
         // Explicit retraction zeroes the fact out in any mode.
         if (t?.invalidatedAt != null && !t.invalidatedAt.isAfter(asOf)) return 0.0
 
-        // DATED — a known valid window ([TemporalMetadata.validFrom] set). Crisply
-        // in- or out-of-window; a CLOSED window is permanently true about itself and
-        // never decays, an OPEN-ENDED one ("since X, still?") keeps decaying.
+        // DATED — a known valid window ([TemporalMetadata.validFrom] set). Crisply in-
+        // or out-of-window: a CLOSED window is permanently true about itself and never
+        // decays; an OPEN-ENDED one ("since X, still?") keeps decaying from validFrom.
         val validFrom = t?.validFrom
         if (validFrom != null) {
             if (!t.isCurrentAsOf(asOf)) return 0.0
@@ -262,8 +332,9 @@ data class Proposition(
             return confidence * decayFactor(from = validFrom, to = asOf, k = k)
         }
 
-        // DECAYING — no valid window: confidence fades from the last revision.
-        return confidence * decayFactor(from = revised, to = asOf, k = k)
+        // DECAYING — no valid window: confidence fades from the last content revision
+        // (the decay anchor).
+        return confidence * decayFactor(from = contentRevised, to = asOf, k = k)
     }
 
     private fun decayFactor(from: Instant, to: Instant, k: Double): Double {

--- a/src/main/kotlin/com/embabel/dice/proposition/revision/LlmPropositionReviser.kt
+++ b/src/main/kotlin/com/embabel/dice/proposition/revision/LlmPropositionReviser.kt
@@ -596,7 +596,7 @@ data class LlmPropositionReviser(
             decay = slowedDecay,
             grounding = combinedGrounding,
             reinforceCount = existing.reinforceCount + 1,
-            revised = Instant.now(),
+            contentRevised = Instant.now(),
             lastAccessed = Instant.now(),
         )
     }
@@ -618,7 +618,7 @@ data class LlmPropositionReviser(
             decay = slowedDecay,
             grounding = combinedGrounding,
             reinforceCount = existing.reinforceCount + 1,
-            revised = Instant.now(),
+            contentRevised = Instant.now(),
             lastAccessed = Instant.now(),
         )
     }

--- a/src/test/kotlin/com/embabel/dice/common/LifecycleDiceEventTest.kt
+++ b/src/test/kotlin/com/embabel/dice/common/LifecycleDiceEventTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.common
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Asserts the lifecycle transition events are defined as first-class [DiceEvent]
+ * subtypes carrying the full proposition snapshot, so they can flow through the
+ * existing single `DiceEventListener` surface (no parallel listener type).
+ */
+class LifecycleDiceEventTest {
+
+    private val contextId = ContextId("test-context")
+
+    private fun prop(status: PropositionStatus = PropositionStatus.ACTIVE) = Proposition(
+        contextId = contextId,
+        text = "a fact",
+        mentions = emptyList(),
+        confidence = 0.7,
+        status = status,
+    )
+
+    @Test
+    fun `status changed event is a DiceEvent carrying both statuses and the snapshot`() {
+        val p = prop(PropositionStatus.STALE)
+        val event = PropositionStatusChanged(
+            proposition = p,
+            previousStatus = PropositionStatus.ACTIVE,
+            newStatus = PropositionStatus.STALE,
+            reason = "decayed below threshold",
+        )
+
+        assertTrue(event is DiceEvent)
+        assertSame(p, event.proposition)
+        assertEquals(PropositionStatus.ACTIVE, event.previousStatus)
+        assertEquals(PropositionStatus.STALE, event.newStatus)
+        assertEquals("decayed below threshold", event.reason)
+    }
+
+    @Test
+    fun `status changed reason is optional`() {
+        val event = PropositionStatusChanged(
+            proposition = prop(),
+            previousStatus = PropositionStatus.ACTIVE,
+            newStatus = PropositionStatus.SUPERSEDED,
+        )
+        assertEquals(null, event.reason)
+    }
+
+    @Test
+    fun `pinned event is a DiceEvent carrying the snapshot`() {
+        val p = prop()
+        val event = PropositionPinned(proposition = p)
+        assertTrue(event is DiceEvent)
+        assertSame(p, event.proposition)
+    }
+
+    @Test
+    fun `unpinned event is a DiceEvent carrying the snapshot`() {
+        val p = prop()
+        val event = PropositionUnpinned(proposition = p)
+        assertTrue(event is DiceEvent)
+        assertSame(p, event.proposition)
+    }
+
+    @Test
+    fun `lifecycle events dispatch through a single DiceEventListener surface`() {
+        // A consumer-style listener over the common DiceEvent type must be able to
+        // receive every lifecycle subtype without a parallel listener interface.
+        val received = mutableListOf<DiceEvent>()
+        val listener: (DiceEvent) -> Unit = { received.add(it) }
+
+        val p = prop()
+        listener(PropositionStatusChanged(p, PropositionStatus.ACTIVE, PropositionStatus.STALE))
+        listener(PropositionPinned(p))
+        listener(PropositionUnpinned(p))
+
+        assertEquals(3, received.size)
+        assertTrue(received[0] is PropositionStatusChanged)
+        assertTrue(received[1] is PropositionPinned)
+        assertTrue(received[2] is PropositionUnpinned)
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/projection/memory/MemoryMaintenanceOrchestratorTest.kt
+++ b/src/test/kotlin/com/embabel/dice/projection/memory/MemoryMaintenanceOrchestratorTest.kt
@@ -55,7 +55,7 @@ class MemoryMaintenanceOrchestratorTest {
             decay = decay,
             status = status,
             created = created,
-            revised = revised,
+            contentRevised = revised,
         )
     }
 

--- a/src/test/kotlin/com/embabel/dice/proposition/DecaySweeperTypesTest.kt
+++ b/src/test/kotlin/com/embabel/dice/proposition/DecaySweeperTypesTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.proposition
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.common.DecayStatusPolicy
+import com.embabel.dice.common.StatusTransitionPolicy
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Behavioral surface tests for the [DecaySweeper] extension point: the config
+ * defaults that downstream forgetting/consolidation work depends on, and the
+ * sealed result type that callers must be able to exhaustively branch over.
+ *
+ * The sweeper implementation itself is intentionally deferred to a later phase;
+ * this asserts the stable type surface delivered now.
+ */
+class DecaySweeperTypesTest {
+
+    private val testContextId = ContextId("test-context")
+
+    private fun prop(text: String = "fact") = Proposition(
+        contextId = testContextId,
+        text = text,
+        mentions = emptyList(),
+        confidence = 0.5,
+    )
+
+    @Nested
+    inner class ConfigDefaults {
+
+        @Test
+        fun `default config uses the DecayStatusPolicy default`() {
+            val config = DecaySweepConfig()
+            assertTrue(config.policy is DecayStatusPolicy)
+        }
+
+        @Test
+        fun `default target statuses scope to ACTIVE only and exclude PROMOTED`() {
+            val config = DecaySweepConfig()
+            assertEquals(setOf(PropositionStatus.ACTIVE), config.targetStatuses)
+            assertFalse(config.targetStatuses.contains(PropositionStatus.PROMOTED))
+        }
+
+        @Test
+        fun `default config is non-destructive (pruneStale is false)`() {
+            assertFalse(DecaySweepConfig().pruneStale)
+        }
+
+        @Test
+        fun `config preserves a custom policy and widened target statuses`() {
+            val custom: StatusTransitionPolicy = StatusTransitionPolicy { null }
+            val config = DecaySweepConfig(
+                policy = custom,
+                targetStatuses = setOf(PropositionStatus.ACTIVE, PropositionStatus.PROMOTED),
+                pruneStale = true,
+            )
+            assertSame(custom, config.policy)
+            assertEquals(setOf(PropositionStatus.ACTIVE, PropositionStatus.PROMOTED), config.targetStatuses)
+            assertTrue(config.pruneStale)
+        }
+    }
+
+    @Nested
+    inner class SealedResult {
+
+        @Test
+        fun `Swept carries transitioned revived pruned and skipped counts`() {
+            val transitioned = listOf(prop("stale-now"))
+            val revived = listOf(prop("active-again"))
+            val result: DecaySweepResult = DecaySweepResult.Swept(
+                transitioned = transitioned,
+                revived = revived,
+                pruned = emptyList(),
+                skipped = 3,
+            )
+
+            val summary = when (result) {
+                is DecaySweepResult.Swept ->
+                    "${result.transitioned.size}/${result.revived.size}/${result.pruned.size}/${result.skipped}"
+                is DecaySweepResult.NoOp -> "noop"
+                is DecaySweepResult.Failed -> "failed"
+            }
+            assertEquals("1/1/0/3", summary)
+        }
+
+        @Test
+        fun `NoOp carries a reason and is distinct from Swept`() {
+            val result: DecaySweepResult = DecaySweepResult.NoOp("nothing to sweep")
+            assertTrue(result is DecaySweepResult.NoOp)
+            assertEquals("nothing to sweep", (result as DecaySweepResult.NoOp).reason)
+        }
+
+        @Test
+        fun `Failed carries the cause`() {
+            val boom = IllegalStateException("repository unavailable")
+            val result: DecaySweepResult = DecaySweepResult.Failed(boom)
+            assertSame(boom, (result as DecaySweepResult.Failed).cause)
+        }
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/proposition/DecaySweeperTypesTest.kt
+++ b/src/test/kotlin/com/embabel/dice/proposition/DecaySweeperTypesTest.kt
@@ -29,9 +29,6 @@ import org.junit.jupiter.api.Test
  * Behavioral surface tests for the [DecaySweeper] extension point: the config
  * defaults that downstream forgetting/consolidation work depends on, and the
  * sealed result type that callers must be able to exhaustively branch over.
- *
- * The sweeper implementation itself is intentionally deferred to a later phase;
- * this asserts the stable type surface delivered now.
  */
 class DecaySweeperTypesTest {
 

--- a/src/test/kotlin/com/embabel/dice/proposition/PropositionJacksonRoundTripTest.kt
+++ b/src/test/kotlin/com/embabel/dice/proposition/PropositionJacksonRoundTripTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.proposition
+
+import com.embabel.agent.core.ContextId
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+// A real consumer registers modules (incl. JSR-310 for the Instant fields) on its mapper;
+// findAndRegisterModules() picks up jackson-datatype-jsr310 from the classpath.
+
+/**
+ * Verifies that a [Proposition] round-trips cleanly through JSON. The class exposes computed
+ * read-only accessors (`contextIdValue`, `revised`, `lastTouched`) with no matching constructor
+ * parameters, so the mapper must tolerate unknown properties on read — if it doesn't,
+ * deserialization fails. This pins that the canonical knowledge unit survives a default
+ * Kotlin mapper round-trip.
+ */
+class PropositionJacksonRoundTripTest {
+
+    private val mapper = jacksonObjectMapper().findAndRegisterModules()
+
+    @Test
+    fun `a Proposition round-trips through JSON preserving its core fields`() {
+        val original = Proposition(
+            contextId = ContextId("ctx-round-trip"),
+            text = "The substrate stays canonical",
+            mentions = emptyList(),
+            confidence = 0.8,
+            decay = 0.1,
+        ).withMetadataValue("dice.trust.score", 0.9)
+
+        val json = mapper.writeValueAsString(original)
+        val restored = mapper.readValue(json, Proposition::class.java)
+
+        assertEquals(original.id, restored.id)
+        assertEquals(original.contextId, restored.contextId)
+        assertEquals(original.text, restored.text)
+        assertEquals(original.confidence, restored.confidence)
+        assertEquals(original.decay, restored.decay)
+        assertEquals(original.status, restored.status)
+        assertEquals(original.contentRevised, restored.contentRevised)
+        assertEquals(original.metadata["dice.trust.score"], restored.metadata["dice.trust.score"])
+    }
+}

--- a/src/test/kotlin/com/embabel/dice/proposition/PropositionTemporalScoringTest.kt
+++ b/src/test/kotlin/com/embabel/dice/proposition/PropositionTemporalScoringTest.kt
@@ -37,7 +37,7 @@ class PropositionTemporalScoringTest {
 
     @Test
     fun `no temporal block decays from revised`() {
-        val p = prop().copy(revised = t("2026-01-01T00:00:00Z"))
+        val p = prop().copy(contentRevised = t("2026-01-01T00:00:00Z"))
         assertEquals(0.8, p.effectiveConfidenceAt(t("2026-01-01T00:00:00Z")), 1e-9)
         assertTrue(p.effectiveConfidenceAt(t("2026-12-01T00:00:00Z")) < 0.8)
     }
@@ -45,7 +45,7 @@ class PropositionTemporalScoringTest {
     @Test
     fun `source-date-only fact (observedAt, no validFrom) is NOT dated and still decays`() {
         // The embabel/dice#26 case: we know when it was said, not a valid window.
-        val p = prop().copy(revised = t("2026-06-03T00:00:00Z"))
+        val p = prop().copy(contentRevised = t("2026-06-03T00:00:00Z"))
             .withTemporal(TemporalMetadata(observedAt = t("2026-04-20T00:00:00Z")))
         // validFrom is null → decaying, anchored on revised, exactly like no temporal block.
         assertEquals(0.8, p.effectiveConfidenceAt(t("2026-06-03T00:00:00Z")), 1e-9)

--- a/src/test/kotlin/com/embabel/dice/proposition/PropositionTest.kt
+++ b/src/test/kotlin/com/embabel/dice/proposition/PropositionTest.kt
@@ -20,6 +20,9 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.temporal.TemporalMetadata
+import java.time.Duration
 import java.time.Instant
 
 class PropositionTest {
@@ -339,6 +342,210 @@ class PropositionTest {
 
             assertEquals(3, updated.grounding.size)
             assertTrue(updated.grounding.containsAll(listOf("chunk-1", "chunk-2", "chunk-3")))
+        }
+    }
+
+    @Nested
+    inner class LifecycleStateTests {
+
+        private val oldInstant = Instant.now().minus(Duration.ofDays(30))
+
+        private fun agedProp(
+            confidence: Double = 0.9,
+            decay: Double = 0.5,
+            status: PropositionStatus = PropositionStatus.ACTIVE,
+        ) = Proposition(
+            contextId = testContextId,
+            text = "Aged proposition",
+            mentions = emptyList(),
+            confidence = confidence,
+            decay = decay,
+            status = status,
+            contentRevised = oldInstant,
+            metadataRevised = oldInstant,
+        )
+
+        // --- STALE + pinned ---
+
+        @Test
+        fun `STALE status is assignable via withStatus`() {
+            val stale = agedProp().withStatus(PropositionStatus.STALE)
+            assertEquals(PropositionStatus.STALE, stale.status)
+        }
+
+        @Test
+        fun `fresh proposition is not pinned by default`() {
+            val prop = Proposition(contextId = testContextId, text = "T", mentions = emptyList(), confidence = 0.9)
+            assertFalse(prop.pinned)
+        }
+
+        @Test
+        fun `withPinned sets pinned flag`() {
+            val prop = agedProp()
+            assertTrue(prop.withPinned(true).pinned)
+            assertFalse(prop.withPinned(true).withPinned(false).pinned)
+        }
+
+        // --- deprecated revised alias ---
+
+        @Test
+        @Suppress("DEPRECATION")
+        fun `deprecated revised alias equals contentRevised`() {
+            val prop = agedProp()
+            assertEquals(prop.contentRevised, prop.revised)
+        }
+
+        // --- content withers reset contentRevised, preserve metadataRevised ---
+
+        @Test
+        fun `withText resets contentRevised and preserves metadataRevised`() {
+            val prop = agedProp()
+            val updated = prop.withText("new text")
+            assertTrue(updated.contentRevised.isAfter(prop.contentRevised))
+            assertEquals(prop.metadataRevised, updated.metadataRevised)
+        }
+
+        @Test
+        fun `withResolvedMentions resets contentRevised and preserves metadataRevised`() {
+            val prop = agedProp()
+            val updated = prop.withResolvedMentions(emptyList())
+            assertTrue(updated.contentRevised.isAfter(prop.contentRevised))
+            assertEquals(prop.metadataRevised, updated.metadataRevised)
+        }
+
+        @Test
+        fun `withConfidence resets contentRevised and preserves metadataRevised`() {
+            val prop = agedProp()
+            val updated = prop.withConfidence(0.4)
+            assertTrue(updated.contentRevised.isAfter(prop.contentRevised))
+            assertEquals(prop.metadataRevised, updated.metadataRevised)
+        }
+
+        // --- metadata withers advance metadataRevised, preserve contentRevised (decay clock) ---
+
+        @Test
+        fun `withStatus advances metadataRevised and preserves contentRevised`() {
+            val prop = agedProp()
+            val updated = prop.withStatus(PropositionStatus.STALE)
+            assertEquals(prop.contentRevised, updated.contentRevised)
+            assertTrue(updated.metadataRevised.isAfter(prop.metadataRevised))
+        }
+
+        @Test
+        fun `withGrounding advances metadataRevised and preserves contentRevised`() {
+            val prop = agedProp()
+            val updated = prop.withGrounding(listOf("chunk-x"))
+            assertEquals(prop.contentRevised, updated.contentRevised)
+            assertTrue(updated.metadataRevised.isAfter(prop.metadataRevised))
+        }
+
+        // --- explicit withTemporal + withProvenanceEntries decay preservation ---
+
+        @Test
+        fun `withTemporal preserves contentRevised and advances metadataRevised`() {
+            val prop = agedProp()
+            val temporal = TemporalMetadata(observedAt = Instant.now(), validFrom = Instant.now())
+            val updated = prop.withTemporal(temporal)
+            assertEquals(prop.contentRevised, updated.contentRevised)
+            assertTrue(updated.metadataRevised.isAfter(prop.metadataRevised))
+        }
+
+        @Test
+        fun `withProvenanceEntries preserves contentRevised and advances metadataRevised`() {
+            val prop = agedProp()
+            val entry = ProvenanceEntry(
+                locator = com.embabel.dice.provenance.UriLocator("https://example.com/doc"),
+                chunkId = "c1",
+            )
+            val updated = prop.withProvenanceEntries(listOf(entry))
+            assertEquals(prop.contentRevised, updated.contentRevised)
+            assertTrue(updated.metadataRevised.isAfter(prop.metadataRevised))
+        }
+
+        // --- lastTouched tracks any update (metadata touches stay queryable) ---
+
+        @Test
+        fun `lastTouched advances on a metadata-only touch while contentRevised is preserved`() {
+            val prop = agedProp()
+            val touched = prop.withStatus(PropositionStatus.STALE)
+            // Decay anchor unchanged, but the proposition WAS just touched.
+            assertEquals(prop.contentRevised, touched.contentRevised)
+            assertTrue(touched.metadataRevised.isAfter(prop.metadataRevised))
+            assertEquals(touched.metadataRevised, touched.lastTouched)
+            assertTrue(touched.lastTouched.isAfter(prop.lastTouched))
+        }
+
+        @Test
+        fun `lastTouched is the later of contentRevised and metadataRevised`() {
+            val prop = agedProp()
+            assertEquals(maxOf(prop.contentRevised, prop.metadataRevised), prop.lastTouched)
+            // A content touch advances both the decay anchor and lastTouched.
+            val contentTouched = prop.withText("revised text")
+            assertEquals(contentTouched.contentRevised, contentTouched.lastTouched)
+            assertTrue(contentTouched.lastTouched.isAfter(prop.lastTouched))
+        }
+
+        // --- decay anchors on contentRevised, not metadataRevised ---
+
+        @Test
+        fun `effectiveConfidenceAt anchors age on contentRevised`() {
+            val prop = agedProp(confidence = 0.9, decay = 0.5)
+            val before = prop.effectiveConfidenceAt(Instant.now())
+            // A metadata wither (status change) must NOT regain confidence:
+            // contentRevised (decay clock) is preserved.
+            val afterMeta = prop.withStatus(PropositionStatus.STALE).effectiveConfidenceAt(Instant.now())
+            assertEquals(before, afterMeta, 1e-9)
+            // The aged proposition has decayed substantially below its raw confidence.
+            assertTrue(before < 0.9)
+        }
+
+        // --- create() seeds both timestamps from legacy revised ---
+
+        @Test
+        fun `create with only legacy revised seeds both content and metadata timestamps`() {
+            val ts = Instant.now().minus(Duration.ofDays(5))
+            val prop = Proposition.create(
+                id = "p1",
+                contextIdValue = "ctx",
+                text = "T",
+                mentions = emptyList(),
+                confidence = 0.8,
+                decay = 0.1,
+                reasoning = null,
+                grounding = emptyList(),
+                created = ts,
+                revised = ts,
+                status = PropositionStatus.ACTIVE,
+            )
+            assertEquals(ts, prop.contentRevised)
+            assertEquals(ts, prop.metadataRevised)
+            assertFalse(prop.pinned)
+        }
+
+        @Test
+        fun `create honors explicit content and metadata overrides`() {
+            val created = Instant.now().minus(Duration.ofDays(10))
+            val content = Instant.now().minus(Duration.ofDays(3))
+            val metadata = Instant.now().minus(Duration.ofDays(1))
+            val prop = Proposition.create(
+                id = "p2",
+                contextIdValue = "ctx",
+                text = "T",
+                mentions = emptyList(),
+                confidence = 0.8,
+                decay = 0.1,
+                reasoning = null,
+                grounding = emptyList(),
+                created = created,
+                revised = created,
+                status = PropositionStatus.ACTIVE,
+                contentRevised = content,
+                metadataRevised = metadata,
+                pinned = true,
+            )
+            assertEquals(content, prop.contentRevised)
+            assertEquals(metadata, prop.metadataRevised)
+            assertTrue(prop.pinned)
         }
     }
 


### PR DESCRIPTION
Gives a proposition a lifecycle so it can age and be retired. Status gains a STALE value, and a proposition can be pinned to exempt it from decay. The single `revised` timestamp splits into `contentRevised` (the decay anchor) and `metadataRevised` (administrative touches) so editing a proposition's text and re-touching its bookkeeping are no longer the same event; `revised` remains as a deprecated alias for `contentRevised`.

- `StatusTransitionPolicy` decides which status transitions are allowed
- `DecaySweeper` marks propositions stale as their confidence decays, leaving pinned ones alone

Existing revisers that stamped `revised` now stamp `contentRevised`.

## Related issues

This is an incremental, self-contained slice; it advances these issues without fully closing the broader ones.

- Relates to #10 (Content-aware decay and revision) — adds the scheduled-sweep write-back (`DecaySweeper`) and policy-driven decay SPI (`StatusTransitionPolicy` / `DecayStatusPolicy`) the issue proposes.
- Relates to #9 (Proposition pinning and eviction immunity) — pinned propositions are decay-immune (the sweep skips them); full eviction/budget behavior is out of scope here.
- Relates to #8 (Proposition lifecycle events) — exercises status-change transitions over the existing lifecycle event surface.
