### PR TITLE
fix(storage): load Proposition nodes missing newer properties

### DIFF
--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/PropositionNode.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/PropositionNode.kt
@@ -36,19 +36,6 @@ import java.time.Instant
  * dice `Proposition` lives in `PropositionGraphMapper`, which the Maven build compiles with
  * dice-core available.
  *
- * ## Schema evolution: keep new fields loadable against old nodes
- *
- * Drivine hydrates a node by projecting each field explicitly, so a property a node was written
- * without comes back as *present-null*, not absent — and a plain Kotlin default only applies for an
- * *absent* property, so it never fires here. A non-nullable field with no null handling therefore
- * fails to load any node predating that field.
- *
- * So every field that might be missing on an older node must be either nullable, or carry a
- * `@Default` (scalars — falls back to the declared Kotlin default) or `@EmptyWhenAbsent`
- * (collections). Only the fields present since the node's first version — `id`, `contextId`,
- * `text`, `confidence`, `created` — are left strict; a node missing one of those is genuinely
- * corrupt and should fail loudly. Apply the same rule to any field added from here on.
- *
  * @see com.embabel.dice.storage.PropositionGraphMapper
  */
 @NodeFragment(labels = ["Proposition"])

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/PropositionNode.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/PropositionNode.kt
@@ -15,6 +15,8 @@
  */
 package com.embabel.dice.storage.model
 
+import org.drivine.annotation.Default
+import org.drivine.annotation.EmptyWhenAbsent
 import org.drivine.annotation.NodeFragment
 import org.drivine.annotation.NodeId
 import org.drivine.annotation.PropertyBag
@@ -34,6 +36,19 @@ import java.time.Instant
  * dice `Proposition` lives in `PropositionGraphMapper`, which the Maven build compiles with
  * dice-core available.
  *
+ * ## Schema evolution: keep new fields loadable against old nodes
+ *
+ * Drivine hydrates a node by projecting each field explicitly, so a property a node was written
+ * without comes back as *present-null*, not absent — and a plain Kotlin default only applies for an
+ * *absent* property, so it never fires here. A non-nullable field with no null handling therefore
+ * fails to load any node predating that field.
+ *
+ * So every field that might be missing on an older node must be either nullable, or carry a
+ * `@Default` (scalars — falls back to the declared Kotlin default) or `@EmptyWhenAbsent`
+ * (collections). Only the fields present since the node's first version — `id`, `contextId`,
+ * `text`, `confidence`, `created` — are left strict; a node missing one of those is genuinely
+ * corrupt and should fail loudly. Apply the same rule to any field added from here on.
+ *
  * @see com.embabel.dice.storage.PropositionGraphMapper
  */
 @NodeFragment(labels = ["Proposition"])
