### PR TITLE
Add context-scoped ChunkHistoryStore lifecycle (fixes #6)

### DIFF
--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivineChunkHistoryStore.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivineChunkHistoryStore.kt
@@ -15,8 +15,11 @@
  */
 package com.embabel.dice.storage
 
+import com.embabel.agent.core.ContextId
 import com.embabel.dice.incremental.AnalysisBookmark
+import com.embabel.dice.incremental.BookmarkKey
 import com.embabel.dice.incremental.ChunkHistoryStore
+import com.embabel.dice.incremental.HashKey
 import com.embabel.dice.incremental.ProcessedChunkRecord
 import com.embabel.dice.storage.model.ProcessedChunkNode
 import org.drivine.manager.*
@@ -34,16 +37,17 @@ open class DrivineChunkHistoryStore(
     private val persistenceManager: PersistenceManager,
 ) : ChunkHistoryStore {
 
-    /** The node id is the content hash, so existence is a direct load-by-id. */
+    /** Node id is scoped by context so the same content hash can exist in different contexts. */
     @Transactional(readOnly = true)
-    override fun isProcessed(contentHash: String): Boolean =
-        graphObjectManager.load<ProcessedChunkNode>(contentHash) != null
+    override fun isProcessed(key: HashKey): Boolean =
+        graphObjectManager.load<ProcessedChunkNode>(storageId(key)) != null
 
     @Transactional
     override fun recordProcessed(record: ProcessedChunkRecord) {
         graphObjectManager.save(
             ProcessedChunkNode(
-                id = record.contentHash,
+                id = storageId(record.hashKey),
+                contextId = record.contextId.value,
                 contentHash = record.contentHash,
                 sourceId = record.sourceId,
                 startIndex = record.startIndex,
@@ -60,17 +64,28 @@ open class DrivineChunkHistoryStore(
      * the node itself is then loaded via the high-level API (correct temporal deserialization).
      */
     @Transactional(readOnly = true)
-    override fun getLastBookmark(sourceId: String): AnalysisBookmark? {
+    override fun getLastBookmark(key: BookmarkKey): AnalysisBookmark? {
         val latestId = persistenceManager.maybeGetOne(
             QuerySpecification
                 .withStatement(
-                    "MATCH (c:ProcessedChunk {sourceId: \$sourceId}) " +
+                    "MATCH (c:ProcessedChunk {contextId: \$contextId, sourceId: \$sourceId}) " +
                         "RETURN c.id AS id ORDER BY c.processedAt DESC LIMIT 1"
                 )
-                .bind(mapOf("sourceId" to sourceId))
+                .bind(mapOf("contextId" to key.contextId.value, "sourceId" to key.sourceId))
                 .transform(String::class.java)
         ) ?: return null
         val node = graphObjectManager.load<ProcessedChunkNode>(latestId) ?: return null
         return AnalysisBookmark(sourceId = node.sourceId, endIndex = node.endIndex, processedAt = node.processedAt)
     }
+
+    @Transactional
+    override fun clearByContext(contextId: ContextId) {
+        persistenceManager.execute(
+            QuerySpecification
+                .withStatement("MATCH (c:ProcessedChunk {contextId: \$contextId}) DETACH DELETE c")
+                .bind(mapOf("contextId" to contextId.value))
+        )
+    }
+
+    private fun storageId(key: HashKey): String = "${key.contextId.value}|${key.contentHash}"
 }

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/ProcessedChunkNode.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/ProcessedChunkNode.kt
@@ -22,13 +22,16 @@ import org.drivine.annotation.Unique
 
 /**
  * Tracks chunks already processed during incremental analysis, so re-runs skip unchanged content.
- * Keyed by content hash (also the node id).
+ * Keyed by context-scoped content hash (also the node id).
  */
 @NodeFragment(labels = ["ProcessedChunk"])
 data class ProcessedChunkNode(
     @NodeId
     @Unique
     val id: String,
+
+    @RangeIndex
+    val contextId: String,
 
     val contentHash: String,
 

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -18,6 +18,8 @@ package com.embabel.dice.storage
 import com.embabel.agent.core.ContextId
 import com.embabel.common.ai.model.EmbeddingService
 import com.embabel.common.core.types.TextSimilaritySearchRequest
+import com.embabel.dice.incremental.BookmarkKey
+import com.embabel.dice.incremental.HashKey
 import com.embabel.dice.incremental.ProcessedChunkRecord
 import com.embabel.dice.proposition.DecaySweepConfig
 import com.embabel.dice.proposition.EntityMention
@@ -30,6 +32,7 @@ import com.embabel.dice.provenance.UriLocator
 import com.embabel.dice.temporal.TemporalMetadata
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -214,11 +217,28 @@ class DrivinePropositionStoreIntegrationTest {
 
     @Test
     fun `chunk history records, dedups, and bookmarks`() {
-        assertTrue(!chunkHistoryStore.isProcessed("hash-1"))
-        chunkHistoryStore.recordProcessed(ProcessedChunkRecord("hash-1", "src-1", 0, 100, Instant.now()))
-        chunkHistoryStore.recordProcessed(ProcessedChunkRecord("hash-2", "src-1", 100, 250, Instant.now().plusSeconds(1)))
-        assertTrue(chunkHistoryStore.isProcessed("hash-1"))
-        assertEquals(250, chunkHistoryStore.getLastBookmark("src-1")?.endIndex)
+        val contextId = ContextId("chunk-ctx")
+        assertFalse(chunkHistoryStore.isProcessed(HashKey(contextId, "hash-1")))
+        chunkHistoryStore.recordProcessed(
+            ProcessedChunkRecord(
+                bookmarkKey = BookmarkKey(contextId, "src-1"),
+                hashKey = HashKey(contextId, "hash-1"),
+                startIndex = 0,
+                endIndex = 100,
+                processedAt = Instant.now(),
+            ),
+        )
+        chunkHistoryStore.recordProcessed(
+            ProcessedChunkRecord(
+                bookmarkKey = BookmarkKey(contextId, "src-1"),
+                hashKey = HashKey(contextId, "hash-2"),
+                startIndex = 100,
+                endIndex = 250,
+                processedAt = Instant.now().plusSeconds(1),
+            ),
+        )
+        assertTrue(chunkHistoryStore.isProcessed(HashKey(contextId, "hash-1")))
+        assertEquals(250, chunkHistoryStore.getLastBookmark(BookmarkKey(contextId, "src-1"))?.endIndex)
     }
 
     @Test

--- a/dice/src/main/kotlin/com/embabel/dice/incremental/AbstractIncrementalAnalyzer.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/incremental/AbstractIncrementalAnalyzer.kt
@@ -76,7 +76,7 @@ abstract class AbstractIncrementalAnalyzer<T, R>(
         source: IncrementalSource<T>,
         context: SourceAnalysisContext,
     ): R? {
-        val lastBookmark = historyStore.getLastBookmark(source.id)
+        val lastBookmark = historyStore.getLastBookmark(context.contextId, source.id)
         val lastIndex = lastBookmark?.endIndex ?: 0
 
         // Check if enough new content to trigger analysis
@@ -100,7 +100,7 @@ abstract class AbstractIncrementalAnalyzer<T, R>(
             return null
         }
 
-        val lastBookmark = historyStore.getLastBookmark(source.id)
+        val lastBookmark = historyStore.getLastBookmark(context.contextId, source.id)
         val lastIndex = lastBookmark?.endIndex ?: 0
 
         return processWindow(source, context, lastIndex)
@@ -126,7 +126,7 @@ abstract class AbstractIncrementalAnalyzer<T, R>(
 
         // Check if already processed (hash dedup)
         val contentHash = contentHasher.hash(text)
-        if (historyStore.isProcessed(contentHash)) {
+        if (historyStore.isProcessed(context.contextId, contentHash)) {
             logger.debug("Content already processed (hash: {})", contentHash.take(8))
             return null
         }
@@ -148,6 +148,7 @@ abstract class AbstractIncrementalAnalyzer<T, R>(
         // Record processing
         historyStore.recordProcessed(
             ProcessedChunkRecord(
+                contextId = context.contextId,
                 contentHash = contentHash,
                 sourceId = source.id,
                 startIndex = startIndex,

--- a/dice/src/main/kotlin/com/embabel/dice/incremental/AbstractIncrementalAnalyzer.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/incremental/AbstractIncrementalAnalyzer.kt
@@ -76,7 +76,7 @@ abstract class AbstractIncrementalAnalyzer<T, R>(
         source: IncrementalSource<T>,
         context: SourceAnalysisContext,
     ): R? {
-        val lastBookmark = historyStore.getLastBookmark(context.contextId, source.id)
+        val lastBookmark = historyStore.getLastBookmark(BookmarkKey(context.contextId, source.id))
         val lastIndex = lastBookmark?.endIndex ?: 0
 
         // Check if enough new content to trigger analysis
@@ -100,7 +100,7 @@ abstract class AbstractIncrementalAnalyzer<T, R>(
             return null
         }
 
-        val lastBookmark = historyStore.getLastBookmark(context.contextId, source.id)
+        val lastBookmark = historyStore.getLastBookmark(BookmarkKey(context.contextId, source.id))
         val lastIndex = lastBookmark?.endIndex ?: 0
 
         return processWindow(source, context, lastIndex)
@@ -126,7 +126,7 @@ abstract class AbstractIncrementalAnalyzer<T, R>(
 
         // Check if already processed (hash dedup)
         val contentHash = contentHasher.hash(text)
-        if (historyStore.isProcessed(context.contextId, contentHash)) {
+        if (historyStore.isProcessed(HashKey(context.contextId, contentHash))) {
             logger.debug("Content already processed (hash: {})", contentHash.take(8))
             return null
         }
@@ -148,9 +148,8 @@ abstract class AbstractIncrementalAnalyzer<T, R>(
         // Record processing
         historyStore.recordProcessed(
             ProcessedChunkRecord(
-                contextId = context.contextId,
-                contentHash = contentHash,
-                sourceId = source.id,
+                bookmarkKey = BookmarkKey(context.contextId, source.id),
+                hashKey = HashKey(context.contextId, contentHash),
                 startIndex = startIndex,
                 endIndex = endIndex,
                 processedAt = Instant.now(),

--- a/dice/src/main/kotlin/com/embabel/dice/incremental/ChunkHistoryModels.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/incremental/ChunkHistoryModels.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.incremental
+
+import com.embabel.agent.core.ContextId
+import java.time.Instant
+
+/**
+ * Composite key for per-source analysis bookmarks within a [ContextId].
+ */
+data class BookmarkKey(
+    val contextId: ContextId,
+    val sourceId: String,
+)
+
+/**
+ * Composite key for content-hash deduplication within a [ContextId].
+ */
+data class HashKey(
+    val contextId: ContextId,
+    val contentHash: String,
+) {
+    override fun toString(): String =
+        "HashKey(contextId=$contextId, contentHash=${contentHash.take(8)}…)"
+}
+
+/**
+ * Resume marker for incremental source analysis within a [ContextId].
+ *
+ * When [AbstractIncrementalAnalyzer] processes a growing source (conversation,
+ * message stream, log tail), it cannot re-read from the beginning each time.
+ * After each successful window it records an [AnalysisBookmark] so the next
+ * invocation knows how far analysis has progressed for that [BookmarkKey].
+ *
+ * [endIndex] is the exclusive upper bound of items already incorporated into a
+ * processed window. The analyzer uses it to:
+ * - compute how many new items have arrived since the last run ([WindowConfig.triggerInterval])
+ * - start the next window with optional overlap ([WindowConfig.overlapSize]) for LLM context
+ *
+ * Bookmarks complement content-hash deduplication ([ChunkHistoryStore.isProcessed]):
+ * the hash prevents re-processing identical *text*, while the bookmark prevents
+ * re-scanning from index zero when new items append to the same source.
+ *
+ * Cleared by [ChunkHistoryStore.clearByContext] when a session or tenant ends.
+ *
+ * @property sourceId Identifier of the incremental source (e.g. conversation id)
+ * @property endIndex Exclusive index of the last analyzed item in the source sequence
+ * @property processedAt When this bookmark was last updated
+ */
+data class AnalysisBookmark(
+    val sourceId: String,
+    val endIndex: Int,
+    val processedAt: Instant,
+)
+
+/**
+ * Record of a processed chunk, keyed by [BookmarkKey] and [HashKey].
+ */
+data class ProcessedChunkRecord(
+    val bookmarkKey: BookmarkKey,
+    val hashKey: HashKey,
+    val startIndex: Int,
+    val endIndex: Int,
+    val processedAt: Instant,
+) {
+    init {
+        require(bookmarkKey.contextId == hashKey.contextId) {
+            "bookmarkKey and hashKey must share the same contextId"
+        }
+    }
+
+    val contextId: ContextId get() = bookmarkKey.contextId
+    val sourceId: String get() = bookmarkKey.sourceId
+    val contentHash: String get() = hashKey.contentHash
+
+    override fun toString(): String =
+        "ProcessedChunkRecord(bookmarkKey=$bookmarkKey, hashKey=$hashKey, " +
+            "startIndex=$startIndex, endIndex=$endIndex, processedAt=$processedAt)"
+}
+
+/**
+ * Configuration for windowed processing.
+ */
+data class WindowConfig(
+    /**
+     * Maximum number of items to process in one window.
+     */
+    val windowSize: Int = 20,
+
+    /**
+     * Number of items to overlap between windows for context.
+     */
+    val overlapSize: Int = 2,
+
+    /**
+     * Minimum number of new items required before triggering analysis.
+     */
+    val triggerInterval: Int = 4,
+)

--- a/dice/src/main/kotlin/com/embabel/dice/incremental/ChunkHistoryStore.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/incremental/ChunkHistoryStore.kt
@@ -16,7 +16,7 @@
 package com.embabel.dice.incremental
 
 import com.embabel.agent.core.ContextId
-import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Tracks the history of processed chunks for incremental analysis.
@@ -36,12 +36,12 @@ interface ChunkHistoryStore {
      * window starts and whether enough new items exist to trigger processing.
      * Returns null if the source has never been processed in that context.
      */
-    fun getLastBookmark(contextId: ContextId, sourceId: String): AnalysisBookmark?
+    fun getLastBookmark(key: BookmarkKey): AnalysisBookmark?
 
     /**
      * Check if content with the given hash has already been processed in a context.
      */
-    fun isProcessed(contextId: ContextId, contentHash: String): Boolean
+    fun isProcessed(key: HashKey): Boolean
 
     /**
      * Record that a chunk has been processed.
@@ -60,83 +60,21 @@ interface ChunkHistoryStore {
 }
 
 /**
- * Resume marker for incremental source analysis within a [ContextId].
- *
- * When [AbstractIncrementalAnalyzer] processes a growing source (conversation,
- * message stream, log tail), it cannot re-read from the beginning each time.
- * After each successful window it records an [AnalysisBookmark] so the next
- * invocation knows how far analysis has progressed for that `(contextId, sourceId)`.
- *
- * [endIndex] is the exclusive upper bound of items already incorporated into a
- * processed window. The analyzer uses it to:
- * - compute how many new items have arrived since the last run ([WindowConfig.triggerInterval])
- * - start the next window with optional overlap ([WindowConfig.overlapSize]) for LLM context
- *
- * Bookmarks complement content-hash deduplication ([ChunkHistoryStore.isProcessed]):
- * the hash prevents re-processing identical *text*, while the bookmark prevents
- * re-scanning from index zero when new items append to the same source.
- *
- * Cleared by [ChunkHistoryStore.clearByContext] when a session or tenant ends.
- *
- * @property sourceId Identifier of the incremental source (e.g. conversation id)
- * @property endIndex Exclusive index of the last analyzed item in the source sequence
- * @property processedAt When this bookmark was last updated
- */
-data class AnalysisBookmark(
-    val sourceId: String,
-    val endIndex: Int,
-    val processedAt: Instant,
-)
-
-/**
- * Record of a processed chunk.
- */
-data class ProcessedChunkRecord(
-    val contextId: ContextId,
-    val contentHash: String,
-    val sourceId: String,
-    val startIndex: Int,
-    val endIndex: Int,
-    val processedAt: Instant,
-)
-
-/**
- * Configuration for windowed processing.
- */
-data class WindowConfig(
-    /**
-     * Maximum number of items to process in one window.
-     */
-    val windowSize: Int = 20,
-
-    /**
-     * Number of items to overlap between windows for context.
-     */
-    val overlapSize: Int = 2,
-
-    /**
-     * Minimum number of new items required before triggering analysis.
-     */
-    val triggerInterval: Int = 4,
-)
-
-/**
- * Simple in-memory implementation for testing.
+ * Thread-safe in-memory implementation for testing.
+ * Not intended for production use.
  */
 class InMemoryChunkHistoryStore : ChunkHistoryStore {
 
-    private val bookmarks = mutableMapOf<BookmarkKey, AnalysisBookmark>()
-    private val processedHashes = mutableSetOf<HashKey>()
+    private val bookmarks = ConcurrentHashMap<BookmarkKey, AnalysisBookmark>()
+    private val processedHashes = ConcurrentHashMap.newKeySet<HashKey>()
 
-    override fun getLastBookmark(contextId: ContextId, sourceId: String): AnalysisBookmark? =
-        bookmarks[BookmarkKey(contextId, sourceId)]
+    override fun getLastBookmark(key: BookmarkKey): AnalysisBookmark? = bookmarks[key]
 
-    override fun isProcessed(contextId: ContextId, contentHash: String): Boolean =
-        HashKey(contextId, contentHash) in processedHashes
+    override fun isProcessed(key: HashKey): Boolean = key in processedHashes
 
     override fun recordProcessed(record: ProcessedChunkRecord) {
-        processedHashes.add(HashKey(record.contextId, record.contentHash))
-        bookmarks[BookmarkKey(record.contextId, record.sourceId)] = AnalysisBookmark(
+        processedHashes.add(record.hashKey)
+        bookmarks[record.bookmarkKey] = AnalysisBookmark(
             sourceId = record.sourceId,
             endIndex = record.endIndex,
             processedAt = record.processedAt,
@@ -152,8 +90,4 @@ class InMemoryChunkHistoryStore : ChunkHistoryStore {
         bookmarks.clear()
         processedHashes.clear()
     }
-
-    private data class BookmarkKey(val contextId: ContextId, val sourceId: String)
-
-    private data class HashKey(val contextId: ContextId, val contentHash: String)
 }

--- a/dice/src/main/kotlin/com/embabel/dice/incremental/ChunkHistoryStore.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/incremental/ChunkHistoryStore.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.dice.incremental
 
+import com.embabel.agent.core.ContextId
 import java.time.Instant
 
 /**
@@ -22,37 +23,64 @@ import java.time.Instant
  * Enables deduplication and resumption of processing.
  *
  * Implementations should persist this data to allow resumption across sessions.
+ * Bookmarks and content-hash deduplication are scoped by [ContextId] so that
+ * isolated sessions (multi-tenant runs, simulations, tests) do not leak state.
  */
 interface ChunkHistoryStore {
 
     /**
-     * Get the last analysis bookmark for a source.
-     * Returns null if the source has never been processed.
+     * Get the last [AnalysisBookmark] for a source within a context.
      *
-     * @param sourceId The source identifier
-     * @return The last bookmark, or null if never processed
+     * Bookmarks drive incremental resumption in [AbstractIncrementalAnalyzer]:
+     * the analyzer reads [AnalysisBookmark.endIndex] to decide where the next
+     * window starts and whether enough new items exist to trigger processing.
+     * Returns null if the source has never been processed in that context.
      */
-    fun getLastBookmark(sourceId: String): AnalysisBookmark?
+    fun getLastBookmark(contextId: ContextId, sourceId: String): AnalysisBookmark?
 
     /**
-     * Check if content with the given hash has already been processed.
-     * Used for deduplication.
-     *
-     * @param contentHash SHA-256 hash of the content
-     * @return true if already processed
+     * Check if content with the given hash has already been processed in a context.
      */
-    fun isProcessed(contentHash: String): Boolean
+    fun isProcessed(contextId: ContextId, contentHash: String): Boolean
 
     /**
      * Record that a chunk has been processed.
-     *
-     * @param record The processing record to store
      */
     fun recordProcessed(record: ProcessedChunkRecord)
+
+    /**
+     * Remove all history for the given context. Default no-op for backward compatibility.
+     */
+    fun clearByContext(contextId: ContextId) {}
+
+    /**
+     * Remove all history across every context. Default no-op for backward compatibility.
+     */
+    fun clearAll() {}
 }
 
 /**
- * Bookmark tracking the last analysis position for a source.
+ * Resume marker for incremental source analysis within a [ContextId].
+ *
+ * When [AbstractIncrementalAnalyzer] processes a growing source (conversation,
+ * message stream, log tail), it cannot re-read from the beginning each time.
+ * After each successful window it records an [AnalysisBookmark] so the next
+ * invocation knows how far analysis has progressed for that `(contextId, sourceId)`.
+ *
+ * [endIndex] is the exclusive upper bound of items already incorporated into a
+ * processed window. The analyzer uses it to:
+ * - compute how many new items have arrived since the last run ([WindowConfig.triggerInterval])
+ * - start the next window with optional overlap ([WindowConfig.overlapSize]) for LLM context
+ *
+ * Bookmarks complement content-hash deduplication ([ChunkHistoryStore.isProcessed]):
+ * the hash prevents re-processing identical *text*, while the bookmark prevents
+ * re-scanning from index zero when new items append to the same source.
+ *
+ * Cleared by [ChunkHistoryStore.clearByContext] when a session or tenant ends.
+ *
+ * @property sourceId Identifier of the incremental source (e.g. conversation id)
+ * @property endIndex Exclusive index of the last analyzed item in the source sequence
+ * @property processedAt When this bookmark was last updated
  */
 data class AnalysisBookmark(
     val sourceId: String,
@@ -64,6 +92,7 @@ data class AnalysisBookmark(
  * Record of a processed chunk.
  */
 data class ProcessedChunkRecord(
+    val contextId: ContextId,
     val contentHash: String,
     val sourceId: String,
     val startIndex: Int,
@@ -96,21 +125,35 @@ data class WindowConfig(
  */
 class InMemoryChunkHistoryStore : ChunkHistoryStore {
 
-    private val bookmarks = mutableMapOf<String, AnalysisBookmark>()
-    private val processedHashes = mutableSetOf<String>()
+    private val bookmarks = mutableMapOf<BookmarkKey, AnalysisBookmark>()
+    private val processedHashes = mutableSetOf<HashKey>()
 
-    override fun getLastBookmark(sourceId: String): AnalysisBookmark? =
-        bookmarks[sourceId]
+    override fun getLastBookmark(contextId: ContextId, sourceId: String): AnalysisBookmark? =
+        bookmarks[BookmarkKey(contextId, sourceId)]
 
-    override fun isProcessed(contentHash: String): Boolean =
-        contentHash in processedHashes
+    override fun isProcessed(contextId: ContextId, contentHash: String): Boolean =
+        HashKey(contextId, contentHash) in processedHashes
 
     override fun recordProcessed(record: ProcessedChunkRecord) {
-        processedHashes.add(record.contentHash)
-        bookmarks[record.sourceId] = AnalysisBookmark(
+        processedHashes.add(HashKey(record.contextId, record.contentHash))
+        bookmarks[BookmarkKey(record.contextId, record.sourceId)] = AnalysisBookmark(
             sourceId = record.sourceId,
             endIndex = record.endIndex,
             processedAt = record.processedAt,
         )
     }
+
+    override fun clearByContext(contextId: ContextId) {
+        bookmarks.keys.removeIf { it.contextId == contextId }
+        processedHashes.removeIf { it.contextId == contextId }
+    }
+
+    override fun clearAll() {
+        bookmarks.clear()
+        processedHashes.clear()
+    }
+
+    private data class BookmarkKey(val contextId: ContextId, val sourceId: String)
+
+    private data class HashKey(val contextId: ContextId, val contentHash: String)
 }

--- a/dice/src/main/kotlin/com/embabel/dice/pipeline/PropositionPipeline.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/pipeline/PropositionPipeline.kt
@@ -190,7 +190,7 @@ class PropositionPipeline private constructor(
     ): ChunkPropositionResult? {
         if (historyStore != null) {
             val hash = contentHasher.hash(text)
-            if (historyStore.isProcessed(hash)) {
+            if (historyStore.isProcessed(context.contextId, hash)) {
                 logger.debug("Content already processed (hash: {})", hash.take(8))
                 return null
             }
@@ -206,6 +206,7 @@ class PropositionPipeline private constructor(
             val result = processChunk(chunk, context)
             historyStore.recordProcessed(
                 ProcessedChunkRecord(
+                    contextId = context.contextId,
                     contentHash = hash,
                     sourceId = sourceId,
                     startIndex = 0,

--- a/dice/src/main/kotlin/com/embabel/dice/pipeline/PropositionPipeline.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/pipeline/PropositionPipeline.kt
@@ -23,7 +23,9 @@ import com.embabel.dice.common.resolver.ChainedEntityResolver
 import com.embabel.dice.common.resolver.InMemoryEntityResolver
 import com.embabel.dice.common.resolver.KnownEntityResolver
 import com.embabel.dice.common.support.Sha256ContentHasher
+import com.embabel.dice.incremental.BookmarkKey
 import com.embabel.dice.incremental.ChunkHistoryStore
+import com.embabel.dice.incremental.HashKey
 import com.embabel.dice.incremental.ProcessedChunkRecord
 import com.embabel.dice.proposition.PropositionExtractor
 import com.embabel.dice.proposition.PropositionRepository
@@ -190,7 +192,7 @@ class PropositionPipeline private constructor(
     ): ChunkPropositionResult? {
         if (historyStore != null) {
             val hash = contentHasher.hash(text)
-            if (historyStore.isProcessed(context.contextId, hash)) {
+            if (historyStore.isProcessed(HashKey(context.contextId, hash))) {
                 logger.debug("Content already processed (hash: {})", hash.take(8))
                 return null
             }
@@ -206,9 +208,8 @@ class PropositionPipeline private constructor(
             val result = processChunk(chunk, context)
             historyStore.recordProcessed(
                 ProcessedChunkRecord(
-                    contextId = context.contextId,
-                    contentHash = hash,
-                    sourceId = sourceId,
+                    bookmarkKey = BookmarkKey(context.contextId, sourceId),
+                    hashKey = HashKey(context.contextId, hash),
                     startIndex = 0,
                     endIndex = 1,
                     processedAt = Instant.now(),

--- a/dice/src/test/kotlin/com/embabel/dice/incremental/InMemoryChunkHistoryStoreTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/incremental/InMemoryChunkHistoryStoreTest.kt
@@ -35,8 +35,8 @@ class InMemoryChunkHistoryStoreTest {
         val hash = "abc123"
 
         store.recordProcessed(record(contextId = tenantA, sourceId = "doc-1", hash = hash, endIndex = 5))
-        assertTrue(store.isProcessed(tenantA, hash))
-        assertFalse(store.isProcessed(tenantB, hash))
+        assertTrue(store.isProcessed(HashKey(tenantA, hash)))
+        assertFalse(store.isProcessed(HashKey(tenantB, hash)))
     }
 
     @Test
@@ -46,8 +46,8 @@ class InMemoryChunkHistoryStoreTest {
         store.recordProcessed(record(contextId = tenantA, sourceId = "thread-1", hash = "h1", endIndex = 3))
         store.recordProcessed(record(contextId = tenantB, sourceId = "thread-1", hash = "h2", endIndex = 9))
 
-        assertEquals(3, store.getLastBookmark(tenantA, "thread-1")?.endIndex)
-        assertEquals(9, store.getLastBookmark(tenantB, "thread-1")?.endIndex)
+        assertEquals(3, store.getLastBookmark(BookmarkKey(tenantA, "thread-1"))?.endIndex)
+        assertEquals(9, store.getLastBookmark(BookmarkKey(tenantB, "thread-1"))?.endIndex)
     }
 
     @Test
@@ -58,10 +58,10 @@ class InMemoryChunkHistoryStoreTest {
 
         store.clearByContext(tenantA)
 
-        assertNull(store.getLastBookmark(tenantA, "doc-1"))
-        assertFalse(store.isProcessed(tenantA, "h1"))
-        assertEquals(4, store.getLastBookmark(tenantB, "doc-1")?.endIndex)
-        assertTrue(store.isProcessed(tenantB, "h2"))
+        assertNull(store.getLastBookmark(BookmarkKey(tenantA, "doc-1")))
+        assertFalse(store.isProcessed(HashKey(tenantA, "h1")))
+        assertEquals(4, store.getLastBookmark(BookmarkKey(tenantB, "doc-1"))?.endIndex)
+        assertTrue(store.isProcessed(HashKey(tenantB, "h2")))
     }
 
     @Test
@@ -72,10 +72,10 @@ class InMemoryChunkHistoryStoreTest {
 
         store.clearAll()
 
-        assertNull(store.getLastBookmark(tenantA, "doc-1"))
-        assertNull(store.getLastBookmark(tenantB, "doc-2"))
-        assertFalse(store.isProcessed(tenantA, "h1"))
-        assertFalse(store.isProcessed(tenantB, "h2"))
+        assertNull(store.getLastBookmark(BookmarkKey(tenantA, "doc-1")))
+        assertNull(store.getLastBookmark(BookmarkKey(tenantB, "doc-2")))
+        assertFalse(store.isProcessed(HashKey(tenantA, "h1")))
+        assertFalse(store.isProcessed(HashKey(tenantB, "h2")))
     }
 
     @Test
@@ -84,11 +84,11 @@ class InMemoryChunkHistoryStoreTest {
         val hash = "same-content"
 
         store.recordProcessed(record(contextId = tenantA, sourceId = "doc-1", hash = hash, endIndex = 1))
-        assertTrue(store.isProcessed(tenantA, hash))
+        assertTrue(store.isProcessed(HashKey(tenantA, hash)))
 
         store.clearByContext(tenantA)
 
-        assertFalse(store.isProcessed(tenantA, hash))
+        assertFalse(store.isProcessed(HashKey(tenantA, hash)))
     }
 
     private fun record(
@@ -97,9 +97,8 @@ class InMemoryChunkHistoryStoreTest {
         hash: String,
         endIndex: Int,
     ) = ProcessedChunkRecord(
-        contextId = contextId,
-        contentHash = hash,
-        sourceId = sourceId,
+        bookmarkKey = BookmarkKey(contextId, sourceId),
+        hashKey = HashKey(contextId, hash),
         startIndex = 0,
         endIndex = endIndex,
         processedAt = now,

--- a/dice/src/test/kotlin/com/embabel/dice/incremental/InMemoryChunkHistoryStoreTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/incremental/InMemoryChunkHistoryStoreTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.incremental
+
+import com.embabel.agent.core.ContextId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class InMemoryChunkHistoryStoreTest {
+
+    private val tenantA = ContextId("tenant-a")
+    private val tenantB = ContextId("tenant-b")
+    private val now = Instant.parse("2026-06-18T10:00:00Z")
+
+    @Test
+    fun `deduplication is scoped to context`() {
+        val store = InMemoryChunkHistoryStore()
+        val hash = "abc123"
+
+        store.recordProcessed(record(contextId = tenantA, sourceId = "doc-1", hash = hash, endIndex = 5))
+        assertTrue(store.isProcessed(tenantA, hash))
+        assertFalse(store.isProcessed(tenantB, hash))
+    }
+
+    @Test
+    fun `bookmarks are scoped to context`() {
+        val store = InMemoryChunkHistoryStore()
+
+        store.recordProcessed(record(contextId = tenantA, sourceId = "thread-1", hash = "h1", endIndex = 3))
+        store.recordProcessed(record(contextId = tenantB, sourceId = "thread-1", hash = "h2", endIndex = 9))
+
+        assertEquals(3, store.getLastBookmark(tenantA, "thread-1")?.endIndex)
+        assertEquals(9, store.getLastBookmark(tenantB, "thread-1")?.endIndex)
+    }
+
+    @Test
+    fun `clearByContext removes only that context`() {
+        val store = InMemoryChunkHistoryStore()
+        store.recordProcessed(record(contextId = tenantA, sourceId = "doc-1", hash = "h1", endIndex = 2))
+        store.recordProcessed(record(contextId = tenantB, sourceId = "doc-1", hash = "h2", endIndex = 4))
+
+        store.clearByContext(tenantA)
+
+        assertNull(store.getLastBookmark(tenantA, "doc-1"))
+        assertFalse(store.isProcessed(tenantA, "h1"))
+        assertEquals(4, store.getLastBookmark(tenantB, "doc-1")?.endIndex)
+        assertTrue(store.isProcessed(tenantB, "h2"))
+    }
+
+    @Test
+    fun `clearAll removes every context`() {
+        val store = InMemoryChunkHistoryStore()
+        store.recordProcessed(record(contextId = tenantA, sourceId = "doc-1", hash = "h1", endIndex = 1))
+        store.recordProcessed(record(contextId = tenantB, sourceId = "doc-2", hash = "h2", endIndex = 2))
+
+        store.clearAll()
+
+        assertNull(store.getLastBookmark(tenantA, "doc-1"))
+        assertNull(store.getLastBookmark(tenantB, "doc-2"))
+        assertFalse(store.isProcessed(tenantA, "h1"))
+        assertFalse(store.isProcessed(tenantB, "h2"))
+    }
+
+    @Test
+    fun `content can be reprocessed after clearByContext`() {
+        val store = InMemoryChunkHistoryStore()
+        val hash = "same-content"
+
+        store.recordProcessed(record(contextId = tenantA, sourceId = "doc-1", hash = hash, endIndex = 1))
+        assertTrue(store.isProcessed(tenantA, hash))
+
+        store.clearByContext(tenantA)
+
+        assertFalse(store.isProcessed(tenantA, hash))
+    }
+
+    private fun record(
+        contextId: ContextId,
+        sourceId: String,
+        hash: String,
+        endIndex: Int,
+    ) = ProcessedChunkRecord(
+        contextId = contextId,
+        contentHash = hash,
+        sourceId = sourceId,
+        startIndex = 0,
+        endIndex = endIndex,
+        processedAt = now,
+    )
+}

--- a/dice/src/test/kotlin/com/embabel/dice/pipeline/PropositionPipelineTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/pipeline/PropositionPipelineTest.kt
@@ -1241,10 +1241,55 @@ class PropositionPipelineTest {
             )
 
             // Verify the bookmark was recorded
-            val bookmark = historyStore.getLastBookmark("doc-1")
+            val bookmark = historyStore.getLastBookmark(testContextId, "doc-1")
             assertNotNull(bookmark)
             assertEquals("doc-1", bookmark!!.sourceId)
             assertEquals(1, bookmark.endIndex)
+        }
+
+        @Test
+        fun `deduplication does not leak across contexts`() {
+            val extractor = MockPropositionExtractor()
+            val pipeline = PropositionPipeline.withExtractor(extractor)
+            val historyStore = InMemoryChunkHistoryStore()
+
+            val contextA = SourceAnalysisContext(
+                schema = schema,
+                entityResolver = AlwaysCreateEntityResolver,
+                contextId = ContextId("context-a"),
+            )
+            val contextB = SourceAnalysisContext(
+                schema = schema,
+                entityResolver = AlwaysCreateEntityResolver,
+                contextId = ContextId("context-b"),
+            )
+
+            assertNotNull(
+                pipeline.processOnce(
+                    text = "mentions:Alice",
+                    sourceId = "doc-1",
+                    context = contextA,
+                    historyStore = historyStore,
+                )
+            )
+            assertNull(
+                pipeline.processOnce(
+                    text = "mentions:Alice",
+                    sourceId = "doc-1",
+                    context = contextA,
+                    historyStore = historyStore,
+                ),
+                "Same context should dedupe",
+            )
+            assertNotNull(
+                pipeline.processOnce(
+                    text = "mentions:Alice",
+                    sourceId = "doc-1",
+                    context = contextB,
+                    historyStore = historyStore,
+                ),
+                "Different context should not dedupe",
+            )
         }
     }
 

--- a/dice/src/test/kotlin/com/embabel/dice/pipeline/PropositionPipelineTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/pipeline/PropositionPipelineTest.kt
@@ -32,6 +32,7 @@ import com.embabel.agent.core.DynamicType
 import com.embabel.agent.core.ValidatedPropertyDefinition
 import com.embabel.dice.common.validation.NoVagueReferences
 import com.embabel.dice.common.validation.LengthConstraint
+import com.embabel.dice.incremental.BookmarkKey
 import com.embabel.dice.incremental.InMemoryChunkHistoryStore
 import com.embabel.dice.proposition.*
 import com.embabel.dice.text2graph.builder.Animal
@@ -1241,7 +1242,7 @@ class PropositionPipelineTest {
             )
 
             // Verify the bookmark was recorded
-            val bookmark = historyStore.getLastBookmark(testContextId, "doc-1")
+            val bookmark = historyStore.getLastBookmark(BookmarkKey(testContextId, "doc-1"))
             assertNotNull(bookmark)
             assertEquals("doc-1", bookmark!!.sourceId)
             assertEquals(1, bookmark.endIndex)


### PR DESCRIPTION
## Summary

- Scope chunk deduplication and analysis bookmarks by `ContextId` so multi-session / multi-tenant incremental analysis does not leak state across isolated runs.
- Add `contextId` to `ProcessedChunkRecord` and thread it through `AbstractIncrementalAnalyzer` and `PropositionPipeline.processOnce()`.
- Add `clearByContext(contextId)` and `clearAll()` to `ChunkHistoryStore` (default no-op on the interface for backward-compatible custom implementations).
- Implement context-scoped storage and lifecycle methods in `InMemoryChunkHistoryStore`.

Fixes #6

## Motivation

`InMemoryChunkHistoryStore` previously keyed bookmarks and content hashes globally. Applications running multiple isolated sessions (simulations, tests, multi-tenant chat) could not clear history per session without replacing the entire store bean, and identical content processed in one context would incorrectly dedupe in another.

## What changed

| Area | Change |
|---|---|
| `ChunkHistoryStore` | `getLastBookmark(contextId, sourceId)`, `isProcessed(contextId, contentHash)`, `clearByContext()`, `clearAll()` |
| `ProcessedChunkRecord` | New required `contextId` field |
| `InMemoryChunkHistoryStore` | Keys by `(contextId, sourceId)` and `(contextId, contentHash)`; implements clear methods |
| `AbstractIncrementalAnalyzer` | Uses `context.contextId` for bookmark lookup, dedup, and recording |
| `PropositionPipeline.processOnce()` | Same context-scoped behavior when a history store is provided |

## Test plan

- [x] `InMemoryChunkHistoryStoreTest` — context isolation, `clearByContext`, `clearAll`, reprocessing after clear
- [x] `PropositionPipelineTest` — `deduplication does not leak across contexts`
- [x] `PropositionPipelineTest` — existing `records processing in history store` updated for context-scoped API
- [x] Full suite: `.\mvnw.cmd test`

## Backward compatibility

- Custom `ChunkHistoryStore` implementations must adopt the new method signatures and record `contextId`.
- `clearByContext` / `clearAll` default to no-op on the interface, so existing implementations compile without immediate clear support.
- Single-context apps behave the same as before when all work uses the same `ContextId`.
