### PR TITLE
Wire provenanceEntries through extraction and revision

### DIFF
--- a/dice/src/main/kotlin/com/embabel/dice/common/SourceAnalysisContext.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/SourceAnalysisContext.kt
@@ -17,6 +17,7 @@ package com.embabel.dice.common
 
 import com.embabel.agent.core.ContextId
 import com.embabel.agent.core.DataDictionary
+import com.embabel.dice.provenance.SourceLocator
 
 /**
  * Base context for analyzing sources.
@@ -27,6 +28,9 @@ import com.embabel.agent.core.DataDictionary
  * @param relations optional collection of additional relation types beyond those defined in the schema
  * @param promptVariables optional additional model data for analysis. Must be passed to any templated
  * LLM prompts used.
+ * @param defaultSourceLocator optional locator for the material being analyzed in this run.
+ *   Used by [com.embabel.dice.provenance.ChunkProvenanceFactory] when chunk metadata does not
+ *   specify a more specific source.
  */
 data class SourceAnalysisContext @JvmOverloads constructor(
     val schema: DataDictionary,
@@ -35,6 +39,7 @@ data class SourceAnalysisContext @JvmOverloads constructor(
     val knownEntities: List<KnownEntity> = emptyList(),
     val relations: Relations = Relations.empty(),
     val promptVariables: Map<String, Any> = emptyMap(),
+    val defaultSourceLocator: SourceLocator? = null,
 ) {
 
     companion object {
@@ -88,6 +93,12 @@ data class SourceAnalysisContext @JvmOverloads constructor(
      */
     fun withPromptVariables(promptVariables: Map<String, Any>): SourceAnalysisContext =
         copy(promptVariables = promptVariables)
+
+    /**
+     * Returns a copy with the default [SourceLocator] for provenance on extracted propositions.
+     */
+    fun withDefaultSourceLocator(locator: SourceLocator?): SourceAnalysisContext =
+        copy(defaultSourceLocator = locator)
 
     /**
      * Builder step: has context ID, needs entity resolver.

--- a/dice/src/main/kotlin/com/embabel/dice/pipeline/PropositionPipeline.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/pipeline/PropositionPipeline.kt
@@ -27,6 +27,7 @@ import com.embabel.dice.incremental.BookmarkKey
 import com.embabel.dice.incremental.ChunkHistoryStore
 import com.embabel.dice.incremental.HashKey
 import com.embabel.dice.incremental.ProcessedChunkRecord
+import com.embabel.dice.provenance.ChunkProvenanceFactory
 import com.embabel.dice.proposition.PropositionExtractor
 import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.revision.PropositionReviser
@@ -116,9 +117,11 @@ class PropositionPipeline private constructor(
      * @param context Configuration including schema and entity resolver
      * @return Processing result with propositions, entities, and optional revision results
      */
+    @JvmOverloads
     fun processChunk(
         chunk: Chunk,
         context: SourceAnalysisContext,
+        contentHash: String? = null,
     ): ChunkPropositionResult {
         logger.debug("Processing chunk: {}", chunk.id)
 
@@ -142,7 +145,17 @@ class PropositionPipeline private constructor(
         logger.debug("Resolved {} entities", resolutions.resolutions.size)
 
         // Step 4: Apply resolutions to create final propositions
-        val propositions = extractor.resolvePropositions(suggestedPropositions, resolutions, context)
+        val provenanceEntry = ChunkProvenanceFactory.entryFor(
+            chunk = chunk,
+            context = context,
+            contentHash = contentHash ?: Sha256ContentHasher.hash(chunk.text),
+        )
+        val propositions = extractor.resolvePropositions(
+            suggestedPropositions,
+            resolutions,
+            context,
+            provenanceEntries = listOf(provenanceEntry),
+        )
         logger.debug("Created {} propositions", propositions.size)
 
         // Step 5: Optionally revise propositions against existing ones
@@ -205,7 +218,11 @@ class PropositionPipeline private constructor(
             // Backward-compatible: callers that pass UUID-shaped
             // sourceIds get UUID chunk ids exactly as before.
             val chunk = Chunk.create(text = text, parentId = sourceId, id = sourceId)
-            val result = processChunk(chunk, context)
+            val result = processChunk(
+                chunk = chunk,
+                context = context,
+                contentHash = hash,
+            )
             historyStore.recordProcessed(
                 ProcessedChunkRecord(
                     bookmarkKey = BookmarkKey(context.contextId, sourceId),

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionExtractor.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionExtractor.kt
@@ -21,6 +21,7 @@ import com.embabel.dice.common.SourceAnalysisContext
 import com.embabel.dice.common.SuggestedEntities
 import com.embabel.dice.common.SuggestedEntityResolution
 import com.embabel.dice.common.filter.MentionFilter
+import com.embabel.dice.provenance.ProvenanceEntry
 
 /**
  * Extracts propositions from text chunks.
@@ -70,12 +71,14 @@ interface PropositionExtractor {
      * @param suggestedPropositions The original suggested propositions
      * @param resolutions Entity resolution results from EntityResolver
      * @param context The source analysis context containing contextId
+     * @param provenanceEntries Rich grounding for the chunk (from [com.embabel.dice.provenance.ChunkProvenanceFactory])
      * @return Propositions with entity IDs resolved where possible
      */
     fun resolvePropositions(
         suggestedPropositions: SuggestedPropositions,
         resolutions: Resolutions<SuggestedEntityResolution>,
         context: SourceAnalysisContext,
+        provenanceEntries: List<ProvenanceEntry> = emptyList(),
     ): List<Proposition>
 }
 

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/SuggestedProposition.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/SuggestedProposition.kt
@@ -17,6 +17,7 @@ package com.embabel.dice.proposition
 
 import com.embabel.agent.core.ContextId
 import com.embabel.common.core.types.ZeroToOne
+import com.embabel.dice.provenance.ProvenanceEntry
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
 
 /**
@@ -98,7 +99,11 @@ data class SuggestedProposition(
      * Convert to a Proposition with the given chunk grounding.
      * Entity resolution happens separately.
      */
-    fun toProposition(chunkIds: List<String>, contextId: ContextId): Proposition =
+    fun toProposition(
+        chunkIds: List<String>,
+        contextId: ContextId,
+        provenanceEntries: List<ProvenanceEntry> = emptyList(),
+    ): Proposition =
         Proposition(
             contextId = contextId,
             text = text,
@@ -108,6 +113,7 @@ data class SuggestedProposition(
             importance = importance.coerceIn(0.0, 1.0),
             reasoning = reasoning.ifBlank { null },
             grounding = chunkIds,
+            provenanceEntries = provenanceEntries,
         )
 }
 

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/extraction/LlmPropositionExtractor.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/extraction/LlmPropositionExtractor.kt
@@ -34,6 +34,7 @@ import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.proposition.SuggestedMention
 import com.embabel.dice.proposition.SuggestedProposition
 import com.embabel.dice.proposition.SuggestedPropositions
+import com.embabel.dice.provenance.ProvenanceEntry
 import org.slf4j.LoggerFactory
 
 
@@ -322,6 +323,7 @@ data class LlmPropositionExtractor(
         suggestedPropositions: SuggestedPropositions,
         resolutions: Resolutions<SuggestedEntityResolution>,
         context: SourceAnalysisContext,
+        provenanceEntries: List<ProvenanceEntry>,
     ): List<Proposition> {
         // Build a map from mention key to resolved entity ID
         val resolutionMap = buildResolutionMap(resolutions)
@@ -335,7 +337,11 @@ data class LlmPropositionExtractor(
                 mention.toEntityMention(resolvedId)
             }
 
-            suggested.toProposition(chunkIds = listOf(suggestedPropositions.chunkId), contextId = context.contextId)
+            suggested.toProposition(
+                chunkIds = listOf(suggestedPropositions.chunkId),
+                contextId = context.contextId,
+                provenanceEntries = provenanceEntries,
+            )
                 .copy(mentions = resolvedMentions)
         }
     }

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/revision/LlmPropositionReviser.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/revision/LlmPropositionReviser.kt
@@ -24,6 +24,7 @@ import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionQuery
 import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
+import com.embabel.dice.provenance.mergeProvenanceEntries
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.Locale
@@ -590,11 +591,13 @@ data class LlmPropositionReviser(
         val slowedDecay = (existing.decay * 0.7).coerceAtLeast(0.0)
         // Combine grounding
         val combinedGrounding = (existing.grounding + new.grounding).distinct()
+        val combinedProvenance = mergeProvenanceEntries(existing.provenanceEntries, new.provenanceEntries)
 
         return existing.copy(
             confidence = boostedConfidence,
             decay = slowedDecay,
             grounding = combinedGrounding,
+            provenanceEntries = combinedProvenance,
             reinforceCount = existing.reinforceCount + 1,
             contentRevised = Instant.now(),
             lastAccessed = Instant.now(),
@@ -612,11 +615,13 @@ data class LlmPropositionReviser(
         val slowedDecay = (existing.decay * 0.85).coerceAtLeast(0.0)
         // Combine grounding
         val combinedGrounding = (existing.grounding + new.grounding).distinct()
+        val combinedProvenance = mergeProvenanceEntries(existing.provenanceEntries, new.provenanceEntries)
 
         return existing.copy(
             confidence = boostedConfidence,
             decay = slowedDecay,
             grounding = combinedGrounding,
+            provenanceEntries = combinedProvenance,
             reinforceCount = existing.reinforceCount + 1,
             contentRevised = Instant.now(),
             lastAccessed = Instant.now(),

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/ChunkProvenanceFactory.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/ChunkProvenanceFactory.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+import com.embabel.agent.rag.model.Chunk
+import com.embabel.dice.common.SourceAnalysisContext
+
+/**
+ * Builds [ProvenanceEntry] values from extraction inputs.
+ *
+ * The pipeline calls this once per processed [Chunk] so extracted propositions
+ * carry rich grounding (locator + chunk id + optional content hash) alongside
+ * the legacy [com.embabel.dice.proposition.Proposition.grounding] chunk-id list.
+ *
+ * Locator resolution order:
+ * 1. [SourceAnalysisContext.defaultSourceLocator] when the run has a known source
+ * 2. Chunk metadata (`source_uri`, `source_path`, `connector_id` + `external_id`)
+ * 3. Parsed chunk / parent id (`https://...`, `email:thread`, `file:path`, …)
+ * 4. [ConnectorRef] fallback using the chunk id as the external reference
+ */
+object ChunkProvenanceFactory {
+
+    fun entryFor(
+        chunk: Chunk,
+        context: SourceAnalysisContext,
+        contentHash: String? = null,
+    ): ProvenanceEntry =
+        ProvenanceEntry(
+            locator = resolveLocator(chunk, context),
+            chunkId = chunk.id,
+            contentHash = contentHash,
+        )
+
+    internal fun resolveLocator(chunk: Chunk, context: SourceAnalysisContext): SourceLocator {
+        context.defaultSourceLocator?.let { return it }
+
+        val metadata = chunk.metadata
+        stringMetadata(metadata, "source_uri")?.let { return UriLocator(it) }
+        stringMetadata(metadata, "source_path")?.let { return FileLocator(it) }
+        val connectorId = stringMetadata(metadata, "connector_id")
+        val externalId = stringMetadata(metadata, "external_id")
+        if (connectorId != null && externalId != null) {
+            return ConnectorRef(connectorId, externalId)
+        }
+
+        sequenceOf(chunk.id, chunk.parentId)
+            .filter { it.isNotBlank() }
+            .mapNotNull(::parseSourceKey)
+            .firstOrNull()
+            ?.let { return it }
+
+        return ConnectorRef(connectorId = "source", externalId = chunk.id)
+    }
+
+    private fun parseSourceKey(key: String): SourceLocator? = when {
+        key.startsWith("http://") || key.startsWith("https://") -> UriLocator(key)
+        key.startsWith("file:") -> FileLocator(key.removePrefix("file:"))
+        key.startsWith("url:") -> {
+            val rest = key.removePrefix("url:")
+            if (rest.startsWith("http://") || rest.startsWith("https://")) UriLocator(rest)
+            else ConnectorRef("url", rest)
+        }
+        ':' in key -> {
+            val separator = key.indexOf(':')
+            val prefix = key.substring(0, separator)
+            val rest = key.substring(separator + 1)
+            if (prefix.isNotBlank() && rest.isNotBlank()) ConnectorRef(prefix, rest) else null
+        }
+        else -> null
+    }
+
+    private fun stringMetadata(metadata: Any?, key: String): String? {
+        if (metadata !is Map<*, *>) return null
+        return (metadata[key] as? String)?.takeIf { it.isNotBlank() }
+    }
+}

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceMerge.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceMerge.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+/**
+ * Merges provenance from revision candidates without duplicates.
+ * Uses [ProvenanceEntry] equality (locator key + optional offsets/hash/chunk id).
+ */
+fun mergeProvenanceEntries(
+    existing: List<ProvenanceEntry>,
+    incoming: List<ProvenanceEntry>,
+): List<ProvenanceEntry> = (existing + incoming).distinct()

--- a/dice/src/main/kotlin/com/embabel/dice/web/rest/MemoryDtos.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/web/rest/MemoryDtos.kt
@@ -21,6 +21,7 @@ import com.embabel.dice.proposition.MentionRole
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.proposition.revision.RevisionResult
+import com.embabel.dice.provenance.ProvenanceEntry
 import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.Instant
 
@@ -174,6 +175,7 @@ data class PropositionDto(
     val decay: Double,
     val reasoning: String?,
     val grounding: List<String>,
+    val provenanceEntries: List<ProvenanceEntry> = emptyList(),
     val created: Instant,
     val revised: Instant,
     val lastAccessed: Instant,
@@ -190,6 +192,7 @@ data class PropositionDto(
             decay = proposition.decay,
             reasoning = proposition.reasoning,
             grounding = proposition.grounding,
+            provenanceEntries = proposition.provenanceEntries,
             created = proposition.created,
             revised = proposition.revised,
             lastAccessed = proposition.lastAccessed,

--- a/dice/src/test/kotlin/com/embabel/dice/pipeline/PropositionPipelineTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/pipeline/PropositionPipelineTest.kt
@@ -35,6 +35,10 @@ import com.embabel.dice.common.validation.LengthConstraint
 import com.embabel.dice.incremental.BookmarkKey
 import com.embabel.dice.incremental.InMemoryChunkHistoryStore
 import com.embabel.dice.proposition.*
+import com.embabel.dice.provenance.ConnectorRef
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.UriLocator
+import com.embabel.dice.common.support.Sha256ContentHasher
 import com.embabel.dice.text2graph.builder.Animal
 import com.embabel.dice.text2graph.builder.Person
 import org.junit.jupiter.api.Assertions.*
@@ -161,6 +165,7 @@ class PropositionPipelineTest {
             suggestedPropositions: SuggestedPropositions,
             resolutions: Resolutions<SuggestedEntityResolution>,
             context: SourceAnalysisContext,
+            provenanceEntries: List<ProvenanceEntry>,
         ): List<Proposition> {
             // Build lookup from entity name to resolved ID
             val nameToId = mutableMapOf<String, String>()
@@ -185,6 +190,7 @@ class PropositionPipelineTest {
                     mentions = resolvedMentions,
                     confidence = suggestedProp.confidence,
                     grounding = listOf(suggestedPropositions.chunkId),
+                    provenanceEntries = provenanceEntries,
                 )
             }
         }
@@ -1291,6 +1297,58 @@ class PropositionPipelineTest {
                 ),
                 "Different context should not dedupe",
             )
+        }
+    }
+
+    @Nested
+    inner class ProvenanceWiringTests {
+
+        @Test
+        fun `processChunk populates provenanceEntries from chunk id`() {
+            val pipeline = PropositionPipeline.withExtractor(MockPropositionExtractor())
+            val chunk = Chunk(
+                id = "email:thread-42",
+                text = "mentions:Alice",
+                metadata = emptyMap(),
+                parentId = "",
+            )
+            val context = SourceAnalysisContext(
+                schema = schema,
+                entityResolver = AlwaysCreateEntityResolver,
+                contextId = testContextId,
+            )
+
+            val result = pipeline.processChunk(chunk, context)
+            val proposition = result.propositions.single()
+
+            assertEquals(listOf("email:thread-42"), proposition.grounding)
+            assertEquals(1, proposition.provenanceEntries.size)
+            val entry = proposition.provenanceEntries.single()
+            assertEquals("email:thread-42", entry.chunkId)
+            assertEquals(ConnectorRef("email", "thread-42"), entry.locator)
+            assertEquals(Sha256ContentHasher.hash(chunk.text), entry.contentHash)
+        }
+
+        @Test
+        fun `processOnce uses provided content hash for provenance`() {
+            val pipeline = PropositionPipeline.withExtractor(MockPropositionExtractor())
+            val context = SourceAnalysisContext(
+                schema = schema,
+                entityResolver = AlwaysCreateEntityResolver,
+                contextId = testContextId,
+                defaultSourceLocator = UriLocator("https://example.com/doc"),
+            )
+
+            val result = pipeline.processOnce(
+                text = "mentions:Alice",
+                sourceId = "doc-1",
+                context = context,
+            )!!
+
+            val entry = result.propositions.single().provenanceEntries.single()
+            assertEquals(UriLocator("https://example.com/doc"), entry.locator)
+            assertEquals("doc-1", entry.chunkId)
+            assertEquals(Sha256ContentHasher.hash("mentions:Alice"), entry.contentHash)
         }
     }
 

--- a/dice/src/test/kotlin/com/embabel/dice/proposition/revision/PropositionReviserTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/proposition/revision/PropositionReviserTest.kt
@@ -24,6 +24,9 @@ import com.embabel.dice.proposition.MentionRole
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.UriLocator
+import com.embabel.dice.provenance.mergeProvenanceEntries
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -411,6 +414,59 @@ class PropositionReviserTest {
             // Decay should slow: 0.2 * 0.85 = 0.17
             assertEquals(0.17, reinforced.revised.decay, 0.001)
             assertTrue(reinforced.revised.decay < existing.decay)
+        }
+    }
+
+    @Nested
+    inner class ProvenanceAccumulationTests {
+
+        private lateinit var repository: TestPropositionRepository
+        private lateinit var reviser: TestPropositionReviser
+
+        @BeforeEach
+        fun setup() {
+            repository = TestPropositionRepository()
+            reviser = TestPropositionReviser()
+        }
+
+        @Test
+        fun `merged proposition accumulates provenance entries`() {
+            val first = ProvenanceEntry(locator = UriLocator("https://example.com/a"), chunkId = "c1")
+            val second = ProvenanceEntry(locator = UriLocator("https://example.com/b"), chunkId = "c2")
+            val existing = createProposition("Alice works at Google").copy(provenanceEntries = listOf(first))
+            repository.save(existing)
+
+            reviser.nextClassification = listOf(
+                ClassifiedProposition(existing, PropositionRelation.IDENTICAL, 0.95, "Same fact"),
+            )
+
+            val newProp = createProposition("Alice is employed at Google").copy(provenanceEntries = listOf(second))
+            val result = reviser.revise(newProp, repository)
+
+            assertTrue(result is RevisionResult.Merged)
+            val merged = (result as RevisionResult.Merged).revised
+            assertEquals(2, merged.provenanceEntries.size)
+            assertTrue(merged.provenanceEntries.containsAll(listOf(first, second)))
+        }
+
+        @Test
+        fun `reinforced proposition accumulates provenance entries`() {
+            val first = ProvenanceEntry(locator = UriLocator("https://example.com/a"), chunkId = "c1")
+            val second = ProvenanceEntry(locator = UriLocator("https://example.com/b"), chunkId = "c2")
+            val existing = createProposition("Alice likes Kotlin").copy(provenanceEntries = listOf(first))
+            repository.save(existing)
+
+            reviser.nextClassification = listOf(
+                ClassifiedProposition(existing, PropositionRelation.SIMILAR, 0.75, "Related"),
+            )
+
+            val newProp = createProposition("Alice enjoys Kotlin").copy(provenanceEntries = listOf(second))
+            val result = reviser.revise(newProp, repository)
+
+            assertTrue(result is RevisionResult.Reinforced)
+            val reinforced = (result as RevisionResult.Reinforced).revised
+            assertEquals(2, reinforced.provenanceEntries.size)
+            assertTrue(reinforced.provenanceEntries.containsAll(listOf(first, second)))
         }
     }
 
@@ -1140,6 +1196,7 @@ class TestPropositionReviser(
             confidence = boostedConfidence,
             decay = slowedDecay,
             grounding = combinedGrounding,
+            provenanceEntries = mergeProvenanceEntries(existing.provenanceEntries, new.provenanceEntries),
             reinforceCount = existing.reinforceCount + 1,
         )
     }
@@ -1153,6 +1210,7 @@ class TestPropositionReviser(
             confidence = boostedConfidence,
             decay = slowedDecay,
             grounding = combinedGrounding,
+            provenanceEntries = mergeProvenanceEntries(existing.provenanceEntries, new.provenanceEntries),
             reinforceCount = existing.reinforceCount + 1,
         )
     }

--- a/dice/src/test/kotlin/com/embabel/dice/provenance/ChunkProvenanceFactoryTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/provenance/ChunkProvenanceFactoryTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+import com.embabel.agent.core.ContextId
+import com.embabel.agent.rag.model.Chunk
+import com.embabel.dice.common.SourceAnalysisContext
+import com.embabel.dice.common.resolver.AlwaysCreateEntityResolver
+import com.embabel.dice.text2graph.builder.Person
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+class ChunkProvenanceFactoryTest {
+
+    private val schema = com.embabel.agent.core.DataDictionary.fromClasses("test", Person::class.java)
+    private val context = SourceAnalysisContext(
+        schema = schema,
+        entityResolver = AlwaysCreateEntityResolver,
+        contextId = ContextId("ctx"),
+    )
+
+    @Test
+    fun `uses default source locator from context`() {
+        val locator = UriLocator("https://example.com/doc")
+        val ctx = context.withDefaultSourceLocator(locator)
+        val chunk = Chunk(id = "chunk-1", text = "text", metadata = emptyMap(), parentId = "")
+
+        val entry = ChunkProvenanceFactory.entryFor(chunk, ctx, contentHash = "abc")
+
+        assertEquals(locator, entry.locator)
+        assertEquals("chunk-1", entry.chunkId)
+        assertEquals("abc", entry.contentHash)
+    }
+
+    @Test
+    fun `parses connector-style chunk ids`() {
+        val chunk = Chunk(id = "email:thread-9", text = "text", metadata = emptyMap(), parentId = "")
+
+        val locator = ChunkProvenanceFactory.resolveLocator(chunk, context)
+
+        assertInstanceOf(ConnectorRef::class.java, locator)
+        assertEquals(ConnectorRef("email", "thread-9"), locator)
+    }
+
+    @Test
+    fun `parses uri chunk ids`() {
+        val chunk = Chunk(
+            id = "https://example.com/page",
+            text = "text",
+            metadata = emptyMap(),
+            parentId = "",
+        )
+
+        val locator = ChunkProvenanceFactory.resolveLocator(chunk, context)
+
+        assertEquals(UriLocator("https://example.com/page"), locator)
+    }
+
+    @Test
+    fun `reads source metadata when present`() {
+        val chunk = Chunk(
+            id = "chunk-1",
+            text = "text",
+            metadata = mapOf("source_uri" to "https://docs.example.com/spec"),
+            parentId = "",
+        )
+
+        val locator = ChunkProvenanceFactory.resolveLocator(chunk, context)
+
+        assertEquals(UriLocator("https://docs.example.com/spec"), locator)
+    }
+}

--- a/dice/src/test/kotlin/com/embabel/dice/provenance/ProvenanceMergeTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/provenance/ProvenanceMergeTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ProvenanceMergeTest {
+
+    @Test
+    fun `merge deduplicates by entry equality`() {
+        val a = ProvenanceEntry(locator = UriLocator("https://example.com/a"), chunkId = "c1")
+        val b = ProvenanceEntry(locator = UriLocator("https://example.com/b"), chunkId = "c2")
+
+        val merged = mergeProvenanceEntries(listOf(a), listOf(a, b))
+
+        assertEquals(2, merged.size)
+        assertEquals(listOf(a, b), merged)
+    }
+}


### PR DESCRIPTION
## Summary
- Populate `provenanceEntries` during chunk extraction via `ChunkProvenanceFactory` (locator from context default, chunk metadata, or parsed chunk id)
- Accumulate provenance on merge/reinforce via `mergeProvenanceEntries` in `LlmPropositionReviser`
- Expose provenance on `PropositionDto` for REST consumers

Fixes #32

## Test plan
- [x] `ChunkProvenanceFactoryTest` and `ProvenanceMergeTest`
- [x] `PropositionPipelineTest\`
- [x] `PropositionReviserTest\`
- [x] Full `mvn test -pl dice`