@@ -48,44 +63,59 @@ data class PropositionNode(
     val text: String,
 
     val confidence: Double,
-    val decay: Double,
-    val importance: Double,
+    @Default
+    val decay: Double = 0.0,
+    @Default
+    val importance: Double = 0.5,
     val reasoning: String? = null,
 
+    @EmptyWhenAbsent
     val grounding: List<String> = emptyList(),
+    @EmptyWhenAbsent
     val sourceIds: List<String> = emptyList(),
     val uri: String? = null,
 
     val created: Instant,
-    // Proposition splits revision into content vs metadata revisions (lifecycle work, PR #30).
-    val contentRevised: Instant,
-    val metadataRevised: Instant,
+    // Content vs metadata revision clocks (lifecycle work, PR #30), materialised as node properties
+    // in PR #47 — so nodes written earlier lack them. Fall back to `created` ("never revised since
+    // creation") rather than failing the load.
+    @Default
+    val contentRevised: Instant = created,
+    @Default
+    val metadataRevised: Instant = created,
 
     /**
      * The later of [contentRevised] and [metadataRevised] — "last touched of any kind". Materialised
      * (not derived at query time) so "revised" filtering and ordering push into the database against a
      * single indexable column, matching the in-memory backend's `Proposition.lastTouched` semantics.
      * Written on every save; the partial-update writers (decay sweep, re-embed) don't touch the
-     * revision clocks, so it never drifts.
+     * revision clocks, so it never drifts. On a node written before this column existed it falls back
+     * to the later of the two revision clocks.
      */
     @RangeIndex
-    val lastTouched: Instant,
+    @Default
+    val lastTouched: Instant = maxOf(contentRevised, metadataRevised),
 
-    val lastAccessed: Instant,
+    @Default
+    val lastAccessed: Instant = created,
 
     /** [com.embabel.dice.proposition.PropositionStatus] name. */
     @RangeIndex
-    val status: String,
+    @Default
+    val status: String = "ACTIVE",
 
     /** Pinned propositions are exempt from decay/forgetting (lifecycle, PR #30). */
     @RangeIndex
+    @Default
     val pinned: Boolean = false,
 
     /** Abstraction level: 0 = raw observation, 1+ = derived. Persisted (unlike the legacy store). */
     @RangeIndex
+    @Default
     val level: Int = 0,
 
     /** Merge/reinforcement count. Persisted (unlike the legacy store). */
+    @Default
     val reinforceCount: Int = 0,
 
     /** Embedding of [text]; the vector index this annotation declares is also what `loadNearest` infers. */
@@ -113,7 +143,9 @@ data class PropositionNode(
     val validTo: Instant? = null,
     val invalidatedAt: Instant? = null,
     val observedAt: Instant? = null,
+    @EmptyWhenAbsent
     val supersedes: List<String> = emptyList(),
+    @EmptyWhenAbsent
     val contradicts: List<String> = emptyList(),
 
     /**

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/PropositionNode.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/PropositionNode.kt
@@ -63,25 +63,22 @@ data class PropositionNode(
     val text: String,
 
     val confidence: Double,
-    @Default
+    @param:Default
     val decay: Double = 0.0,
-    @Default
+    @param:Default
     val importance: Double = 0.5,
     val reasoning: String? = null,
 
-    @EmptyWhenAbsent
+    @param:EmptyWhenAbsent
     val grounding: List<String> = emptyList(),
-    @EmptyWhenAbsent
+    @param:EmptyWhenAbsent
     val sourceIds: List<String> = emptyList(),
     val uri: String? = null,
 
     val created: Instant,
-    // Content vs metadata revision clocks (lifecycle work, PR #30), materialised as node properties
-    // in PR #47 — so nodes written earlier lack them. Fall back to `created` ("never revised since
-    // creation") rather than failing the load.
-    @Default
+    @param:Default
     val contentRevised: Instant = created,
-    @Default
+    @param:Default
     val metadataRevised: Instant = created,
 
     /**
@@ -93,29 +90,29 @@ data class PropositionNode(
      * to the later of the two revision clocks.
      */
     @RangeIndex
-    @Default
+    @param:Default
     val lastTouched: Instant = maxOf(contentRevised, metadataRevised),
 
-    @Default
+    @param:Default
     val lastAccessed: Instant = created,
 
     /** [com.embabel.dice.proposition.PropositionStatus] name. */
     @RangeIndex
-    @Default
+    @param:Default
     val status: String = "ACTIVE",
 
     /** Pinned propositions are exempt from decay/forgetting (lifecycle, PR #30). */
     @RangeIndex
-    @Default
+    @param:Default
     val pinned: Boolean = false,
 
     /** Abstraction level: 0 = raw observation, 1+ = derived. Persisted (unlike the legacy store). */
     @RangeIndex
-    @Default
+    @param:Default
     val level: Int = 0,
 
     /** Merge/reinforcement count. Persisted (unlike the legacy store). */
-    @Default
+    @param:Default
     val reinforceCount: Int = 0,
 
     /** Embedding of [text]; the vector index this annotation declares is also what `loadNearest` infers. */
@@ -143,9 +140,9 @@ data class PropositionNode(
     val validTo: Instant? = null,
     val invalidatedAt: Instant? = null,
     val observedAt: Instant? = null,
-    @EmptyWhenAbsent
+    @param:EmptyWhenAbsent
     val supersedes: List<String> = emptyList(),
-    @EmptyWhenAbsent
+    @param:EmptyWhenAbsent
     val contradicts: List<String> = emptyList(),
 
     /**

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -490,4 +490,48 @@ class DrivinePropositionStoreIntegrationTest {
         assertEquals(listOf(grounded.id), repository.findByGrounding("chunk-1").map { it.id })
         assertTrue(repository.findByGrounding("chunk-x").isEmpty(), "no proposition is grounded in an unknown chunk")
     }
+
+    /**
+     * A node written before a field existed comes back with that property present-null, which used to
+     * fail the load (`MissingKotlinParameterException`). The `@Default` annotations must let such a node
+     * load, falling back to the declared defaults. Here we strip the PR#47 revision columns to mimic a
+     * pre-#47 node.
+     */
+    @Test
+    fun `loads a legacy node missing the PR#47 revision columns, defaulting them to created`() {
+        val saved = repository.save(prop(text = "legacy fact", contentRevised = Instant.parse("2021-06-01T00:00:00Z")))
+        persistenceManager.execute(
+            QuerySpecification
+                .withStatement("MATCH (p:Proposition {id: \$id}) REMOVE p.contentRevised, p.metadataRevised, p.lastTouched")
+                .bind(mapOf("id" to saved.id)),
+        )
+
+        val found = repository.findById(saved.id)
+
+        assertNotNull(found, "a node missing the revision columns must still load")
+        found!!
+        assertEquals(found.created, found.contentRevised, "missing contentRevised falls back to created")
+        assertEquals(found.created, found.metadataRevised, "missing metadataRevised falls back to created")
+    }
+
+    /**
+     * The same load-resilience for a stripped scalar and collection: a node missing `status` and
+     * `grounding` must default to `"ACTIVE"` and an empty list rather than failing to load.
+     */
+    @Test
+    fun `loads a legacy node missing status and grounding, applying defaults`() {
+        val saved = repository.save(prop(text = "another legacy fact", grounding = listOf("chunk-1")))
+        persistenceManager.execute(
+            QuerySpecification
+                .withStatement("MATCH (p:Proposition {id: \$id}) REMOVE p.status, p.grounding")
+                .bind(mapOf("id" to saved.id)),
+        )
+
+        val found = repository.findById(saved.id)
+
+        assertNotNull(found, "a node missing status/grounding must still load")
+        found!!
+        assertEquals(PropositionStatus.ACTIVE, found.status, "missing status defaults to ACTIVE")
+        assertTrue(found.grounding.isEmpty(), "missing grounding defaults to an empty list")
+    }
 }


### PR DESCRIPTION
Fixes #54.

Loading a `:Proposition` node that lacks a property a newer `PropositionNode` field expects threw
`MissingKotlinParameterException`, so the read failed outright — nodes written before PR #47 have no
`contentRevised` / `metadataRevised` / `lastTouched`.

## Root cause

Drivine hydrates a `@NodeFragment` via Jackson, projecting each field explicitly, so a missing
property loads as **present-null**, not absent. `jackson-module-kotlin` only applies a constructor
default for an *absent* field, so a plain Kotlin default never fires and the non-null field fails.

## Fix

- `@Default` on defaultable scalars (falls back to the declared Kotlin default), `@EmptyWhenAbsent`
  on collections. Defaults align with dice-core `Proposition`; revision clocks fall back to `created`
  and `lastTouched` to `max(contentRevised, metadataRevised)`.
- Identity / always-present fields (`id`, `contextId`, `text`, `confidence`, `created`) stay strict
  so a genuinely corrupt node still fails loudly.
- Documented the convention: any new `@NodeFragment` field must be nullable or annotated.
