### PR TITLE
fix(resolver): accurate resolution levels; docs(design): full audit pass

### DIFF
--- a/dice/src/main/kotlin/com/embabel/dice/common/resolver/CandidateSearcher.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/resolver/CandidateSearcher.kt
@@ -78,6 +78,16 @@ data class SearchResult(
 interface CandidateSearcher {
 
     /**
+     * Which [ResolutionLevel] a confident hit from this searcher counts as, for the per-level
+     * telemetry [EscalatingEntityResolver] logs. Each searcher declares its own tier so the counts
+     * stay accurate whatever the chain's length or order. Defaults to [ResolutionLevel.HEURISTIC_MATCH];
+     * exact-lookup searchers report [ResolutionLevel.EXACT_MATCH] and vector search reports
+     * [ResolutionLevel.EMBEDDING_MATCH].
+     */
+    val resolutionLevel: ResolutionLevel
+        get() = ResolutionLevel.HEURISTIC_MATCH
+
+    /**
      * Search for candidates matching the suggested entity.
      *
      * @param suggested The suggested entity to find matches for

--- a/dice/src/main/kotlin/com/embabel/dice/common/resolver/EscalatingEntityResolver.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/resolver/EscalatingEntityResolver.kt
@@ -144,13 +144,13 @@ class EscalatingEntityResolver(
         val allCandidates = mutableListOf<NamedEntityData>()
 
         // Run each searcher in order
-        for ((index, searcher) in searchers.withIndex()) {
+        for (searcher in searchers) {
             val result = searcher.search(suggested, schema)
             allCandidates.addAll(result.candidates)
 
             // If we got a confident match, return early
             if (result.confident != null) {
-                val level = levelForSearcherIndex(index)
+                val level = searcher.resolutionLevel
                 logger.debug(
                     "{}: '{}' -> '{}' (searcher: {})",
                     level, suggested.name, result.confident.name, searcher::class.simpleName
@@ -210,15 +210,6 @@ class EscalatingEntityResolver(
         }
 
         return LevelResult(ResolutionLevel.NO_MATCH, null, 0.0, uniqueCandidates.size)
-    }
-
-    private fun levelForSearcherIndex(index: Int): ResolutionLevel {
-        return when (index) {
-            0 -> ResolutionLevel.EXACT_MATCH
-            1 -> ResolutionLevel.HEURISTIC_MATCH
-            2 -> ResolutionLevel.EMBEDDING_MATCH
-            else -> ResolutionLevel.HEURISTIC_MATCH
-        }
     }
 
     private fun createNewOrVeto(

--- a/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/AgenticCandidateSearcher.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/AgenticCandidateSearcher.kt
@@ -28,6 +28,7 @@ import com.embabel.agent.rag.tools.ToolishRag
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.dice.common.SuggestedEntity
 import com.embabel.dice.common.resolver.CandidateSearcher
+import com.embabel.dice.common.resolver.ResolutionLevel
 import com.embabel.dice.common.resolver.SearchResult
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import org.slf4j.LoggerFactory
@@ -77,6 +78,9 @@ class AgenticCandidateSearcher(
     private val ai: Ai,
     private val llmOptions: LlmOptions,
 ) : CandidateSearcher {
+
+    // A confident hit here is the LLM choosing among the results it searched up — a bakeoff.
+    override val resolutionLevel = ResolutionLevel.LLM_BAKEOFF
 
     private val logger = LoggerFactory.getLogger(AgenticCandidateSearcher::class.java)
 

--- a/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/ByExactNameCandidateSearcher.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/ByExactNameCandidateSearcher.kt
@@ -21,6 +21,7 @@ import com.embabel.agent.rag.service.NamedEntityDataRepository
 import com.embabel.common.core.types.TextSimilaritySearchRequest
 import com.embabel.dice.common.SuggestedEntity
 import com.embabel.dice.common.resolver.CandidateSearcher
+import com.embabel.dice.common.resolver.ResolutionLevel
 import com.embabel.dice.common.resolver.SearchResult
 import org.slf4j.LoggerFactory
 
@@ -35,6 +36,8 @@ import org.slf4j.LoggerFactory
 class ByExactNameCandidateSearcher(
     private val repository: NamedEntityDataRepository,
 ) : CandidateSearcher {
+
+    override val resolutionLevel = ResolutionLevel.EXACT_MATCH
 
     private val logger = LoggerFactory.getLogger(ByExactNameCandidateSearcher::class.java)
 

--- a/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/ByIdCandidateSearcher.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/ByIdCandidateSearcher.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.core.DataDictionary
 import com.embabel.agent.rag.service.NamedEntityDataRepository
 import com.embabel.dice.common.SuggestedEntity
 import com.embabel.dice.common.resolver.CandidateSearcher
+import com.embabel.dice.common.resolver.ResolutionLevel
 import com.embabel.dice.common.resolver.SearchResult
 import org.slf4j.LoggerFactory
 
@@ -33,6 +34,8 @@ import org.slf4j.LoggerFactory
 class ByIdCandidateSearcher(
     private val repository: NamedEntityDataRepository,
 ) : CandidateSearcher {
+
+    override val resolutionLevel = ResolutionLevel.EXACT_MATCH
 
     private val logger = LoggerFactory.getLogger(ByIdCandidateSearcher::class.java)
 

--- a/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/VectorCandidateSearcher.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/VectorCandidateSearcher.kt
@@ -22,6 +22,7 @@ import com.embabel.agent.rag.service.NamedEntityDataRepository
 import com.embabel.common.core.types.TextSimilaritySearchRequest
 import com.embabel.dice.common.SuggestedEntity
 import com.embabel.dice.common.resolver.CandidateSearcher
+import com.embabel.dice.common.resolver.ResolutionLevel
 import com.embabel.dice.common.resolver.SearchResult
 import org.slf4j.LoggerFactory
 
@@ -42,6 +43,8 @@ class VectorCandidateSearcher(
     private val candidateThreshold: Double = 0.7,
     private val topK: Int = 10,
 ) : CandidateSearcher {
+
+    override val resolutionLevel = ResolutionLevel.EMBEDDING_MATCH
 
     private val logger = LoggerFactory.getLogger(VectorCandidateSearcher::class.java)
 

--- a/dice/src/main/kotlin/com/embabel/dice/operations/consolidation/ConsolidationPass.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/operations/consolidation/ConsolidationPass.kt
@@ -30,9 +30,10 @@ import com.embabel.dice.proposition.Proposition
  * and applies the accumulated saves/deletes in a single write per cycle.
  *
  * Passes MUST be idempotent: running the same pass twice with no intervening write must produce
- * [ConsolidationPassResult.NoOp] on the second run. The consolidation loop runs passes
- * repeatedly until the snapshot settles, so a pass that keeps returning [ConsolidationPassResult.Changed]
- * for an already-consolidated snapshot would loop forever.
+ * [ConsolidationPassResult.NoOp] on the second run. The orchestrator runs each pass once per cycle,
+ * so successive scheduled cycles converge on a settled snapshot; a pass that keeps returning
+ * [ConsolidationPassResult.Changed] for an already-consolidated snapshot would re-save the same
+ * data every cycle instead of quieting down.
  *
  * Implement this interface to add domain-specific consolidation behavior without touching DICE core.
  */

--- a/dice/src/test/kotlin/com/embabel/dice/common/resolver/EscalatingEntityResolverTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/common/resolver/EscalatingEntityResolverTest.kt
@@ -24,6 +24,7 @@ import com.embabel.dice.common.ExistingEntity
 import com.embabel.dice.common.NewEntity
 import com.embabel.dice.common.SuggestedEntities
 import com.embabel.dice.common.SuggestedEntity
+import com.embabel.dice.common.resolver.searcher.AgenticCandidateSearcher
 import com.embabel.dice.common.resolver.searcher.ByExactNameCandidateSearcher
 import com.embabel.dice.common.resolver.searcher.ByIdCandidateSearcher
 import com.embabel.dice.common.resolver.searcher.FuzzyNameCandidateSearcher
@@ -367,6 +368,33 @@ class EscalatingEntityResolverTest {
             assertEquals(1, result.resolutions.size)
             assertTrue(result.resolutions.first() is ExistingEntity)
             assertEquals("brahms-123", (result.resolutions.first() as ExistingEntity).existing.id)
+        }
+    }
+
+    @Nested
+    inner class ResolutionLevels {
+
+        @Test
+        fun `each default searcher reports its true tier regardless of chain position`() {
+            assertEquals(ResolutionLevel.EXACT_MATCH, ByIdCandidateSearcher(repository).resolutionLevel)
+            assertEquals(ResolutionLevel.EXACT_MATCH, ByExactNameCandidateSearcher(repository).resolutionLevel)
+            assertEquals(ResolutionLevel.HEURISTIC_MATCH, NormalizedNameCandidateSearcher(repository).resolutionLevel)
+            assertEquals(ResolutionLevel.HEURISTIC_MATCH, PartialNameCandidateSearcher(repository).resolutionLevel)
+            assertEquals(ResolutionLevel.HEURISTIC_MATCH, FuzzyNameCandidateSearcher(repository).resolutionLevel)
+            assertEquals(ResolutionLevel.EMBEDDING_MATCH, VectorCandidateSearcher(repository).resolutionLevel)
+            assertEquals(
+                ResolutionLevel.LLM_BAKEOFF,
+                AgenticCandidateSearcher(repository, mockk(), mockk()).resolutionLevel,
+            )
+        }
+
+        @Test
+        fun `a searcher that does not override defaults to heuristic`() {
+            val plain = object : CandidateSearcher {
+                override fun search(suggested: SuggestedEntity, schema: DataDictionary): SearchResult =
+                    SearchResult.empty()
+            }
+            assertEquals(ResolutionLevel.HEURISTIC_MATCH, plain.resolutionLevel)
         }
     }
 }

--- a/docs/design/INDEX.md
+++ b/docs/design/INDEX.md
@@ -1,0 +1,86 @@
+# DICE design docs
+
+Entry point into DICE's design notes. DICE is a proposition-first knowledge substrate: raw text
+becomes confidence-weighted natural-language statements (propositions), which are kept healthy
+over time and projected into whatever representation a task needs (graph, Prolog, vectors, agent
+memory). Start with [architecture](architecture.md) for the big picture, then drop into the theme
+you need.
+
+## Architecture & modules
+
+- [architecture.md](architecture.md) — system overview, the six-module map, and how propositions
+  flow from ingestion through projection. Read this first.
+
+## Ingestion & extraction
+
+- [ingestion.md](ingestion.md) — `dice-ingestion`'s two jobs: content-hash dedup before
+  extraction, and turning artifact text into `Chunk`s the pipeline understands.
+- [extraction-pipeline.md](extraction-pipeline.md) — the two-stage pipeline (extract, then
+  resolve/reconcile) that turns chunks into grounded propositions; why the stages are separable
+  and what "unsaved results" means for the caller.
+- [entity-resolution-and-text2graph.md](entity-resolution-and-text2graph.md) — how mentions get
+  matched to existing entities (or minted as new ones) without blowing the LLM budget or
+  fragmenting the graph with near-duplicates.
+
+## Propositions & lifecycle
+
+- [proposition-lifecycle.md](proposition-lifecycle.md) — how a proposition earns or loses trust,
+  what happens on conflict, supersession, and decay over its life.
+- [grounding-and-conflicts.md](grounding-and-conflicts.md) — how propositions stay anchored to
+  source material (grounding) and how the conflict/policy SPI resolves disagreements between
+  propositions.
+
+## Projections
+
+- [graph-projection.md](graph-projection.md) — projecting propositions into a typed Neo4j graph:
+  lineage back to evidence, dedup across re-runs, and cleaning up stale structure.
+- [prolog-projection.md](prolog-projection.md) — projecting propositions into a Prolog fact base
+  for logical/transitive queries that are awkward to express as graph traversals.
+
+## Memory hygiene & consolidation
+
+- [knowledge-hygiene.md](knowledge-hygiene.md) — the umbrella note: why hygiene is three separate
+  interventions (admission, reclamation, consolidation) at three different moments, not one.
+- [multi-signal-collector.md](multi-signal-collector.md) — pluggable duplicate detection that
+  combines multiple signals (similarity, contradiction, shared entities/grounding), not just
+  cosine similarity.
+- [reclamation-and-collector.md](reclamation-and-collector.md) — reclamation as a tracing garbage
+  collector: one stage marks what looks like garbage, another sweeps it, every action is recorded.
+- [collector-trace-store.md](collector-trace-store.md) — the `CollectorTraceStore` audit trail
+  that makes a collapse/merge decision explainable after the fact.
+- [consolidation-and-dream-loop.md](consolidation-and-dream-loop.md) — folding a session's raw
+  facts into long-term memory: passes, composition, and the between-session cycle.
+
+## Retrieval & query
+
+- [retrieval-and-discovery.md](retrieval-and-discovery.md) — how propositions come back out:
+  vector search, graph walks, temporal windows, trust filtering at read time, and surfacing
+  connections nobody explicitly queried for.
+- [oracle-and-query.md](oracle-and-query.md) — the layer above retrieval: turning a
+  natural-language question into an answer, not just a bag of relevant propositions.
+
+## Storage & platform
+
+- [durable-storage.md](durable-storage.md) — the `PropositionStore` SPI family, the durable Neo4j
+  backend, dedup, and the decay tick.
+- [events.md](events.md) — the domain events DICE emits (fact persisted, status changed, batch
+  finished) and how they loosely couple the substrate to observers.
+- [web-api.md](web-api.md) — the opt-in REST surface over the pipeline, memory, and discovery
+  layers, gated by an API-key filter.
+- [report.md](report.md) — `dice-report`'s pure projectors that turn queried propositions into
+  human-facing artifacts: structured breakdowns, discovered links, LLM-generated rationale.
+
+## Modules
+
+DICE ships as six Maven modules; [architecture.md](architecture.md#module-map) has the full
+dependency map. Quick pointer to where each is documented:
+
+| Module | Documented in |
+| --- | --- |
+| `dice` (core) | most notes above — propositions, pipeline, projections, hygiene, retrieval |
+| `dice-storage` | [durable-storage.md](durable-storage.md), [graph-projection.md](graph-projection.md), [prolog-projection.md](prolog-projection.md) |
+| `dice-storage-autoconfigure` | [durable-storage.md](durable-storage.md) |
+| `dice-ingestion` | [ingestion.md](ingestion.md) |
+| `dice-report` | [report.md](report.md) |
+| `dice-integration-tests` | not separately documented — exercises the above end-to-end |
+</content>

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -5,6 +5,65 @@ language statements (propositions), keeps them healthy over time, and projects t
 representation a task needs — a Neo4j graph, a Prolog fact base, vector embeddings, or agent
 working memory. Propositions are the single system of record. Everything else derives from them.
 
+## Module map
+
+DICE is a multi-module Maven build. Each module's intent, and what it's allowed to depend on:
+
+| Module | Intent |
+|---|---|
+| `dice` | The core: proposition model, pipeline, gates, projection interfaces, query facades, agent tools, REST controllers. In-memory implementations only — no database driver. |
+| `dice-storage` | The durable Neo4j backend: `Drivine`-based repository, graph/Prolog/lineage projectors, schema and index bootstrap. Depends on `dice`. |
+| `dice-storage-autoconfigure` | Spring Boot autoconfiguration that wires `dice-storage`'s beans (repository, projectors, trust scorer) into a host application. Depends on `dice-storage`. |
+| `dice-ingestion` | Content-hash dedup ledger and source adapters that sit in front of `PropositionPipeline`, so the same artifact is never extracted twice concurrently. Depends on `dice`. |
+| `dice-report` | Rationale and structured report generation over propositions and their lineage. Depends on `dice`. |
+| `dice-integration-tests` | End-to-end tests exercising the real Neo4j backend and full pipeline across module boundaries. Depends on `dice`, `dice-ingestion`, `dice-report` (and transitively `dice-storage`). Not shipped. |
+
+```mermaid
+flowchart TB
+    dice["dice<br/>(core)"]
+    storage["dice-storage<br/>(Neo4j backend)"]
+    autoconf["dice-storage-autoconfigure<br/>(Spring Boot wiring)"]
+    ingestion["dice-ingestion<br/>(dedup ledger)"]
+    report["dice-report<br/>(rationale/reports)"]
+    itest["dice-integration-tests"]
+
+    storage --> dice
+    autoconf --> storage
+    ingestion --> dice
+    report --> dice
+    itest --> dice
+    itest --> ingestion
+    itest --> report
+```
+
+`dice` never depends on any other DICE module — it's the leaf of the graph, so every other module
+can be added or removed without touching core logic. `dice-storage-autoconfigure` is the only
+module that knows about Spring Boot autoconfiguration; plain `dice-storage` stays framework-neutral
+so it can be wired by hand outside Spring Boot.
+
+### Subsystem design docs
+
+Each subsystem below the module level has its own design note:
+
+- [proposition-lifecycle](proposition-lifecycle.md) — proposition states and transitions
+- [extraction-pipeline](extraction-pipeline.md) — `PropositionPipeline` extraction and revision
+- [ingestion](ingestion.md) — content-hash dedup ledger, source adapters
+- [graph-projection](graph-projection.md) — `GraphProjector`, `Reconciler`, lineage
+- [prolog-projection](prolog-projection.md) — `PrologProjector`, fact base generation
+- [retrieval-and-discovery](retrieval-and-discovery.md) — `RetrievalRouter`, `GraphQuery`
+- [oracle-and-query](oracle-and-query.md) — query answering over the substrate
+- [consolidation-and-dream-loop](consolidation-and-dream-loop.md) — `DreamLoopOrchestrator`
+- [knowledge-hygiene](knowledge-hygiene.md) — admission gates, pinning, decay
+- [reclamation-and-collector](reclamation-and-collector.md) — mark-and-sweep reclamation
+- [multi-signal-collector](multi-signal-collector.md) — collector marking strategies
+- [collector-trace-store](collector-trace-store.md) — collector audit trail persistence
+- [grounding-and-conflicts](grounding-and-conflicts.md) — contradiction and grounding resolution
+- [entity-resolution-and-text2graph](entity-resolution-and-text2graph.md) — entity resolution, text-to-graph
+- [durable-storage](durable-storage.md) — `dice-storage` backend, schema, indexes
+- [events](events.md) — `DiceEvent` model and emitters
+- [report](report.md) — `dice-report` rationale and structured reports
+- [web-api](web-api.md) — REST surface (`DiscoveryController` and friends)
+
 ## System-level map
 
 The subsystems form a left-to-right pipeline from ingestion through maintenance to query. Each box
@@ -64,7 +123,7 @@ and where to persist. See [extraction-pipeline](extraction-pipeline.md).
 ### Store and trust/authority
 
 `PropositionStore` is the base port: CRUD plus a composable `PropositionQuery`. `PropositionRepository`
-extends it with four opt-in capability fragments a backend declares only when it genuinely supports
+extends it with three opt-in capability fragments a backend declares only when it genuinely supports
 them:
 
 | Fragment | What it adds |
@@ -72,7 +131,16 @@ them:
 | `VectorSearchCapable` | similarity search and clustering |
 | `GraphTraversalCapable` | proposition abstraction-hierarchy traversal |
 | `TemporalQueryCapable` | bitemporal valid/observed window queries |
-| `GraphQueryCapable` | native neighbourhood, path, and lineage queries; `honorsAuthorityFilter` opt-in |
+
+A separate interface, `GraphQueryCapable`, adds native neighbourhood, path, and lineage queries
+(with `honorsAuthorityFilter` and `honorsContextFilter` as its own opt-ins) for a graph-native
+backend. It is not part of `PropositionRepository` — a store implements it in addition, and
+`GraphQuery` casts the store `as? GraphQueryCapable` at runtime, routing to the native implementation
+when the backend provides one. The durable Neo4j backend (`dice-storage`) implements it and confines
+each walk to the query's context in Cypher, so graph queries there run as native Cypher for both
+unscoped and context-scoped queries (which is what the production callers issue); a store without the
+capability, or one that doesn't confine a walk to a context itself, falls back to the portable,
+store-agnostic walk.
 
 `TrustScorer` and `AuthorityResolver` are advisory — they score and rank, never delete or hide.
 `AuthorityWeightedTrustScorer` is the production scorer; the default is neutral (everything trusted
@@ -80,7 +148,7 @@ equally). See [proposition-lifecycle](proposition-lifecycle.md) and [durable-sto
 
 ### Maintenance
 
-Three seams keep the store healthy at three different moments:
+Three mechanisms keep the store healthy at three different moments:
 
 ```mermaid
 flowchart TB

--- a/docs/design/collector-trace-store.md
+++ b/docs/design/collector-trace-store.md
@@ -1,0 +1,237 @@
+# The collector trace store: recording and explaining a collapse
+
+Every edge scored, every component grouped, and every merge decided by the multi-signal
+collector (see [multi-signal-collector](multi-signal-collector.md) for the pipeline that
+produces this data) is written to a `CollectorTraceStore` under the run's id. This is the audit
+trail that makes a collapse *explainable* after the fact — "why did proposition X get merged
+into proposition Y" is a query, not a mystery — and, because nothing about a merge is
+destructive (grounding and provenance are folded, not dropped; the loser transitions to `STALE`,
+not deleted), the trace is also what a human reviewer needs to decide whether a given collapse
+should be manually reversed.
+
+This note covers the trace SPI, the two implementations that ship, the graph schema
+`dice-storage` declares for the Neo4j-backed one, and how a run's data is written and read back.
+
+## The trace SPI
+
+```kotlin
+interface CollectorTraceStore {
+    fun recordRunContext(runId: String, contextId: ContextId)
+    fun recordCandidateEdges(runId: String, edges: List<CollectorCandidateEdge>)
+    fun recordComponents(runId: String, components: List<CollectorComponent>)
+    fun recordDecision(runId: String, decision: CollectorDecision)
+    fun deleteTracesForContext(contextId: ContextId)
+}
+
+interface CollectorTraceQuery {
+    fun findEdgesByRun(runId: String): List<CollectorCandidateEdge>
+    fun findDecisionsByRun(runId: String): List<CollectorDecision>
+    fun findDecisionForProposition(propositionId: String): CollectorDecision?
+}
+```
+
+The write side (`CollectorTraceStore`) and the read side (`CollectorTraceQuery`) are declared as
+separate interfaces, but both shipped implementations satisfy both from the same class — a
+single store handles the full lifecycle of a run's trace, and there is intentionally no separate
+query-only bean (see [Wiring: one bean, two interfaces](#wiring-one-bean-two-interfaces) below).
+
+`recordRunContext` is called once per run, before anything else, and exists mainly so
+`deleteTracesForContext` has something to key off — the per-edge/component/decision record
+calls don't carry a `ContextId` of their own; they carry a `runId`, and the run's registered
+context is what makes "delete everything for this context" possible without threading a context
+id through every downstream write.
+
+## Two implementations, one contract
+
+```mermaid
+flowchart LR
+    SPI["CollectorTraceStore /\nCollectorTraceQuery (dice)"]
+    subgraph inmem ["InMemoryCollectorTraceStore (dice)"]
+        MAPS["ConcurrentHashMap keyed by runId:\nedgesByRun, componentsByRun,\ndecisionsByRun, runContexts"]
+    end
+    subgraph graphstore ["DrivineCollectorTraceStore (dice-storage)"]
+        NEO["Neo4j via PersistenceManager\nMERGE-based writes, UNWIND batch inserts"]
+        SCHEMA2["CollectorTraceSchema\n(constraints + indexes)"]
+        NEO --- SCHEMA2
+    end
+    inmem -.implements.-> SPI
+    graphstore -.implements.-> SPI
+```
+
+**`InMemoryCollectorTraceStore`** (`dice/src/main/kotlin/com/embabel/dice/spi/InMemoryCollectorTraceStore.kt`)
+keeps everything in `ConcurrentHashMap`s keyed by `runId`, with `Collections.synchronizedList`
+backing each run's list of edges/components/decisions. It's the always-available default — no
+external dependency, thread-safe, and what tests exercise directly via its `edgesFor`/
+`componentsFor`/`decisionsFor` accessors. Its tradeoff is durability: nothing survives a process
+restart. `deleteTracesForContext` scans the `runContexts` map for every run registered against
+the given context and clears all four maps for those run ids — a run that was never registered
+via `recordRunContext` is simply unreachable from delete, which matters if a caller ever calls
+the edge/component/decision record methods without first calling `recordRunContext`.
+
+**`DrivineCollectorTraceStore`** (`dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStore.kt`)
+persists the same data to Neo4j via `PersistenceManager`, wrapped in `@Transactional` at both
+the class and method level. Every write is a `MERGE` on a natural key, so replaying a run (or
+retrying a partially-failed write) updates rows in place rather than duplicating them. Every
+multi-row write (edges, signals, components, retired members) goes through a single
+`UNWIND $rows AS r ...` statement rather than one round trip per row — no APOC, no GDS, just
+plain Cypher. Query methods are corrupt-row-tolerant: a row that fails to map into its data
+class is logged and skipped rather than failing the whole read, which keeps one bad row from
+making an entire trace unreadable.
+
+## Node model: six labels
+
+`CollectorTraceSchema` (`dice-storage/src/main/kotlin/com/embabel/dice/storage/CollectorTraceSchema.kt`)
+declares six node labels, each with a uniqueness constraint on its natural-key id property, plus
+range indexes on the fields it's actually queried by:
+
+```mermaid
+erDiagram
+    CollectorTraceRun ||--o{ CollectorCandidateEdge : "runId / contextId property"
+    CollectorTraceRun ||--o{ CollectorComponent : "runId / contextId property"
+    CollectorTraceRun ||--o{ CollectorDecision : "runId / contextId property"
+    CollectorCandidateEdge ||--o{ CollectorSignalScore : SCORED
+    CollectorDecision ||--o{ CollectorRetired : RETIRED_IN
+
+    CollectorTraceRun {
+        string runId PK
+        string contextId
+        datetime createdAt
+    }
+    CollectorCandidateEdge {
+        string id PK "runId|anchorId|memberId"
+        string runId
+        string contextId
+        string anchorId
+        string memberId
+        double aggregateScore
+        boolean vetoed
+    }
+    CollectorSignalScore {
+        string id PK
+        string runId
+        string contextId
+        string signal
+        double score
+        double weight
+        boolean veto
+        string explanation
+        string evidenceRef
+    }
+    CollectorComponent {
+        string id PK "runId|componentId"
+        string runId
+        string contextId
+        string componentId
+        list memberIds
+    }
+    CollectorDecision {
+        string id PK "runId|componentId"
+        string runId
+        string contextId
+        string componentId
+        string survivorId
+        string action
+        datetime createdAt
+    }
+    CollectorRetired {
+        string id PK
+        string runId
+        string contextId
+        string propositionId
+        string priorStatus
+        list foldedGrounding
+        list foldedProvenanceRefs
+        list foldedSourceIds
+    }
+```
+
+Only `SCORED` (`CollectorSignalScore` → `CollectorCandidateEdge`) and `RETIRED_IN`
+(`CollectorRetired` → `CollectorDecision`) are real graph relationships. Every node's tie back to
+its run is a plain `runId`/`contextId` *property*, not an edge — deliberately, so that "give me
+everything for this run" or "delete everything for this context" is a property-filtered `MATCH`
+per label rather than a graph traversal from a single run node. `CollectorTraceSchema.LABELS`
+lists all six for exactly that purpose: `deleteTracesForContext` iterates it, running one
+`MATCH (n:$label {contextId: $contextId}) ... DETACH DELETE` per label instead of a
+multi-label query.
+
+The `id` naming convention is a composite natural key, not a generated UUID — `edge.id` is
+`"runId|anchorId|memberId"`, `component.id` is `"runId|componentId"`, `decision.id` is
+`"runId|componentId"`. That's what makes the `MERGE (x:Label {id: ...})` writes idempotent:
+replaying the same run produces the same ids, so a retry updates in place instead of duplicating
+rows.
+
+## Writing a run's trace
+
+`DrivineCollectorTraceStore` writes in the same order `MultiSignalCollectorStrategy` calls it —
+run context first, then edges (with nested signal scores), then components, then decisions (with
+nested retired members):
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Strategy as MultiSignalCollectorStrategy
+    participant Store as DrivineCollectorTraceStore
+    participant Neo4j
+
+    Strategy->>Store: recordRunContext(runId, contextId)
+    Store->>Neo4j: MERGE (:CollectorTraceRun {runId}) SET contextId, createdAt
+
+    Strategy->>Store: recordCandidateEdges(runId, edges)
+    Store->>Neo4j: MATCH run, UNWIND edges, MERGE (:CollectorCandidateEdge {id}) SET += row, contextId
+    Store->>Neo4j: MATCH run, UNWIND signals, MERGE (:CollectorSignalScore {id}), MERGE -[:SCORED]-> edge
+
+    Strategy->>Store: recordComponents(runId, components)
+    Store->>Neo4j: MATCH run, UNWIND components, MERGE (:CollectorComponent {id}) SET += row, contextId
+
+    loop each component with a chosen survivor
+        Strategy->>Store: recordDecision(runId, decision)
+        Store->>Neo4j: MATCH run, MERGE (:CollectorDecision {id}) SET += row, contextId, createdAt
+        Store->>Neo4j: MATCH run, UNWIND retired, MERGE (:CollectorRetired {id}), MERGE -[:RETIRED_IN]-> decision
+    end
+```
+
+Every statement re-`MATCH`es the `CollectorTraceRun` node for its `contextId`, rather than
+threading the context id as a parameter through every call — that's the single-sourcing this
+module leans on: `recordRunContext` is the only place `contextId` gets written directly, and
+every later write copies it from the matched run node (`e.contextId = run.contextId`).
+
+## Reading a run back
+
+`findEdgesByRun` rehydrates edges and their nested signal scores in two passes — one query for
+`CollectorCandidateEdge` nodes, one for their `SCORED` `CollectorSignalScore` children — then
+joins them by edge id in Kotlin (`groupBy` into `signalsByEdgeId`) rather than having Cypher
+return a nested map per edge. Two reasons: each query stays flat, one row per node, so the
+existing flat row mappers (`CollectorCandidateEdgeRowMapper`) consume it directly; and each row is
+mapped inside its own `runCatching`, so one unreadable edge or signal row is skipped and logged
+rather than poisoning the whole read. A single Cypher query returning nested collections per edge
+would mean one result row per (edge, signal) pair to flatten back out, or a `collect()`-based
+aggregation to nest them — either way more to reconstruct than two flat result sets. The cost is
+two round trips, with both result sets held in memory to join; for one run's bounded trace that's
+negligible, but the signals query pulls every `SCORED` signal for the run and groups it
+client-side, so an unusually large run means a correspondingly large in-memory result set — the
+ceiling to watch if run sizes grow.
+
+`findDecisionsByRun` and `findDecisionForProposition` follow the same shape: fetch the decision
+node(s), then a helper (`retiredFor`) fetches the `CollectorRetired` children keyed by
+`decisionId`. `findDecisionForProposition` checks both sides of a merge — first whether the id is
+a decision's `survivorId`, then (if not) whether it appears on a `CollectorRetired` node reachable
+via `RETIRED_IN` — so it answers "what happened to this proposition" whether it survived or was
+folded away.
+
+Every mapped row goes through `runCatching { ... }.onFailure { logger.warn(...) }.getOrNull()` —
+a single corrupt or partially-written row is skipped and logged rather than aborting the whole
+read, which matters for a store that's meant to stay readable even after a crash mid-write.
+
+## Wiring
+
+The two trace-store beans are wired by `CollectorAutoConfiguration` the same way as the rest of
+the collector's beans — see
+[Graph vs. in-memory trace store selection](multi-signal-collector.md#graph-vs-in-memory-trace-store-selection)
+for why each bean returns its concrete type instead of the `CollectorTraceStore` interface.
+
+The one detail specific to tracing: the graph bean carries a second condition beyond the
+store-type check, `embabel.dice.collector.trace.enabled` (default `true`). Set it to `false`
+with `embabel.dice.store.type=graph` and neither trace-store bean's conditions are satisfied
+purely by that combination — in practice the in-memory bean's `@ConditionalOnMissingBean` still
+lets it step in as the fallback, so tracing degrades to non-durable rather than disappearing
+outright.

--- a/docs/design/consolidation-and-dream-loop.md
+++ b/docs/design/consolidation-and-dream-loop.md
@@ -67,7 +67,39 @@ itself**. That purity contract is the whole design. The orchestrator fetches the
 each pass over it, and applies the accumulated changes in a single write per cycle, so passes stay
 small, independently testable, and reorderable.
 
+```kotlin
+interface ConsolidationPass {
+    val name: String
+    fun run(contextId: ContextId, propositions: List<Proposition>): ConsolidationPassResult
+}
+```
+
 A result is one of three things, sealed so the orchestrator handles every case:
+
+```kotlin
+sealed class ConsolidationPassResult {
+    abstract val passName: String
+
+    data class Changed @JvmOverloads constructor(
+        override val passName: String,
+        val propositionsToSave: List<Proposition> = emptyList(),
+        val propositionsToDelete: List<String> = emptyList(),
+        val skipped: Int = 0,
+        val externallyApplied: Int = 0,
+        val summary: String = "",
+    ) : ConsolidationPassResult()
+
+    data class NoOp(
+        override val passName: String,
+        val reason: String = "",
+    ) : ConsolidationPassResult()
+
+    data class Failed(
+        override val passName: String,
+        val cause: Throwable,
+    ) : ConsolidationPassResult()
+}
+```
 
 - **`Changed`** — propositions to upsert (`propositionsToSave`), ids to hard-delete
   (`propositionsToDelete`, honored only when the orchestrator opts in), a `skipped` count, and an
@@ -77,9 +109,10 @@ A result is one of three things, sealed so the orchestrator handles every case:
 - **`Failed`** — the pass threw; the orchestrator records it and continues with the remaining passes
   rather than aborting the cycle.
 
-Passes must be **idempotent**: running one twice over an unchanged snapshot must yield `NoOp`, because
-the loop runs passes repeatedly until the snapshot settles. A pass that always reports `Changed` would
-loop forever.
+Passes must be **idempotent**: running one twice over an unchanged snapshot must yield `NoOp`. Each
+pass runs exactly once per scheduled cycle, not in a repeat-until-settled loop within a cycle — a pass
+that always reports `Changed` just re-saves its propositions every cycle rather than looping forever.
+Convergence happens across successive scheduled cycles, not within a single one.
 
 ## The four passes that ship
 
@@ -105,6 +138,41 @@ unordered pair once, so a symmetric reviser can't retire both members and leave 
 save/delete lists and reports the count via `externallyApplied`, avoiding a double write.
 
 ## How a cycle composes them
+
+An orchestrator is assembled with `DefaultDreamLoopOrchestrator.withRepository(...)`'s builder,
+registering passes in the order they should run:
+
+```kotlin
+val orchestrator = DefaultDreamLoopOrchestrator.withRepository(repository)
+    .withPass(sessionConsolidationPass)
+    .withPass(abstractionPass)
+    .withPass(contradictionResolutionPass)
+    .withPass(decaySweepPass)
+
+// Scheduled / threshold-gated: may return null if little has changed.
+val maybeReport = orchestrator.consolidate(contextId)
+
+// Always runs.
+val report = orchestrator.consolidateNow(contextId)
+```
+
+`DecaySweepPass` is the report-only pass mentioned above: it drives its own `CollectorRunner` and
+writes the `STALE` transitions itself, then reports the count back as `externallyApplied` instead of
+via `propositionsToSave`, so `DreamLoopReport.totalTransitioned` still reflects the work without the
+orchestrator writing the same transition a second time:
+
+```kotlin
+ConsolidationPassResult.Changed(
+    passName = name,
+    propositionsToSave = emptyList(),
+    propositionsToDelete = emptyList(),
+    skipped = result.skipped.size,
+    externallyApplied = result.applied.size + result.hardDeleted.size,
+    summary = "decay sweep: ${result.applied.size} -> STALE, ${result.hardDeleted.size} hard-deleted",
+)
+```
+
+(from `DecaySweepPass.run`, `dice/src/main/kotlin/com/embabel/dice/operations/consolidation/DecaySweepPass.kt`)
 
 `consolidateNow` is the cycle. It does six things in order, and the shape is deliberate:
 

--- a/docs/design/durable-storage.md
+++ b/docs/design/durable-storage.md
@@ -34,36 +34,48 @@ classDiagram
     class VectorSearchCapable {
         <<interface>>
         +findSimilarWithScores(request) List
-        +findClusters(contextId) List
+        +findClusters(similarityThreshold, topK, query) List
     }
     class GraphTraversalCapable {
         <<interface>>
-        +findAbstractionSources(propositionId) List
-        +findDerivedFrom(propositionId) List
+        +findSources(proposition) List
+        +findAbstractionsOf(propositionId) List
     }
     class TemporalQueryCapable {
         <<interface>>
-        +findByValidWindow(contextId, from, to) List
-        +findByObservedWindow(contextId, from, to) List
-    }
-    class GraphQueryCapable {
-        <<interface>>
-        +honorsAuthorityFilter Boolean
-        +neighborhood(entityId, depth) GraphNeighborhood
-        +pathBetween(entityIdA, entityIdB) List
-        +whyExplain(propositionId) PropositionLineage
+        +findByCreatedBetween(start, end) List
+        +findByRevisedBetween(start, end) List
+        +findAllOrderedByEffectiveConfidence(k) List
     }
     PropositionRepository --|> PropositionStore
     PropositionRepository --|> VectorSearchCapable
     PropositionRepository --|> GraphTraversalCapable
     PropositionRepository --|> TemporalQueryCapable
-    PropositionRepository --|> GraphQueryCapable
 ```
 
-`DrivinePropositionRepository` (in `dice-storage`) implements all four capability fragments.
-`InMemoryPropositionRepository` (in `dice`) implements the base store plus vector search, but not
-graph traversal or temporal queries, because it can't genuinely back them. The backend declares what
-it supports; callers degrade rather than break when a capability is absent.
+`DrivinePropositionRepository` (in `dice-storage`) implements all three capability fragments plus
+`CoreSearchOperations`. `InMemoryPropositionRepository` (in `dice`) implements the base store plus
+vector search, but not graph traversal or temporal queries, because it can't genuinely back them.
+The backend declares what it supports; callers degrade rather than break when a capability is
+absent.
+
+A fourth interface, `GraphQueryCapable`, adds native neighbourhood, path, and lineage queries for a
+graph-native backend — it is not part of `PropositionRepository`. The durable Neo4j backend
+implements it, so graph queries there run as native Cypher; a store without it falls back to the
+portable, store-agnostic walk (see [retrieval-and-discovery](retrieval-and-discovery.md#store-agnostic-graph-queries)).
+
+Callers check for a capability with an `is`/`as?` test rather than calling and guessing from an empty
+result:
+
+```kotlin
+fun supports(mode: RetrievalMode): Boolean = when (mode) {
+    RetrievalMode.VECTOR -> store is VectorSearchCapable
+    RetrievalMode.TEMPORAL -> store is TemporalQueryCapable
+    RetrievalMode.ENTITY -> true
+    RetrievalMode.GRAPH_WALK -> true
+    RetrievalMode.HYBRID -> store is VectorSearchCapable
+}
+```
 
 ## Choosing a backend without choosing it
 
@@ -87,11 +99,21 @@ flowchart TD
     M --> SAME
 ```
 
-The point is that the rest of DICE is written against the SPIs and never learns which backend won.
-The graph backend even declares only the capabilities it can genuinely honour (vector search, graph
-traversal, temporal queries, graph query); a leaner backend simply doesn't claim them, and callers
-degrade rather than break — the same "declare only what you really support" stance the store layer
-takes everywhere.
+The point is that the rest of DICE is written against the SPIs and never learns which backend won —
+callers degrade rather than break when a capability is absent, the same stance the store layer takes
+everywhere.
+
+A consuming application overrides the default wiring by defining its own bean; autoconfig backs off
+because the default is `@ConditionalOnMissingBean(PropositionRepository::class)`:
+
+```kotlin
+@Configuration
+class MyStoreConfiguration {
+
+    @Bean
+    fun propositionRepository(): PropositionRepository = MyCustomPropositionRepository()
+}
+```
 
 ## Dedup as defense in depth
 
@@ -119,7 +141,17 @@ flowchart TB
 
 Two layers because each covers the other's blind spot: the lock is fast but only sees one instance,
 the constraint is global but only fires after the fact. Together they make "the same fact, minted
-twice" converge to one node no matter how the writes interleave.
+twice" converge to one node no matter how the writes interleave. Saving the same fact twice returns
+the same id rather than minting a twin:
+
+```kotlin
+val fact = Proposition(contextId = ContextId("ctx"), text = "Rod visited Sydney", mentions = emptyList(), confidence = 0.9)
+
+val first = repository.save(fact)
+val second = repository.save(fact)
+
+check(first.id == second.id) { "same (contextId, text) must dedup to one node" }
+```
 
 ## Two-phase save: authoritative facts, append-only evidence
 
@@ -144,7 +176,18 @@ sequenceDiagram
 
 The consequence is that a routine save can't accidentally erase the evidence behind a fact. Replacing
 provenance is therefore a *deliberate* act through explicit set/clear provenance calls — never a side
-effect of an ordinary update.
+effect of an ordinary update:
+
+```kotlin
+// Routine save: preserves any provenance the loaded proposition already carries.
+repository.save(proposition.withText("Rod visited Sydney last week"))
+
+// Deliberate replace: authoritatively sets provenance to exactly these entries.
+repository.setProvenance(proposition.id, newEntries)
+
+// Deliberate wipe: removes all provenance.
+repository.clearProvenance(proposition.id)
+```
 
 ## Materialised effective confidence
 
@@ -202,3 +245,39 @@ Backend choice, every store bean, the schema catalogs, and the decay schedule ar
 define your own bean and the autoconfig backs off. What ships is safe by default: in-memory unless
 asked otherwise, dedup enforced in two independent layers, provenance never dropped by a routine
 save, and decay that ages knowledge gently rather than deleting it.
+
+## Config-property reference
+
+All store-oriented properties are bound by `DiceStoreProperties` in `dice-storage-autoconfigure`
+under prefix `embabel.dice.store`. (The collector's own properties, `CollectorProperties` under
+`embabel.dice.collector`, are documented in depth in
+[multi-signal-collector.md](multi-signal-collector.md#configuration-embabeldicecollector) — not
+repeated here.)
+
+| Property | Type | Default | Meaning |
+|---|---|---|---|
+| `embabel.dice.store.type` | `String` | `in-memory` | Backend kind: `graph` (Drivine/Neo4j) or anything else (in-memory). Drives the flowchart in [Choosing a backend without choosing it](#choosing-a-backend-without-choosing-it). |
+| `embabel.dice.store.decay.enabled` | `Boolean` | `true` | Master switch for the scheduled decay tick. `false` means `@EnableScheduling` never switches on for decay. |
+| `embabel.dice.store.decay.interval-ms` | `Long` | `3600000` (1 hour) | Delay between decay ticks, in milliseconds. |
+| `embabel.dice.store.decay.k` | `Double` | `2.0` | Decay-rate multiplier `k` for the staleness policy (see [proposition-lifecycle](proposition-lifecycle.md)). |
+| `embabel.dice.store.decay.prune-stale` | `Boolean` | `false` | Opt-in hard-delete of `STALE` propositions during the lifecycle sweep. Left `false`, `STALE` propositions are kept (reversible). |
+| `embabel.dice.store.vector-index.enabled` | `Boolean` | `true` | Whether the graph backend declares its vector index (graph backend only). Label, property name, and similarity metric are fixed by the `@VectorIndex` annotation on `PropositionNode.embedding`, not configurable here. |
+
+### How to configure the store: a worked example
+
+A deployment that wants the graph backend, a faster decay tick, and pruning turned on:
+
+```yaml
+embabel:
+  dice:
+    store:
+      type: graph
+      decay:
+        interval-ms: 900000   # 15 minutes
+        k: 2.5
+        prune-stale: true
+```
+
+Everything else — vector index, dedup, schema catalogs — keeps its safe default. Because every
+store bean is `@ConditionalOnMissingBean`, an application can still override any single piece (say,
+its own `GraphDecayManager`) without touching this file at all.

--- a/docs/design/entity-resolution-and-text2graph.md
+++ b/docs/design/entity-resolution-and-text2graph.md
@@ -1,0 +1,280 @@
+# Entity resolution and text2graph
+
+Turning free text into a knowledge graph means answering the same question over and over: *is
+this the entity I already know about, or a new one?* Get it wrong cheaply — miss the LLM budget,
+say yes to everything — and the graph fills with duplicate nodes ("Watson", "Dr. Watson", "John
+H. Watson") that never converge. Get it right expensively — call an LLM for every mention — and
+ingestion is too slow and costly to run at scale. This subsystem is built around escalation: try
+the cheap, deterministic matchers first, and only pay for an LLM when the cheap matchers are
+genuinely unsure.
+
+Two things live here, and they compose but aren't the same thing:
+
+- **Entity resolution** (`com.embabel.dice.entity`, `com.embabel.dice.common.resolver`) — given a
+  *suggested* entity (a name, some labels, maybe a summary), find or create the *canonical* entity
+  it refers to.
+- **text2graph** (`com.embabel.dice.text2graph`) — the pipeline that turns chunks of text into a
+  `KnowledgeGraphDelta`: it extracts entities and relationships, resolves the entities via the
+  resolver above, and resolves/merges the relationships.
+
+Neither of these is `projection.graph` (the persistent-store projector covered in
+[graph-projection](graph-projection.md)). See [How this differs from projection.graph](#how-this-differs-from-projectiongraph)
+below — the naming collision is a real trap, not a stylistic choice.
+
+## Entity extraction
+
+`EntityExtractor` (`com.embabel.dice.entity.EntityExtractor`) is the narrow half of source
+analysis: given a `Chunk` and a `SourceAnalysisContext` (schema + config), it returns
+`SuggestedEntities` — no relationships, no resolution, just "here's what I think I saw." It exists
+as a simpler alternative to `SourceAnalyzer` (below) for callers who only need entities — for
+example `EntityResolutionService`, which resolves directly-asserted entities with no text at all.
+
+The shipped implementation, `LlmEntityExtractor`, prompts an LLM against the schema and parses the
+response into `ExtractedEntityInfo` (labels, name, summary, optional id, properties), then converts
+each to a `SuggestedEntity` tagged with the source `chunkId`. The `id` field matters later: if the
+extractor (or a caller) already knows the entity's identity — because the assertion carries a
+UUID — resolution can skip straight to an ID lookup instead of guessing from the name.
+
+```kotlin
+val extractor: EntityExtractor = LlmEntityExtractor
+    .withLlm(llmOptions)
+    .withAi(ai)
+val suggested: SuggestedEntities = extractor.suggestEntities(chunk, context)
+```
+
+## The resolver chain
+
+`EntityResolver` is the interface (`com.embabel.dice.common.EntityResolver`); `EscalatingEntityResolver`
+is the production implementation. It walks a list of `CandidateSearcher`s cheapest-first, stopping
+as soon as one is confident. If nobody's confident, the accumulated candidates go to an optional
+LLM `CandidateBakeoff`; if that also comes up empty, a new entity is minted — or vetoed if the
+schema doesn't permit creating that type.
+
+```mermaid
+flowchart TD
+    S[SuggestedEntity] --> ID["ByIdCandidateSearcher<br/>(exact id lookup)"]
+    ID -->|confident| DONE[ExistingEntity]
+    ID -->|no match| EXACT["ByExactNameCandidateSearcher<br/>(case-insensitive exact name)"]
+    EXACT -->|confident| DONE
+    EXACT -->|no match| NORM["NormalizedNameCandidateSearcher<br/>(strip titles/suffixes)"]
+    NORM -->|confident| DONE
+    NORM -->|no match| PART["PartialNameCandidateSearcher<br/>('Holmes' vs 'Sherlock Holmes')"]
+    PART -->|confident| DONE
+    PART -->|no match| FUZZY["FuzzyNameCandidateSearcher<br/>(Levenshtein distance)"]
+    FUZZY -->|confident| DONE
+    FUZZY -->|no match| VEC["VectorCandidateSearcher<br/>(embedding similarity)"]
+    VEC -->|confident, 1 hit >= 0.95| DONE
+    VEC -->|candidates, none confident| BAKE{"CandidateBakeoff<br/>configured?"}
+    BAKE -->|no / heuristicOnly| NEW{"schema permits<br/>creation?"}
+    BAKE -->|yes| LLM["LLM picks best match<br/>(or none) from candidates"]
+    LLM -->|match| DONE
+    LLM -->|no match| NEW
+    NEW -->|yes| NEWENT[NewEntity]
+    NEW -->|no| VETO[VetoedEntity]
+```
+
+Each searcher returns a `SearchResult`: either a single `confident` match (resolution stops right
+there) or a list of `candidates` that get carried forward. "Confident" always means *exactly one*
+hit clears that searcher's bar — two plausible hits is exactly the ambiguity the LLM tier exists
+to resolve, so no heuristic searcher is allowed to guess between them.
+
+The default chain, cheapest to most expensive (`DefaultCandidateSearchers.create`):
+
+| # | Searcher | Confident when | Notes |
+|---|----------|-----------------|-------|
+| 1 | `ByIdCandidateSearcher` | `suggested.id` set and resolves to exactly one row | Skips search entirely — used when the caller already knows the identity |
+| 2 | `ByExactNameCandidateSearcher` | exactly one exact (case-insensitive) name match | |
+| 3 | `NormalizedNameCandidateSearcher` | exactly one match after stripping titles/suffixes | "Dr. Watson" → "Watson" |
+| 4 | `PartialNameCandidateSearcher` | exactly one partial match, part ≥ `minPartLength` (default 4) | "Holmes" → "Sherlock Holmes"; "Doe" is too short to match "John Doe" |
+| 5 | `FuzzyNameCandidateSearcher` | exactly one match within a Levenshtein ratio (default 0.2) | catches typos |
+| 6 | `VectorCandidateSearcher` | exactly one embedding hit ≥ `autoAcceptThreshold` (default 0.95) | anything ≥ `candidateThreshold` (0.7) becomes a bakeoff candidate |
+| 7 | `AgenticCandidateSearcher` | LLM-driven, iterative `ToolishRag` search | not in the default chain — opt in when entities have many aliases/translations (musical works, place names) and the fixed heuristics above can't cover it |
+
+`EscalatingEntityResolver.create(repository, bakeoff)` wires searchers 1–6; `withoutVector` drops
+the embedding searcher for stores with no vector index. Add `AgenticCandidateSearcher` explicitly
+as the last searcher when your domain needs it — see its kdoc for when that trade-off is worth it.
+
+### Resolving one mention
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Caller
+    participant Resolver as EscalatingEntityResolver
+    participant Searchers as CandidateSearcher chain
+    participant Bakeoff as CandidateBakeoff (LLM)
+    Caller->>Resolver: resolve(suggestedEntities, schema)
+    loop each SuggestedEntity
+        Resolver->>Searchers: search(suggested, schema), cheapest first
+        alt a searcher is confident
+            Searchers-->>Resolver: SearchResult(confident = match)
+            Resolver-->>Caller: ExistingEntity(suggested, match)
+        else all candidates exhausted, none confident
+            Searchers-->>Resolver: accumulated candidates (deduped by id)
+            alt bakeoff configured and not heuristicOnly
+                Resolver->>Bakeoff: selectBestMatch(suggested, candidates, sourceText)
+                Bakeoff-->>Resolver: best match or null
+                alt match found
+                    Resolver-->>Caller: ExistingEntity(suggested, bestMatch)
+                else no match
+                    Resolver-->>Caller: NewEntity or VetoedEntity
+                end
+            else no bakeoff
+                Resolver-->>Caller: NewEntity or VetoedEntity
+            end
+        end
+    end
+```
+
+Note the escalation levels tracked alongside the walk (`ResolutionLevel`: `EXACT_MATCH` →
+`HEURISTIC_MATCH` → `EMBEDDING_MATCH` → `LLM_VERIFICATION` (exactly one candidate reached the LLM)
+→ `LLM_BAKEOFF` (multiple candidates) → `NO_MATCH`). `EscalatingEntityResolver` logs a count per
+level for the whole batch — that's the signal to watch if resolution quality regresses: a spike in
+`LLM_BAKEOFF` or `NO_MATCH` usually means the heuristic tiers stopped covering your data (new
+naming convention, new language, near-duplicate seed data), not that the LLM tier is broken.
+
+Each `CandidateSearcher` declares its own `resolutionLevel`, so the count is accurate whatever the
+chain's length or order: the exact searchers report `EXACT_MATCH`, the normalized/partial/fuzzy
+searchers `HEURISTIC_MATCH`, and the vector searcher `EMBEDDING_MATCH`.
+
+### The four resolution outcomes
+
+`SuggestedEntityResolution` (`com.embabel.dice.common`) is sealed over four cases, each meaning
+something different downstream:
+
+- **`NewEntity`** — nothing matched and creation is permitted. `recommended` is the suggested
+  entity's own data.
+- **`ExistingEntity`** — a match was found. `recommended` merges labels from both suggested and
+  existing (so a `Person` later identified as a `Detective` ends up with both labels) and unions
+  properties, preferring the existing entity's description.
+- **`ReferenceOnlyEntity`** — a match exists but must not be modified (e.g. the current user,
+  managed externally). Referenced but excluded from `updatedEntities`.
+- **`VetoedEntity`** — no match, and the schema's `DataDictionary.domainTypeForLabels(...)` says
+  this type can't be created (`creationPermitted == false`). The mention is dropped, not persisted.
+
+Downstream code (`EntityResolutionService`, `KnowledgeGraphDelta`) branches on this sealed type
+rather than on a boolean "found/not found" — that's the same shape of decision as projection's
+`CreateNew`/`Adopt`/`Align`/skip/fail in [graph-projection](graph-projection.md#projection-outcomes),
+for the same reason: collapsing distinct outcomes into a boolean throws away information a later
+stage needs.
+
+### Standalone entity assertion: `EntityResolutionService`
+
+Not every entity comes from text. `EntityResolutionService`
+(`com.embabel.dice.entity.EntityResolutionService`) exposes the resolver chain as a first-class
+operation for callers who already have a name/labels/properties in hand — no chunk required. It
+turns each `EntityAssertion` into a `SuggestedEntity`, runs it through the full escalation chain,
+persists the outcome (`save` for `NewEntity`, `update` for `ExistingEntity`), and then creates the
+requested `RelationshipAssertion`s between resolved entities — skipping any relationship whose
+endpoint was vetoed.
+
+```kotlin
+val service = EntityResolutionService(entityResolver, repository, schema)
+val result = service.resolve(
+    EntityAssertionRequest(
+        entities = listOf(EntityAssertion(labels = listOf("Person"), name = "Ada Lovelace")),
+        relationships = listOf(RelationshipAssertion(source = "Ada Lovelace", target = "Analytical Engine", type = "DESIGNED")),
+    )
+)
+```
+
+The key difference from the text2graph pipeline below: **every** asserted entity is persisted here
+— there's no "referenced entity IDs" gate filtering out entities that were only mentioned in
+passing. If you're asserting it directly, you meant it.
+
+## text2graph: from chunks to a graph delta
+
+`SourceAnalyzer` (`com.embabel.dice.text2graph.SourceAnalyzer`) is the superset of
+`EntityExtractor`: per chunk, it suggests entities *and* suggests relationships between already-
+resolved entities. It explicitly does not do disambiguation or merging — that's `KnowledgeGraphBuilder`'s
+job, one layer up.
+
+`KnowledgeGraphBuilder.computeDelta(chunks, context)` is the orchestrator. The shipped
+`MultiPassKnowledgeGraphBuilder` runs, per chunk:
+
+1. `sourceAnalyzer.suggestEntities(chunk, context)` → `SuggestedEntities`
+2. `entityResolver.resolve(suggestedEntities, schema)` → the escalating chain above
+3. `sourceAnalyzer.suggestRelationships(chunk, entityResolutions, context)` → `SuggestedRelationships`
+4. `relationshipResolver.resolveRelationships(...)` → `NewRelationship` / `ExistingRelationship`
+5. `entityMergePolicy` / `relationshipMergePolicy` decide what actually goes into the delta
+
+...and accumulates everything across chunks into one `KnowledgeGraphDelta` (`entityMerges`,
+`relationshipMerges`), which exposes `newEntities()`, `mergedEntities()`, `newOrModifiedEntities()`
+(deduplicated by ID, merged entities' upgraded labels winning) and the relationship equivalents.
+
+`RelationshipResolver` mirrors the entity side but is simpler — there's no escalating searcher
+chain, just a decision between `NewRelationship` (suggested as-is) and `ExistingRelationship`
+(matches something already in the graph). The shipped `AcceptSuggestionRelationshipResolver`
+accepts every suggestion as new; swap in your own when you need relationship-level dedup (e.g. "same
+type between the same two resolved entities is one edge, not N").
+
+```kotlin
+val builder = KnowledgeGraphBuilders
+    .withSourceAnalyzer(LlmSourceAnalyzer(ai, llmOptions))
+    .withEntityResolver(EscalatingEntityResolver.create(repository, bakeoff))
+
+val delta = builder.knowledgeGraphBuilder().computeDelta(chunks, sourceAnalysisContext)
+// or, to get domain objects directly:
+val objects = builder.projector().project(chunks, sourceAnalysisContext)
+```
+
+`KgbBuilder.projector()` hands you a `ToObjects` wrapper around a
+`text2graph.builder.GraphProjector<Any>` (default `InMemoryObjectGraphGraphProjector`) — its
+`project(chunks, context)` walks the delta and instantiates domain objects (`Person`, `Animal`, ...)
+with relationships wired as real object references, sharing one instance per entity ID. It's an
+in-memory object graph, not a persistence step. (This is the one canonical example of the builder
+chain; see [Common use cases](#common-use-cases-and-how-to-extend) for how it composes with
+resolution options like `bakeoff`/`heuristicOnly`.)
+
+## How this differs from projection.graph
+
+There are, deliberately or not, **two different types both named `GraphProjector`** in this
+codebase:
+
+| | `com.embabel.dice.text2graph.builder.GraphProjector<E>` | `com.embabel.dice.projection.graph.GraphProjector` |
+|---|---|---|
+| Input | a `KnowledgeGraphDelta` from text2graph | `Proposition`s from the durable store |
+| Output | in-memory domain objects (`List<E>`), or a rooted object graph | edges/nodes written to a target backend, with a `ProjectionRecord` per outcome |
+| Concerned with | turning *this batch's* extraction result into usable Kotlin/Java objects | lineage, authority tiers, staleness, re-projection over the store's whole lifetime — see [graph-projection](graph-projection.md) |
+| Lifetime | one call, one delta, done | ongoing — the same proposition can be reconciled and re-projected many times |
+
+If you're extracting facts from a document right now and want typed objects back, you want
+text2graph's `GraphProjector`. If you're asking "should this durable proposition update the graph,
+and do we have an auditable trail for it," you want projection.graph's — read
+[graph-projection](graph-projection.md) for that side. Don't let the shared name make you reach for
+the wrong one; check the package.
+
+The two subsystems also compose in one direction: relationships/entities
+extracted through text2graph frequently *become* `Proposition`s that then flow through the
+projection pipeline for durable storage — text2graph is upstream of proposition creation, not a
+replacement for it.
+
+## Common use cases and how to extend
+
+**Run extraction → resolution end to end** (the common path — most callers want
+`KnowledgeGraphBuilders`, not the pieces directly) — see the builder chain example under
+[text2graph: from chunks to a graph delta](#text2graph-from-chunks-to-a-graph-delta).
+
+**Assert entities directly, no text involved** — use `EntityResolutionService` (above), not
+`KnowledgeGraphBuilder`.
+
+**Add a new `CandidateSearcher`** — implement `search(suggested, schema): SearchResult`, return
+`SearchResult.confident(match)` only when you're certain there's exactly one right answer, or
+`SearchResult.candidates(list)` otherwise. Insert it into the chain at the right cost tier: cheaper
+than vector search but more specific than fuzzy matching, for example, goes between `FuzzyNameCandidateSearcher`
+and `VectorCandidateSearcher` in your own list passed to `EscalatingEntityResolver(searchers = ...)`
+(the `DefaultCandidateSearchers` factory is a convenience default, not the only valid chain).
+
+**Add a new `EntityResolver` entirely** (rare) — implement the `EntityResolver` interface directly if
+escalation-over-searchers isn't the right shape for your store (e.g. `InMemoryEntityResolver` /
+`KnownEntityResolver` for tests and seed scenarios that never need to match against real data).
+
+**Tune bakeoff behavior** — pass a `CandidateBakeoff` (e.g. `LlmCandidateBakeoff`) to get LLM
+arbitration; omit it (or set `Config(heuristicOnly = true)`) to stop at the searcher tier and
+always mint new entities when heuristics are unsure. Use `heuristicOnly` for cost-sensitive or
+offline paths where an occasional duplicate is cheaper than an LLM call per ambiguous mention.
+
+**Add a new `RelationshipResolver`** — implement `resolveRelationships`, returning `NewRelationship`
+or `ExistingRelationship` per suggestion; use the already-resolved `entityResolution` to check
+whether a matching edge already exists between those two resolved entities before accepting a new
+one.

--- a/docs/design/events.md
+++ b/docs/design/events.md
@@ -2,7 +2,7 @@
 
 DICE emits domain events as it works — a fact was persisted, a proposition changed status, a batch
 finished — so other parts of a system can react without DICE having to know about them. This note
-covers the event model and what the store and pipeline emit; it's the seam that loosely couples the
+covers the event model and what the store and pipeline emit; it's the extension point that loosely couples the
 substrate to whatever observes it.
 
 ## The model
@@ -41,6 +41,8 @@ flowchart TB
     DE["DiceEvent (marker)"]
     PE["PropositionPersisted<br/>(save — no status change)"]
     SC["PropositionStatusChanged<br/>(previous + new status + reason)"]
+    PIN["PropositionPinned<br/>(exempted from decay)"]
+    UNP["PropositionUnpinned<br/>(back in scope for decay)"]
     PBC["ProjectionBatchCompleted<br/>(success / skip / fail counts)"]
     EBC["ExtractionBatchCompleted<br/>(run statistics)"]
     PD["PropositionDiscovered<br/>(revision: new fact)"]
@@ -48,8 +50,14 @@ flowchart TB
     PR["PropositionReinforced<br/>(revision: similar)"]
     PC["PropositionContradicted<br/>(revision: conflict)"]
     PG["PropositionGeneralized<br/>(revision: generalizes)"]
+    REJ["PropositionRejected<br/>(gate: discarded)"]
+    RTR["PropositionRoutedToReview<br/>(gate: needs a second look)"]
+    SKIP["PropositionProjectionSkipped<br/>(gate: saved but not projected)"]
+    DEM["PropositionDemoted<br/>(gate: relation weakened)"]
     DE --> PE
     DE --> SC
+    DE --> PIN
+    DE --> UNP
     DE --> PBC
     DE --> EBC
     DE --> PD
@@ -57,6 +65,10 @@ flowchart TB
     DE --> PR
     DE --> PC
     DE --> PG
+    DE --> REJ
+    DE --> RTR
+    DE --> SKIP
+    DE --> DEM
 ```
 
 ## What the store and pipeline emit
@@ -80,8 +92,73 @@ new proposition against what's stored — **`PropositionDiscovered`**, **`Propos
 **`ExtractionBatchCompleted`** with run statistics at the end of a batch. These are pre-persistence
 signals about what the reviser decided; the durable record of a save is still `PropositionPersisted`.
 
+## The emitter map
+
+Events aren't limited to the store and pipeline above — several other components emit them too. This is
+every emitter in the system today, and what each one puts out:
+
+```mermaid
+flowchart LR
+    REPO["EventEmittingPropositionRepository<br/>(store decorator)"] -->|"PropositionPersisted<br/>PropositionStatusChanged"| L((DiceEventListener))
+    PROJ["EventEmittingProjector<br/>(projection decorator)"] -->|ProjectionBatchCompleted| L
+    PIPE["PropositionPipeline<br/>(revision reconciliation)"] -->|"PropositionDiscovered<br/>PropositionMerged<br/>PropositionReinforced<br/>PropositionContradicted<br/>PropositionGeneralized<br/>PropositionRoutedToReview<br/>ExtractionBatchCompleted"| L
+    GATE["ObservableGate<br/>(admission gate decorator)"] -->|"PropositionRejected<br/>PropositionRoutedToReview<br/>PropositionProjectionSkipped<br/>PropositionDemoted"| L
+    COLLECTOR["DefaultCollectorRunner<br/>(reclamation sweep)"] -->|PropositionStatusChanged| L
+    DREAM["ContradictionResolutionPass<br/>(dream-loop consolidation)"] -->|PropositionRoutedToReview| L
+    T2G["MultiPassKnowledgeGraphBuilder<br/>(text2graph entity resolution)"] -->|NewEntity| L
+    L --> CASCADE["ProjectionLineageStaleCascade<br/>(built-in consumer)"]
+    L --> C["your consumers:<br/>audit, dashboards, indexes"]
+    CASCADE -.->|"marks ProjectionRecord STALE<br/>on terminal PropositionStatusChanged"| LIN[(ProjectionRecordStore)]
+```
+
+Source locations for each emitter: `EventEmittingPropositionRepository`
+(`dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingPropositionRepository.kt`),
+`EventEmittingProjector`
+(`dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingProjector.kt`),
+`PropositionPipeline`
+(`dice/src/main/kotlin/com/embabel/dice/pipeline/PropositionPipeline.kt:269-280,499`),
+`ObservableGate`
+(`dice/src/main/kotlin/com/embabel/dice/proposition/gate/ObservableGate.kt:72-88`),
+`DefaultCollectorRunner`
+(`dice/src/main/kotlin/com/embabel/dice/projection/memory/DefaultCollectorRunner.kt:291`),
+`ContradictionResolutionPass`
+(`dice/src/main/kotlin/com/embabel/dice/operations/consolidation/ContradictionResolutionPass.kt:96`),
+`MultiPassKnowledgeGraphBuilder`
+(`dice/src/main/kotlin/com/embabel/dice/text2graph/support/MultiPassKnowledgeGraphBuilder.kt:71`).
+
+Two things worth noticing in that map:
+
+- If you need the cause of a `PropositionStatusChanged`, use the `reason` field rather than trying
+  to infer it from which emitter fired — it's a comma-joined list of `MarkReason.key` values (e.g.
+  `"duplicate"`, or `"stale,duplicate"` when more than one strategy marked the same proposition).
+- **`ProjectionLineageStaleCascade` is a listener that is also an internal consumer** — it doesn't
+  emit new `DiceEvent`s, but it reacts to `PropositionStatusChanged` by writing to the
+  `ProjectionRecordStore` directly. If you're deciding whether your own consumer belongs beside it
+  (in-process, synchronous) or as an out-of-process subscriber, the deciding factor is exactly
+  what it optimizes for: cascade must run before the sweep that triggered it returns, because lineage
+  staleness is part of the same consistency boundary as the status change.
+
 ## Wiring
 
 Events are off until you wire them. Wrap the store and projector in their event-emitting decorators,
 hand a listener to the pipeline, and combine several listeners with `CompositeDiceEventListener`.
 Every event is set up for polymorphic JSON, so a listener can forward them out of process.
+
+```kotlin
+val repo = EventEmittingPropositionRepository(
+    delegate = inMemoryRepository,
+    listener = SafeDiceEventListener(myListener),
+)
+```
+
+A listener is a one-method fun interface, so a lambda or a class both work:
+
+```kotlin
+val myListener = DiceEventListener { event ->
+    when (event) {
+        is PropositionPersisted -> println("saved: ${event.proposition.id}")
+        is PropositionStatusChanged -> println("${event.previousStatus} -> ${event.newStatus}: ${event.reason}")
+        else -> Unit
+    }
+}
+```

--- a/docs/design/extraction-pipeline.md
+++ b/docs/design/extraction-pipeline.md
@@ -35,7 +35,7 @@ flowchart LR
 
 The admission gates (see [knowledge-hygiene](knowledge-hygiene.md)) run between the pipeline result and the store — they are the caller's responsibility to apply.
 
-## Pipeline SPI seams
+## Pipeline extension points
 
 Every variable part of the pipeline is a pluggable interface. This is how they fit together:
 
@@ -43,12 +43,12 @@ Every variable part of the pipeline is a pluggable interface. This is how they f
 classDiagram
     class PropositionPipeline {
         +process(chunks, context) PropositionResults
-        +processOnce(text, sourceId, context, historyStore) PropositionResults
+        +processOnce(text, sourceId, context, historyStore) ChunkPropositionResult?
         +processChunk(chunk, context) ChunkResult
     }
     class PropositionExtractor {
         <<interface>>
-        +extract(chunk, context) ExtractionResult
+        +extract(chunk, context) SuggestedPropositions
     }
     class PropositionReviser {
         <<interface>>
@@ -60,7 +60,7 @@ classDiagram
     }
     class ExtractionGate {
         <<interface>>
-        +evaluate(proposition, context) GateDecision
+        +evaluate(proposition, context) GateEvaluation
     }
     class GateDecision {
         <<sealed>>
@@ -74,6 +74,32 @@ classDiagram
     PropositionPipeline --> PropositionReviser : stage 2 optional
     PropositionPipeline --> ExtractionExecutionStrategy : dispatches extraction
     ExtractionGate --> GateDecision : returns
+```
+
+## Using the pipeline
+
+Build a pipeline from an extractor, optionally chain in revision, then run it over chunks:
+
+```kotlin
+val pipeline = PropositionPipeline
+    .withExtractor(LlmPropositionExtractor(ai))
+    .withRevision(reviser, propositionRepository)  // Optional
+
+val result = pipeline.process(chunks, context)
+```
+
+A gate is a plain function from proposition + context to a routing decision, applied by the caller
+after the pipeline runs and before it saves anything:
+
+```kotlin
+val confidenceGate = ExtractionGate { proposition, _ ->
+    val decision = if (proposition.effectiveConfidence() < 0.5) {
+        GateDecision.Reject("confidence below threshold")
+    } else {
+        GateDecision.Persist
+    }
+    GateEvaluation("ConfidenceGate", proposition, decision)
+}
 ```
 
 ## Why extraction and resolution are separate
@@ -242,10 +268,6 @@ the store emits on save (see [events](events.md)). `processOnce` adds a hash che
 the same text is a no-op, and lets a caller attach extra grounding ids — the source records a fact
 came from — that later become provenance edges.
 
-## Configurable behavior
-
-The extractor, the optional reviser and mention filter, the event listener, and the execution
-strategy are all pluggable through the pipeline's fluent builders. What ships is intentionally
-conservative — serial execution, revision off, no persistence — so the safe, predictable behaviour
-is the default, and a deployment opts into concurrency, reconciliation, and its own write boundary
-as it needs them.
+Every piece here — extractor, reviser, mention filter, event listener, execution strategy — is
+pluggable through the pipeline's fluent builders, and what ships defaults to the conservative choice
+at each one (serial, revision off, no persistence).

--- a/docs/design/graph-projection.md
+++ b/docs/design/graph-projection.md
@@ -1,10 +1,10 @@
 # Graph projection: lineage, outcomes, and staleness
 
 DICE projects its propositions into a typed graph so they can be queried as entities and
-relationships. Projection is easy to get wrong in ways that quietly erode trust: edges with no trail
-back to their evidence, duplicate nodes on every re-run, and stale structure left behind when the
-underlying facts change. This note is about the decisions that keep the projected graph honest — not
-about the projector classes themselves.
+relationships. Projection can quietly erode trust: edges with no trail back to their evidence,
+duplicate nodes on every re-run, and stale structure left behind when the underlying facts change.
+This note is about the decisions that keep the projected graph honest — not about the projector
+classes themselves.
 
 ## The projection pipeline
 
@@ -16,30 +16,46 @@ an existing one, is skipped, or fails. The authority tier travels with the recor
 sequenceDiagram
     autonumber
     participant Caller
+    participant Service as GraphProjectionService
     participant Projector as GraphProjector
     participant Reconciler
-    participant Backend as Target backend
+    participant Backend as GraphRelationshipPersister
     participant Records as ProjectionRecordStore
-    Caller->>Projector: project(propositions, target)
-    loop each proposition
-        Projector->>Reconciler: reconcile(proposition, target)
-        Reconciler-->>Projector: CreateNew / Adopt / Align
-        alt CreateNew
-            Projector->>Backend: create new edge / node
-            Backend-->>Projector: targetRef
-        else Adopt
-            Projector->>Backend: point at existing node (targetRef from decision)
-        else Align
-            Projector->>Backend: merge attributes into existing node
-            Backend-->>Projector: targetRef
-        end
-        Projector->>Records: record(propositionId, target, lifecycle, authority)
+    Caller->>Service: projectAndPersist(propositions)
+    Service->>Projector: projectAll(propositions, schema)
+    Projector-->>Service: ProjectionResults<ProjectedRelationship>
+    loop each successful result
+        Service->>Reconciler: reconcile(proposition, target, projected)
+        Reconciler-->>Service: CreateNew / Adopt / Align
     end
-    Projector-->>Caller: ProjectionBatchResult
+    Service->>Backend: persist(projectionResults)
+    Backend-->>Service: RelationshipPersistenceResult
+    loop each result
+        Service->>Records: record(ProjectionRecord)
+    end
+    Service-->>Caller: Pair<ProjectionResults, RelationshipPersistenceResult>
 ```
 
-After the batch, the `EventEmittingProjector` decorator publishes a `ProjectionBatchCompleted`
-event so downstream consumers can react without polling.
+```kotlin
+val (projectionResults, persistenceResult) = graphProjectionService.projectAndPersist(propositions)
+projectionResults.results.forEach { result ->
+    when (result) {
+        is ProjectionSuccess -> println("projected: ${result.projected}")
+        is ProjectionSkipped -> println("skipped: ${result.reason}")
+        is ProjectionFailed -> println("failed: ${result.reason}")
+    }
+}
+```
+
+`GraphProjector` itself only does the classification step (`project`/`projectAll`, turning a
+proposition into a `ProjectedRelationship`); it has no notion of a reconciler, a backend, or a
+record store. Reconciliation, persistence, and lineage recording are all orchestrated by
+`GraphProjectionService.projectAndPersist`.
+
+`EventEmittingProjector` is a generic decorator available for any `Projector`: it wraps a
+delegate, forwards `projectAll`, and publishes a `ProjectionBatchCompleted` event afterwards so
+listeners can react without polling. It isn't wired into `GraphProjectionService` by default —
+use it if you want that event.
 
 ## Edge lineage
 
@@ -50,9 +66,14 @@ propositions and the authority tier of their source.
 
 The reason is auditability. An edge with no provenance is an opaque assertion: you can't ask "where
 did this come from?" or "how much should I trust it?" Keeping the record turns the graph into
-something you can interrogate. The record store is even reversible — given a node in the graph you
-can find every record that created or adopted it — so a graph artifact can always be traced back to
-the text that justified it.
+something you can interrogate. The record store is even reversible — given an artifact reference
+from the graph you can find every record that created or adopted it:
+
+```kotlin
+val records = recordStore.findByTargetRef(targetRef)
+```
+
+so a graph artifact can always be traced back to the text that justified it.
 
 Authority travels with the edge for the same reason it matters everywhere else (see
 [proposition-lifecycle](proposition-lifecycle.md)): a relationship derived from a first-party record
@@ -91,17 +112,21 @@ flowchart TD
 
 `CreateNew` creates a fresh artifact in the target backend. `Adopt` reuses an existing artifact verbatim — the proposition's projected identity becomes that node's reference. `Align` is the middle option: the proposition merges attributes into an existing artifact while keeping its own distinct identity (for example, a projector that enriches an existing entity node rather than pointing at it wholesale). The shipped `RepositoryBackedReconciler` uses exact entity-ID match to return `Adopt` or `CreateNew`; `Align` is available for backends that need finer-grained merging.
 
-## SPI seams for projection
+## SPI extension points for projection
 
 The projectors, the reconciler, and the record stores are all SPIs. Here is how they fit together:
 
 ```mermaid
 classDiagram
+    class GraphProjectionService {
+        +projectAndPersist(propositions) Pair
+    }
     class GraphProjector {
-        +project(propositions, target) ProjectionBatchResult
+        +project(proposition, schema) ProjectionResult
+        +projectAll(propositions, schema) ProjectionResults
     }
     class Reconciler {
-        +reconcile(proposition, target) ReconciliationDecision
+        +reconcile(proposition, target, projected) ReconciliationDecision
     }
     class ReconciliationDecision {
         <<sealed>>
@@ -131,8 +156,9 @@ classDiagram
         FAILED
         STALE
     }
-    GraphProjector --> Reconciler : delegates reconciliation
-    GraphProjector --> ProjectionRecordStore : writes outcome
+    GraphProjectionService --> GraphProjector : projects
+    GraphProjectionService --> Reconciler : delegates reconciliation
+    GraphProjectionService --> ProjectionRecordStore : writes outcome
     ProjectionRecordStore --> ProjectionRecord : stores
     ProjectionRecord --> ProjectionLifecycle : lifecycle field
     Reconciler --> ReconciliationDecision : returns
@@ -151,10 +177,10 @@ record derived from it as stale.
 Two deliberate choices live here. First, the trigger is the proposition's *status change*, not a
 manual sweep, so the graph self-heals as a side effect of the lifecycle rather than needing a
 separate reconciliation job to remember. Second, the cascade only marks the *records* stale; it
-doesn't rip out the actual edge. Edge removal or refresh is a re-projection concern, and keeping the
-cascade to a fast, idempotent "flag it" step means a status change never triggers expensive graph
-surgery inline. The stale flag is a signal to downstream consumers that the edge needs a refresh,
-not the refresh itself.
+doesn't rip out the actual edge. Edge removal or refresh is a re-projection concern — the stale flag
+is a signal to downstream consumers that the edge needs a refresh, not the refresh itself, and
+keeping the cascade to a fast, idempotent "flag it" step means a status change never triggers
+expensive graph surgery inline.
 
 The trigger is the `PropositionStatusChanged` event (see [events](events.md)) — this cascade is the
 one place DICE consumes its own events, so nothing has to remember to run it:
@@ -169,7 +195,6 @@ sequenceDiagram
     Life->>Bus: status becomes superseded / contradicted / stale
     Bus->>Cascade: deliver the change
     Cascade->>Records: markStaleByProposition(propositionId)
-    Note over Records: the graph edge is left intact — the mark is only a refresh signal for later
 ```
 
 ## Idempotent ingestion and reconciliation
@@ -183,13 +208,29 @@ and if extraction fails, the claim is released so a transient error doesn't perm
 re-ingestion. (A second, durable layer tracks processed chunks across sessions for the incremental
 path.)
 
-At the **graph end**, a reconciler checks the live graph before creating anything: if an entity a
-proposition mentions already exists, the projection adopts that node instead of minting a duplicate.
-The default match is exact-ID and deterministic — the reconciler would rather create a clean new
-node than guess a fuzzy match and merge two things that aren't the same.
+At the **graph end**, deduplication is opt-in, not the default. `GraphProjectionService` defaults
+to `AlwaysCreateReconciler`, which always returns `CreateNew` and never looks at the live graph —
+running it twice over the same content mints a new edge each time. To dedupe, configure a
+`RepositoryBackedReconciler`, which checks whether the exact edge already exists before deciding to
+adopt it:
+
+```kotlin
+val reconciler = RepositoryBackedReconciler(repository = namedEntityDataRepository)
+val service = GraphProjectionService(
+    graphProjector = graphProjector,
+    persister = persister,
+    schema = schema,
+    recordStore = recordStore,
+    reconciler = reconciler,
+)
+```
+
+The match is exact-ID and deterministic — it would rather create a clean new node than guess a
+fuzzy match and merge two things that aren't the same.
 
 The unifying idea is that ingestion and projection are operations you'll run repeatedly over
-overlapping material, so they're built to converge rather than accumulate.
+overlapping material, so they're built to converge rather than accumulate — but for the graph end,
+you have to ask for it.
 
 ## Backend access through a port
 
@@ -200,10 +241,10 @@ port. All the Neo4j-specific wiring lives in the storage module; domain code nev
 driver. Because the core talks only to those interfaces, you can swap the backend or test against an
 in-memory substitute.
 
-One consequence worth noting: the entity-repository-backed proposition store deliberately declares
-only what it can honestly support — plain storage and vector search — and not proposition-scoped
-graph traversal or temporal queries, because the entity-scoped repository can't genuinely back them.
-That's the same "declare only what you really support" stance the store layer takes.
+The entity-repository-backed proposition store follows the same "declare only what you really
+support" stance as the durable-storage design (see [durable storage](durable-storage.md)): it
+exposes plain storage and vector search, not proposition-scoped graph traversal or temporal
+queries, because the entity-scoped repository can't genuinely back them.
 
 ## Configurable behavior
 

--- a/docs/design/grounding-and-conflicts.md
+++ b/docs/design/grounding-and-conflicts.md
@@ -1,0 +1,399 @@
+# Grounding and conflict/SPI: how facts stay anchored and how clashes get resolved
+
+Two mechanisms gate whether a proposition can be trusted: **grounding** ties it back to the
+source material it came from, and the **conflict/policy SPI** decides what happens when two
+propositions disagree. This doc covers the interfaces those two mechanisms expose and how to use
+them (see the best-practices summary at the end for the short version); for the broader lifecycle
+they participate in — why CONTRADICTED and SUPERSEDED are different, why decay doesn't delete —
+see [proposition-lifecycle](proposition-lifecycle.md).
+
+## Grounding: evidence linking a proposition to its sources
+
+A `Proposition.grounding` field is a `List<String>` of ids — the extractor's claim about
+which source entities back this fact. On its own that's just strings sitting on the
+proposition; nothing forces them to resolve to anything real. Two collaborators turn that
+claim into an actual, queryable graph edge:
+
+- **`GroundingResolver`** (`dice/src/main/kotlin/com/embabel/dice/projection/grounding/GroundingResolver.kt`)
+  is the single, pluggable definition of what a grounding id *means* — given a grounding id,
+  which stored entity node(s) does it refer to? This exists so the resolution rule lives in
+  exactly one place instead of being reimplemented (inconsistently) by every caller that
+  needs to go from a grounding string to a node.
+- **`GroundingWiringService`** (`dice/src/main/kotlin/com/embabel/dice/projection/grounding/GroundingWiringService.kt`)
+  is the writer: it walks a batch of propositions, resolves each grounding id via a
+  `GroundingResolver`, and materializes a `(:Proposition)-[:GROUNDED_IN]->(:<entity>)` edge for
+  every hit.
+
+Why split resolution from writing? Because "what does this id mean" and "what do I do once I
+know" are different concerns with different failure modes — the resolver can be tested and
+reused (by the wiring service *and* by source-text readers) without dragging in graph-write
+side effects.
+
+### The resolution convention
+
+A grounding id is either the full node id (`email:<user>:<hash>`) or a namespace-stripped
+form (`email:<hash>`) that some extractors stamp. `DefaultGroundingResolver`
+(`dice/src/main/kotlin/com/embabel/dice/projection/grounding/DefaultGroundingResolver.kt`)
+resolves it in two steps:
+
+1. **Exact** — `findById(groundingId)`. Most groundings hit here.
+2. **Namespace suffix** — on a miss, match any entity whose id ends with the grounding id's
+   trailing segment (everything after the first `:`). This bridges `email:<hash>` grounding
+   to the stored `email:<user>:<hash>` node, mirroring how source-text readers have always
+   matched (`n.id ENDS WITH <suffix>`).
+
+A grounding id with no `:` (a bare chunk hash or free-text fingerprint) only ever matches
+exactly — legacy chunk ids stay unresolved and edge-free, exactly as before this resolver
+existed.
+
+```mermaid
+flowchart LR
+    P["Proposition.grounding: List of ids"] --> W[GroundingWiringService.wire]
+    W -->|resolveAll per id| R[GroundingResolver]
+    R -->|exact findById| M1{match?}
+    M1 -->|yes| N[NamedEntityData]
+    M1 -->|no, has a colon| M2[suffix scan: id ENDS WITH suffix]
+    M2 -->|unique or multiple| N
+    M2 -->|none| S[skipped: no entity match]
+    N --> E["mergeRelationship writes\nProposition GROUNDED_IN entity"]
+```
+
+**A single best match vs. all matches.** `GroundingResolver` exposes two methods for
+different callers: `resolveAll` returns every entity a grounding id resolves to (a
+proposition grounded in several sources legitimately backs several nodes — the wiring
+service uses this to write one edge per match), while `resolve` returns a single best
+match — the exact hit, or the unique suffix match — and returns `null` on ambiguity rather
+than guessing. **An ambiguous match is never silently collapsed to an arbitrary node.**
+Callers that need one canonical entity (not a fan-out of edges) use `resolve`.
+
+**Endpoint identity matters.** The wiring service always writes the edge using the
+*resolved* node's real id, never the raw grounding string — a stripped id used directly as
+an endpoint would `MERGE`-create a phantom bare `{id}` node instead of attaching to the real
+one. This is the kind of bug that's invisible in a unit test with one entity and only shows
+up once you have a namespace-suffix grounding pointed at a real, differently-shaped stored
+id — which is exactly the resolver's reason to exist as a shared interface rather than duplicated
+`ENDS WITH` logic per call site.
+
+**Backward compatible, best-effort.** `Proposition.grounding` is unchanged, still a
+`List<String>`. Ids that don't resolve (legacy chunk hashes, free-text fingerprints,
+message-level ids with no entity row of their own) are silently skipped — no edge, no error.
+Writing is idempotent via `mergeRelationship`, so re-running wiring over the same
+propositions never duplicates edges.
+
+### Wiring it up
+
+`GroundingWiringService` is optional and opt-in — it's wired into
+`IncrementalPropositionExtraction` (`dice/src/main/kotlin/com/embabel/dice/proposition/extraction/IncrementalPropositionExtraction.kt`)
+via an optional constructor parameter, and `PropositionPipeline`
+(`dice/src/main/kotlin/com/embabel/dice/pipeline/PropositionPipeline.kt`) documents the
+convention extractors follow when populating `grounding` so this wiring can resolve it later.
+Consumers who don't supply a `GroundingWiringService` see no behavior change — grounding ids
+sit on the proposition as before, just without materialized edges.
+
+```kotlin
+// The convention: pass the entity's stable id verbatim into Proposition.grounding.
+val proposition = Proposition(
+    text = "Alice works at Acme",
+    grounding = listOf(emailSignal.id), // e.g. "email:alice@acme.com:9f2a..."
+    // ...
+)
+
+// Somewhere batch-processing extracted propositions:
+val wiring = GroundingWiringService(entityRepository)
+val report = wiring.wire(propositions)
+// report.written / .skipped / .failed — log or assert on it; most callers just log the count
+```
+
+To use a custom resolution strategy (e.g. a different id convention for a specific
+source type), implement `GroundingResolver` and pass it into the wiring service's
+constructor instead of relying on `DefaultGroundingResolver`.
+
+## Conflict and policy SPI
+
+Grounding answers "is this fact backed by something real?" The conflict/policy SPI answers a
+different question: "what do we do when two facts disagree, and when does a proposition's
+lifecycle status actually change?" Four SPI types live in `com.embabel.dice.spi` and compose
+into that answer. `ConflictDetector` and `ConflictType` are introduced in
+[proposition-lifecycle](proposition-lifecycle.md)'s conflict-classification section; this doc
+documents their contract precisely, plus two SPI types not documented elsewhere:
+`StatusTransitionPolicy` and the mark-and-sweep pair `MarkReason`/`SweepPolicy` (the sweep
+*runtime* — how a collection run actually applies these — is covered operationally in
+[reclamation-and-collector](reclamation-and-collector.md); here is the SPI contract those
+runtimes are built against).
+
+```mermaid
+classDiagram
+    class ConflictDetector {
+        <<fun interface>>
+        +detect(incoming, existing) ConflictType
+    }
+    class ConflictType {
+        <<sealed interface>>
+    }
+    class Revision
+    class Contradiction
+    class WorldProgression
+    class Custom
+    ConflictType <|.. Revision
+    ConflictType <|.. Contradiction
+    ConflictType <|.. WorldProgression
+    ConflictType <|.. Custom
+    ConflictDetector ..> ConflictType : returns
+
+    class StatusTransitionPolicy {
+        <<fun interface>>
+        +evaluate(proposition) PropositionStatus?
+    }
+    class DecayStatusPolicy {
+        +evaluate(proposition) PropositionStatus?
+    }
+    StatusTransitionPolicy <|.. DecayStatusPolicy
+
+    class MarkReason {
+        <<sealed interface>>
+        +key String
+    }
+    class Stale
+    class Duplicate
+    class MarkReasonCustom["Custom"]
+    MarkReason <|.. Stale
+    MarkReason <|.. Duplicate
+    MarkReason <|.. MarkReasonCustom
+
+    class SweepPolicy {
+        <<fun interface>>
+        +decide(proposition, marks) SweepAction
+    }
+    class StatusTransitionSweepPolicy
+    class MergingSweepPolicy
+    SweepPolicy <|.. StatusTransitionSweepPolicy
+    SweepPolicy <|.. MergingSweepPolicy
+    SweepPolicy ..> MarkReason : reads marks
+```
+
+### `ConflictDetector` — classifying a clash, not detecting one
+
+`ConflictDetector` (`dice/src/main/kotlin/com/embabel/dice/spi/ConflictDetector.kt`) does one
+job: given an incoming proposition and an existing one the reviser has already judged to
+clash, label *what kind* of clash it is. Detecting that a clash exists at all is the
+reviser's job (`LlmPropositionReviser`); the detector only refines the label once a
+contradiction is already on the table. See
+[proposition-lifecycle's conflict classification](proposition-lifecycle.md#conflict-classification)
+for the why of the four `ConflictType` values (`Revision`, `Contradiction`,
+`WorldProgression`, `Custom`).
+
+Two implementations ship:
+
+- **`AlwaysContradictionDetector`** — the conservative default. Every clash is labeled
+  `Contradiction`. With this installed, conflict classification is a no-op refinement and
+  behavior matches a reviser with no conflict typing at all.
+- **`TemporalConflictDetector`** — distinguishes world progression from genuine
+  contradiction using the proposition's predicate and temporal recency. A clash is
+  `WorldProgression` only when both hold: the predicate is in a configurable
+  `evolvingPredicates` set (defaults to `employer`, `residence`, `status`, `role`,
+  `location`, `title` — facts that legitimately change over time), and the incoming
+  proposition is *not older* than the existing one. Equal timestamps are deliberately *not*
+  a temporal contradiction — only a strictly older incoming proposition falls back to
+  `Contradiction`. Everything else (a stable predicate, no predicate on either side, or a
+  strictly older incoming) is conservatively `Contradiction`. No LLM or IO involved —
+  classification is deterministic and O(1).
+
+The detector is wired into `LlmPropositionReviser` as an optional constructor collaborator
+(`conflictDetector: ConflictDetector? = null`, set via `withConflictDetector(detector)`).
+When it's present, the reviser attaches the detector's `ConflictType` to the
+`RevisionResult.Contradicted` result instead of the conservative default:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant New as Incoming proposition
+    participant Reviser as LlmPropositionReviser
+    participant Detector as ConflictDetector
+    participant Store
+    New->>Reviser: revise(newProposition)
+    Reviser->>Store: find candidate matches
+    Store-->>Reviser: closest existing proposition
+    Reviser->>Reviser: classify relationship (contradictory)
+    alt existing proposition is pinned
+        Reviser->>Reviser: keep original intact, store new alongside
+        Note over Reviser: no demotion, no detector call - pin wins
+    else not pinned
+        Reviser->>Store: demote original (cut confidence, mark CONTRADICTED)
+        opt detector wired
+            Reviser->>Detector: detect(incoming, existing)
+            Detector-->>Reviser: ConflictType
+        end
+        Reviser-->>New: RevisionResult.Contradicted(conflictType)
+    end
+```
+
+A contradicted proposition is deliberately **not** trust-rescored — it keeps its existing
+confidence-reduction trajectory; a wired detector only refines the classification label, never
+the confidence math (see [proposition-lifecycle's pinning
+section](proposition-lifecycle.md#pinning-permanent-protection-from-the-lifecycle) for why the
+pinned branch skips the detector entirely).
+
+#### Implementing a custom `ConflictDetector`
+
+`ConflictDetector` is a `fun interface`, so a lambda is enough for anything that doesn't need
+state:
+
+```kotlin
+// Treat clashes on a "priority" predicate as a custom conflict kind, everything else
+// falls through to the temporal detector's judgment.
+val detector = ConflictDetector { incoming, existing ->
+    val predicate = incoming.metadata[Proposition.PREDICATE] as? String
+    if (predicate == "priority") {
+        ConflictType.Custom("priority-override")
+    } else {
+        TemporalConflictDetector().detect(incoming, existing)
+    }
+}
+
+val reviser = LlmPropositionReviser(/* ... */).withConflictDetector(detector)
+```
+
+Best practice: keep detectors deterministic and side-effect free (no IO, no LLM calls) unless
+you have a specific reason to do otherwise — the shipped detectors are O(1) and the sweep/dream-loop
+paths that eventually consume `ConflictType` run over potentially large batches.
+
+### `StatusTransitionPolicy` — deciding whether a proposition should transition
+
+`StatusTransitionPolicy` (`dice/src/main/kotlin/com/embabel/dice/spi/StatusTransitionPolicy.kt`)
+is the other half of "what state should this proposition be in?" — separate from the
+`PropositionStatus` enum, which is just the label applied after a policy decision. The
+interface is a `fun interface` with one method: `evaluate(proposition): PropositionStatus?`,
+returning `null` when no transition is needed. Implementations are stateless and are invoked
+per-proposition by `DecaySweeper` (`dice/src/main/kotlin/com/embabel/dice/proposition/DecaySweeper.kt`).
+
+The shipped default, `DecayStatusPolicy`, transitions `ACTIVE → STALE` when a proposition's
+decayed utility drops below `stalenessThreshold`, and `STALE → ACTIVE` when utility recovers
+above `recoveryThreshold`. The two thresholds form a hysteresis band — a proposition sitting
+between them doesn't transition either way, which is what prevents flapping back and forth
+right at a single cutoff (see
+[proposition-lifecycle's decay section](proposition-lifecycle.md#decay-instead-of-deletion)
+for why decay exists as a distinct, non-destructive lifecycle stage). Utility is a composite
+of decayed effective confidence, optional importance weighting, and optional
+reinforcement-count weighting; with default weights of `0.0` it reduces to plain decayed
+confidence. Pinned propositions are always sweep-exempt — `evaluate` returns `null`
+immediately.
+
+```kotlin
+// A domain-specific policy: force STALE whenever a proposition references a schema version
+// that's been retired, regardless of decay.
+val policy = StatusTransitionPolicy { proposition ->
+    val schemaVersion = proposition.metadata["schemaVersion"] as? String
+    when {
+        proposition.pinned -> null
+        schemaVersion != null && schemaVersion in retiredSchemaVersions -> PropositionStatus.STALE
+        else -> DecayStatusPolicy().evaluate(proposition)
+    }
+}
+```
+
+### `MarkReason` and `SweepPolicy` — the mark-and-sweep SPI contract
+
+These two types are the pluggable extension points behind the mark-and-sweep collector described
+operationally in [reclamation-and-collector](reclamation-and-collector.md) and
+[knowledge-hygiene](knowledge-hygiene.md#reclamation-mark-and-sweep) (sweep *runtime*,
+audit trail, dry runs, `CollectorRunner` live there — this section is only the SPI shapes
+those runtimes are built on).
+
+`MarkReason` (`dice/src/main/kotlin/com/embabel/dice/spi/MarkReason.kt`) is a sealed
+interface describing *why* a proposition was flagged — purely descriptive, never mutating
+anything on its own:
+
+- `Stale` — decayed utility dropped below threshold.
+- `Duplicate(survivorId)` — duplicates another, surviving proposition; carries which one
+  should be kept.
+- `Custom(key, description)` — a consumer-defined reason with its own machine key. The
+  constructor rejects a `key` that collides with a built-in (`"stale"` or `"duplicate"`),
+  because the persisted form keys a reason only by its `key` string — a colliding custom key
+  would silently read back as the built-in reason on the next load.
+
+Every variant exposes a stable `key: String` so an audit record can group/label reasons
+without pattern-matching on the concrete type.
+
+`SweepPolicy` (`dice/src/main/kotlin/com/embabel/dice/spi/SweepPolicy.kt`) is the other half:
+given a proposition and its accumulated `List<PropositionMark>`, decide the `SweepAction` —
+`TransitionStatus(newStatus)`, `MergeInto(survivorId, thenStatus)`, `HardDelete`, or `Skip`.
+Deciding is the policy's job; *applying* the decision belongs to the collector runner, not
+the policy.
+
+Two implementations ship:
+
+- **`StatusTransitionSweepPolicy`** — the safe default. Pinned propositions are always
+  skipped; a proposition with no marks is skipped; everything else transitions to
+  `targetStatus` (default `STALE`). It never returns `HardDelete` — the non-destructive
+  outcome is the only one the default policy can produce.
+- **`MergingSweepPolicy`** — for the dedup path. Instead of just flipping a duplicate to
+  STALE (which would make its grounding and provenance invisible once STALE is excluded from
+  retrieval), it returns `MergeInto(survivorId, targetStatus)`, and the runner folds the
+  loser's evidence onto the survivor before retiring it. Falls back to a plain
+  `TransitionStatus` if a `Duplicate` mark doesn't name a usable survivor (blank, or pointing
+  at itself).
+
+```kotlin
+// Custom SweepPolicy: hard-delete anything double-marked stale AND duplicate (clearly
+// worthless), otherwise defer to the merging default.
+class AggressiveDedupPolicy(
+    private val delegate: SweepPolicy = MergingSweepPolicy(),
+) : SweepPolicy {
+    override fun decide(proposition: Proposition, marks: List<PropositionMark>): SweepAction {
+        val reasons = marks.map { it.reason.key }.toSet()
+        return if ("stale" in reasons && "duplicate" in reasons) {
+            SweepAction.HardDelete
+        } else {
+            delegate.decide(proposition, marks)
+        }
+    }
+}
+```
+
+Note this is an explicit opt-in override — the shipped defaults never choose `HardDelete` on
+their own, matching the "decay, don't delete" default posture across the lifecycle.
+
+## How conflicts drive status transitions
+
+Grounding, conflict classification, and status transition are three separate interfaces, but they
+converge on one thing: the value of `PropositionStatus` on a stored proposition. This is the same
+lifecycle as [proposition-lifecycle's overview](proposition-lifecycle.md#lifecycle-overview),
+reframed around *which SPI type fires each transition*:
+
+| Transition | Fired by | Pinned? |
+|---|---|---|
+| `[*] → ACTIVE` | ingest (grounding attached if `GroundingWiringService` wired) | — |
+| `ACTIVE → CONTRADICTED` | reviser demotes the loser; `ConflictDetector` labels the `ConflictType` | never demoted — kept intact, new fact stored alongside |
+| `ACTIVE → STALE` | `StatusTransitionPolicy.evaluate` returns `STALE` (`DecaySweeper`, or a mark-and-sweep collector run) | `evaluate` returns `null` — sweep-exempt |
+| `STALE → ACTIVE` | `StatusTransitionPolicy.evaluate` returns `ACTIVE` on reinforcement (recovery threshold) | n/a |
+| `STALE → [*]` | `SweepPolicy.decide` returns `HardDelete` (opt-in only) | n/a |
+| `CONTRADICTED → [*]` | kept for audit, no auto-revival | n/a |
+
+- **`ConflictDetector` never causes a transition by itself.** The reviser decides *that* a
+  contradiction happened and demotes the loser; the detector only labels *which kind* of
+  contradiction it was, for downstream consumers (e.g. a dream-loop pass that treats
+  `WorldProgression` differently from a genuine `Contradiction`). If no detector is wired,
+  the contradiction still happens — the label is just absent.
+- **`StatusTransitionPolicy` and `SweepPolicy` are two different axes of the same sweep.** A
+  `StatusTransitionPolicy` (used by `DecaySweeper`) evaluates a proposition directly and
+  returns a target status. A `SweepPolicy` (used by the mark-and-sweep collector) instead
+  reacts to accumulated `MarkReason`s from one or more marker strategies. Both can result in
+  a transition to `STALE`, but they're triggered by different runners for different reasons
+  — decay-driven sweep vs. collector-driven mark-and-sweep. Don't assume wiring one also
+  wires the other.
+
+## Best practices summary
+
+- **Grounding**: pass the entity's real, stable id into `Proposition.grounding` at
+  extraction time — don't invent a synthetic id, the resolver's suffix-matching exists to
+  bridge legitimate namespace variance, not arbitrary strings. Wire `GroundingWiringService`
+  whenever you want `GROUNDED_IN` edges materialized; it's safe to leave unwired if you don't
+  need graph-queryable provenance yet, since nothing else depends on the edges existing.
+- **ConflictDetector**: only classify clashes the reviser has already decided are
+  contradictory — don't use this interface to implement new conflict *detection* logic; that
+  belongs upstream in the reviser's matching. Keep implementations deterministic and cheap.
+- **StatusTransitionPolicy / SweepPolicy**: prefer composing the shipped defaults
+  (`DecayStatusPolicy`, `StatusTransitionSweepPolicy`, `MergingSweepPolicy`) over
+  reimplementing from scratch — most custom needs are "the default, plus one extra
+  condition," as shown above. Reach for `HardDelete` only when you've deliberately decided
+  destructive cleanup is acceptable for that data; it's opt-in for a reason.

--- a/docs/design/ingestion.md
+++ b/docs/design/ingestion.md
@@ -1,0 +1,126 @@
+# Ingestion: the front door onto the extraction pipeline
+
+`dice-ingestion` is the normalized handoff between "raw source material a connector parsed" and
+the [extraction pipeline](extraction-pipeline.md). It owns exactly two jobs and nothing else:
+claiming a content hash before extraction runs (so identical content is never processed twice),
+and bridging an artifact's text into a `Chunk` the pipeline understands. Parsing native formats
+(PDF, HTML, connector payloads) is explicitly out of scope — that happens upstream, before an
+`IngestedArtifact` is even constructed.
+
+```mermaid
+flowchart LR
+    subgraph adapter ["External adapter (out of scope)"]
+        RAW["Native format<br/>(PDF, HTML, API payload)"] --> PARSE["Parse to text"]
+    end
+    PARSE --> ART["IngestedArtifact<br/>(sourceId, locator, text)"]
+    subgraph ingestion ["dice-ingestion"]
+        ART --> HANDLER["IngestionHandler<br/>(TextIngestionHandler)"]
+        LEDGER[("IngestionLedger<br/>seen hashes")]
+        HANDLER <--> LEDGER
+    end
+    HANDLER --> PIPELINE["PropositionPipeline.processChunk<br/>(extract → resolve)"]
+    PIPELINE --> RESULT["Unsaved propositions<br/>(caller persists)"]
+```
+
+The pipeline itself is unmodified by ingestion — `TextIngestionHandler` just wraps
+`processChunk` with dedup and provenance. See
+[extraction-pipeline](extraction-pipeline.md) for what happens once a chunk crosses that
+boundary.
+
+## Core types
+
+| Type | Role |
+|---|---|
+| `IngestedArtifact` | A normalized unit of source material: `sourceId`, `locator` (provenance), `text`, optional `contentHash`, `trust` tier, timestamps. Adapters build these after parsing. |
+| `IngestionBatch` | A submission-ordered group of artifacts; the primary handoff surface. |
+| `IngestionHandler` | The SPI: `ingest(batch, context) -> IngestionResult`. Single-artifact `ingest` is a convenience that wraps one artifact in a batch. |
+| `IngestionLedger` | Dedup ledger: `recordIfAbsent(hash)` atomically claims a hash; `forget(hash)` releases a claim (used on failure so retries aren't poisoned). `InMemoryIngestionLedger` ships as the default. |
+| `TextIngestionHandler` | The one shipped `IngestionHandler` — wraps `PropositionPipeline` with dedup and grounding. |
+| `ArtifactOutcome` | Sealed per-artifact result: `Ingested` (propositions), `Deduplicated` (hash already seen), `Failed` (cause, isolated to that artifact). |
+| `IngestionResult` | Aggregate of `ArtifactOutcome`s in batch order; `.propositions` flattens every `Ingested` outcome. |
+
+## Batch lifecycle
+
+`TextIngestionHandler.ingest` processes a batch **sequentially, in submission order** — this is
+a documented contract, not an implementation detail a caller can ignore. Intra-batch
+deduplication (two artifacts in one batch that hash to the same content collapse to a single
+ingest) depends on that ordering: an earlier artifact's ledger claim must be visible before a
+later identical one is checked. A handler that parallelizes the batch must supply its own atomic
+dedup instead of relying on order.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Caller
+    participant Handler as TextIngestionHandler
+    participant Ledger as IngestionLedger
+    participant Pipeline as PropositionPipeline
+
+    Caller->>Handler: ingest(batch, context)
+    loop each artifact, in submission order
+        Handler->>Handler: hash = artifact.contentHash ?: contentHasher.hash(text)
+        Handler->>Ledger: recordIfAbsent(hash)
+        alt hash already claimed
+            Ledger-->>Handler: false
+            Handler-->>Handler: ArtifactOutcome.Deduplicated
+        else newly claimed
+            Ledger-->>Handler: true
+            Handler->>Pipeline: processChunk(chunk, context.withSourceLocator(artifact.locator))
+            alt extraction succeeds
+                Pipeline-->>Handler: unsaved propositions
+                Handler-->>Handler: ArtifactOutcome.Ingested
+            else extraction throws
+                Handler->>Ledger: forget(hash)
+                Handler-->>Handler: ArtifactOutcome.Failed
+            end
+        end
+    end
+    Handler-->>Caller: IngestionResult (one outcome per artifact)
+```
+
+Each artifact's failure is isolated — a `runCatching` around `ingestOne` turns a thrown
+exception into `ArtifactOutcome.Failed` for that artifact only, so one bad document never aborts
+the rest of the batch. The handler runs **extraction only**; revision and persistence stay
+downstream caller concerns (same boundary the pipeline itself draws — see
+[extraction-pipeline: the result, and who persists it](extraction-pipeline.md#the-result-and-who-persists-it)).
+
+## Provenance grounding
+
+The handler stamps the artifact's `locator` onto the context before calling the pipeline
+(`context.withSourceLocator(artifact.locator)`), so every proposition the pipeline extracts from
+that chunk is grounded in where the source material came from. This is how ingestion feeds
+provenance into the rest of the system without the pipeline needing to know anything about
+`IngestedArtifact` at all.
+
+## Common use case: ingesting a text source end-to-end
+
+```kotlin
+val handler = TextIngestionHandler(pipeline = propositionPipeline)
+
+val artifact = IngestedArtifact
+    .withSourceId("doc-42")
+    .withLocator(UriLocator("https://example.com/doc-42"))
+    .withText(extractedText)
+    .withTrust(AuthorityTier.SECONDARY)
+
+val result = handler.ingest(artifact, context)
+
+when (val outcome = result.outcomes.single()) {
+    is ArtifactOutcome.Ingested -> persist(outcome.propositions)  // caller's transaction
+    is ArtifactOutcome.Deduplicated -> logger.debug("already seen: {}", outcome.contentHash)
+    is ArtifactOutcome.Failed -> logger.warn("ingestion failed", outcome.cause)
+}
+```
+
+A caller ingesting a batch instead just swaps `IngestionBatch.of(a, b, c)` and iterates
+`result.outcomes` — the dedup and failure-isolation behavior is identical per-artifact.
+
+## Design notes
+
+- **Ledger is advisory identity, not security** — see [Core types](#core-types); the shipped
+  `InMemoryIngestionLedger` is single-process only, so a durable implementation is a drop-in
+  replacement for cross-session dedup.
+- **Sequential is a contract, not an accident** — see [Batch lifecycle](#batch-lifecycle); a
+  handler that parallelizes the batch must supply its own atomic dedup.
+- **Ingestion never persists**, same as the pipeline it wraps — see
+  [extraction-pipeline: the result, and who persists it](extraction-pipeline.md#the-result-and-who-persists-it).

--- a/docs/design/knowledge-hygiene.md
+++ b/docs/design/knowledge-hygiene.md
@@ -46,6 +46,26 @@ routed to review, projection-skipped, or demoted — so a consumer can watch adm
 persisted proposition stays silent here, because the save boundary already emits that
 (see [events](events.md)).
 
+`ExtractionGate` is a `fun interface`, so a gate is just a function from a proposition and its
+context to one of the five `GateDecision` outcomes:
+
+```kotlin
+val confidenceGate = ExtractionGate { proposition, _ ->
+    val decision = if (proposition.effectiveConfidence() < 0.5) {
+        GateDecision.Reject("confidence below threshold")
+    } else {
+        GateDecision.Persist
+    }
+    GateEvaluation("ConfidenceGate", proposition, decision)
+}
+```
+
+The other three decisions cover the cases a flat persist/reject can't: `GateDecision.RouteToReview`
+holds a proposition for a human or downstream process instead of committing either way,
+`GateDecision.SkipProjection` persists the fact but keeps it out of the typed graph, and
+`GateDecision.Demote(toRelation, reason)` is the evidence-floor case above — persist the
+proposition, but project its relation under a weaker predicate.
+
 ## Reclamation: mark and sweep
 
 Reclamation borrows the shape of a tracing garbage collector on purpose: one stage decides *what
@@ -69,11 +89,25 @@ losing data quietly erodes trust in the whole store.
 Reclamation is built to be auditable: when an audit trail is configured, a run records what was
 marked, why, and what happened to it — and a **dry run** records that trail while changing nothing,
 so you can preview a policy before it touches real data. Duplicate handling resolves overlapping
-clusters down to a single survivor, so merging is deterministic rather than order-dependent.
+clusters down to a single survivor, so merging is deterministic rather than order-dependent. Each
+status transition a sweep applies (on real runs, not dry runs) also emits a
+`PropositionStatusChanged` event — the same event the store emits when a status changes anywhere
+else, so a transition made by the collector isn't a special case downstream (see
+[events](events.md)).
 
-Each status transition a sweep applies also emits a `PropositionStatusChanged` event (on real runs,
-not dry runs) — the same event the store emits when a status changes, so a transition made by the
-collector looks identical to one made anywhere else (see [events](events.md)).
+A marker only ever produces a `MarkReason` — it never decides a fate. `SweepPolicy` is the other
+half, reading the accumulated marks for a proposition and returning a `SweepAction`:
+
+```kotlin
+val marks = listOf(
+    PropositionMark(proposition.id, MarkReason.Stale, strategyName = "DecayMarker"),
+    PropositionMark(proposition.id, MarkReason.Duplicate(survivorId = survivor.id), strategyName = "DedupMarker"),
+)
+
+val action = MergingSweepPolicy().decide(proposition, marks)
+// -> SweepAction.MergeInto(survivor.id, PropositionStatus.STALE), because a Duplicate mark
+//    with a real survivor takes priority over the plain Stale mark.
+```
 
 A run marks candidates, lets the policy decide each one's fate, and records the outcome:
 
@@ -110,7 +144,22 @@ The passes are composable and each does one thing: fold a session's raw facts to
 cluster of related facts into a higher-level proposition, resolve lingering contradictions, and
 sweep decayed entries. Composability is the design decision — consolidation isn't one monolithic
 LLM step you either run or don't; it's a pipeline of small, individually understandable, repeatable
-operations you can reorder, extend, or run on their own.
+operations you can reorder, extend, or run on their own:
+
+```kotlin
+val orchestrator = DefaultDreamLoopOrchestrator(
+    repository = propositionRepository,
+    passes = listOf(
+        SessionConsolidationPass(/* ... */),
+        AbstractionPass(/* ... */),
+        ContradictionResolutionPass(/* ... */),
+        DecaySweepPass(/* ... */),
+    ),
+)
+
+// Add a domain-specific pass without touching the shipped ones.
+val withCustomPass = orchestrator.withPass(myCustomPass)
+```
 
 The loop is threshold-gated: it only does expensive work when there's enough accumulated material
 to be worth it, so running it often is cheap when nothing has changed. And it ties directly back to

--- a/docs/design/multi-signal-collector.md
+++ b/docs/design/multi-signal-collector.md
@@ -1,0 +1,493 @@
+# The multi-signal collector: pluggable duplicate detection
+
+DICE's original duplicate strategy cut on one signal — cosine similarity from vector
+clustering — and called it done. That works for exact-ish rewordings but misses a lot: two
+propositions can be near-identical in wording but contradict each other, or dissimilar in
+wording but clearly about the same fact once you look at shared entities or shared grounding.
+A single threshold on one number can't represent that. `MultiSignalCollectorStrategy` replaces
+the single cut with a small pipeline: pool candidate pairs from any number of sources, score
+each pair on six independent signals, blend the scores into one edge, group edges into
+connected components, and pick one survivor per component. Every step of a run is recorded, so
+a merge decision can be explained — and, because nothing is deleted, effectively reversed — well
+after the fact.
+
+This strategy is one plug-in to the collector framework covered in
+[reclamation-and-collector](reclamation-and-collector.md): it's a `RunAwareCollectorStrategy`
+that runs in the mark phase, same as `DecayCollectorStrategy` or the older
+`DuplicateCollectorStrategy`. It fits into the same lifecycle transitions described in
+[proposition-lifecycle](proposition-lifecycle.md) (a collapsed duplicate ends up `STALE`, same
+destination as decay) and follows the same admission/maintenance separation described in
+[knowledge-hygiene](knowledge-hygiene.md) — marking never mutates anything; only the sweep
+phase does. The collector's own audit trail — the trace store, its schema, and how a
+collapse gets explained after the fact — has enough surface area of its own to warrant a
+companion note: see [collector-trace-store](collector-trace-store.md).
+
+This document covers the whole subsystem: architecture across three modules, the pipeline
+dataflow, the six signals, survivor selection and evidence merge, sweep policies, and
+configuration. The trace store's persistence model gets its own document.
+
+## Motivation: why one cosine cut wasn't enough
+
+Vector-cluster recall answers "does this look similar," which is a good *candidate* filter but
+a bad *decision* rule on its own. Three concrete gaps drove the multi-signal design:
+
+- **Lexical near-duplicates that don't cluster well.** Minor rewordings sometimes land outside
+  a cosine threshold that catches semantic paraphrase — a Jaro-Winkler check on normalized text
+  catches those directly.
+- **Corroborating structure vector similarity doesn't see.** Two propositions sharing entities,
+  grounding, or provenance are more likely to be the same fact restated — evidence a pure
+  embedding comparison throws away.
+- **The one thing a similarity score can actively get wrong: polarity.** "Alice works at Acme"
+  and "Alice no longer works at Acme" can be extremely similar by every distance metric and
+  mean opposite things. A collapse policy built only on similarity has no way to refuse that
+  merge, which is why polarity is a hard veto here rather than another weighted signal — details
+  in [The six signals](#the-six-signals) below.
+
+Blending several signals and reserving one of them as a hard veto lets the collector make a
+more informed collapse decision without hand-tuning a single all-purpose threshold.
+
+## Architecture: three modules, one capability
+
+The collector spans three modules, each with a distinct job:
+
+- **`dice`** — the SPI types (`CandidatePairSource`, `CollectorSignalScorer`,
+  `CollectorTraceStore`, `ConnectedComponentsFinder`, `SweepPolicy`/`SweepAction`), the
+  `MultiSignalCollectorStrategy` orchestrator and its six built-in scorers, the in-memory
+  defaults (`InMemoryCollectorTraceStore`, `InMemoryConnectedComponentsFinder`), and the
+  `CollectorRunner` that drives the mark-and-sweep loop.
+- **`dice-storage`** — `DrivineCollectorTraceStore`, the Neo4j-backed implementation of the
+  trace SPI, plus `CollectorTraceSchema` (the six node labels' constraints/indexes) and the row
+  mappers that translate graph rows back into the SPI's plain data classes.
+- **`dice-storage-autoconfigure`** — a new Spring Boot autoconfiguration module that turns all
+  of the above into beans wired from `embabel.dice.collector.*` properties: the scorers, the pair
+  source, the components finder, the trace stores, the survivor policy, and the
+  `MultiSignalCollectorStrategy` itself. It does not wire a `CollectorRunner` bean — an
+  application still assembles one by hand from the autoconfigured strategy (see
+  [Entry points](reclamation-and-collector.md#entry-points-collect-dry-run-live-run)).
+
+```mermaid
+flowchart TB
+    subgraph core ["dice — SPI + strategy (core)"]
+        direction TB
+        SPI["SPI types:<br/>CandidatePairSource, CollectorSignalScorer,<br/>ConnectedComponentsFinder, CollectorTraceStore,<br/>SweepPolicy / SweepAction"]
+        STRAT["MultiSignalCollectorStrategy<br/>+ 6 built-in scorers<br/>+ VectorCandidatePairSource"]
+        INMEM["InMemoryCollectorTraceStore<br/>InMemoryConnectedComponentsFinder"]
+        RUNNER["CollectorRunner<br/>(mark + sweep loop)"]
+        STRAT --> SPI
+        INMEM --> SPI
+        RUNNER --> STRAT
+    end
+    subgraph storage ["dice-storage — Neo4j persistence"]
+        direction TB
+        DRIVINE["DrivineCollectorTraceStore"]
+        SCHEMA["CollectorTraceSchema<br/>(6 labels, constraints, indexes)"]
+        MAPPERS["CollectorTraceRowMappers"]
+        DRIVINE --> SCHEMA
+        DRIVINE --> MAPPERS
+    end
+    subgraph autoconf ["dice-storage-autoconfigure — Spring wiring (NEW)"]
+        direction TB
+        PROPS["CollectorProperties<br/>(embabel.dice.collector.*)"]
+        AUTOCFG["CollectorAutoConfiguration<br/>(@Bean factory)"]
+        PROPS --> AUTOCFG
+    end
+    DRIVINE -.implements.-> SPI
+    AUTOCFG -->|"wires beans from"| STRAT
+    AUTOCFG -->|"conditionally selects"| INMEM
+    AUTOCFG -->|"conditionally selects"| DRIVINE
+    AUTOCFG -->|"registers indexes via"| SCHEMA
+```
+
+The dependency direction only flows one way: `dice-storage` depends on `dice` (to implement its
+SPI), and `dice-storage-autoconfigure` depends on both. Core collector logic never imports
+anything from `dice-storage` — swap `DrivineCollectorTraceStore` for any other
+`CollectorTraceStore` implementation and the strategy doesn't change.
+
+## The pipeline: from candidates to a merged proposition
+
+`MultiSignalCollectorStrategy.mark()` runs a run in four stages: propose pairs, score and
+aggregate, group into components, pick survivors. The output feeds into the sweep phase exactly
+like any other collector strategy.
+
+```mermaid
+flowchart LR
+    C["ACTIVE candidates<br/>(runner-selected snapshot)"] --> VPS["VectorCandidatePairSource<br/>(+ any other CandidatePairSource)"]
+    VPS --> P["Candidate pairs<br/>(canonicalized: smaller id = anchor;<br/>pooled + deduped across sources)"]
+    P --> S1[VectorSignalScorer]
+    P --> S2[LexicalSignalScorer]
+    P --> S3[EntityOverlapSignalScorer]
+    P --> S4[GroundingOverlapSignalScorer]
+    P --> S5[ProvenanceOverlapSignalScorer]
+    P --> S6[PolarityVetoSignalScorer]
+    S1 --> AGG[CollectorEdgeAggregator]
+    S2 --> AGG
+    S3 --> AGG
+    S4 --> AGG
+    S5 --> AGG
+    S6 --> AGG
+    AGG --> E["CollectorCandidateEdge<br/>(aggregateScore, vetoed)"]
+    E --> CCF["ConnectedComponentsFinder<br/>(non-vetoed edges >= matchThreshold)"]
+    CCF --> COMP["Components (size 2+)"]
+    COMP --> SP["CollectorSurvivorPolicy"]
+    SP --> MARK["PropositionMark:<br/>Duplicate(survivorId) for every non-survivor"]
+    MARK --> SWEEP["MergingSweepPolicy<br/>absorbEvidence() then STALE"]
+```
+
+Stage by stage, in the actual code (`MultiSignalCollectorStrategy.mark()`,
+`dice/src/main/kotlin/com/embabel/dice/projection/memory/collector/MultiSignalCollectorStrategy.kt:87-121`):
+
+1. **Propose.** Every `CandidatePairSource` proposes pairs over the candidate set
+   (`collectPairs`, lines 123-142). Results from every source are pooled, canonicalized (the
+   smaller id becomes the anchor so `A,B` and `B,A` collapse to the same pair), and deduplicated
+   by `(anchorId, memberId)` — a pair proposed twice by two different sources is scored once.
+   Self-pairs (anchor id equals member id) are dropped outright.
+2. **Score and aggregate.** Every `CollectorSignalScorer` scores each pair
+   (`scoreAndAggregate`, line 144). A scorer that returns `null` abstains and drops out of that
+   pair's blend entirely — a pair with grounding on only one side, say, just skips the
+   grounding-overlap signal rather than forcing a zero. `CollectorEdgeAggregator.aggregate()`
+   folds whatever's left into one `CollectorCandidateEdge`
+   (`dice/src/main/kotlin/com/embabel/dice/projection/memory/collector/CollectorEdgeAggregator.kt:40-54`):
+   the aggregate score is the weighted mean of every non-abstaining signal
+   (`Σ(weight·score) / Σ(weight)`, coerced into `0..1`), and any signal with `veto = true` marks
+   the whole edge `vetoed` regardless of the blended number. A pair where every scorer abstained
+   (weight sum is `0.0`) gets an aggregate score of `0.0`.
+3. **Group into components.** `ConnectedComponentsFinder.findComponents()` unions the
+   non-vetoed edges scoring at or above `matchThreshold` (default `0.6`) into components, using
+   union-find so overlapping pairs (A≈B, B≈C) collapse to one cluster `{A, B, C}` instead of
+   fighting over pairwise merges. `MultiSignalCollectorStrategy` just calls
+   `componentsFinder.findComponents(...)`; the union-find itself lives in the shipped
+   implementation, `InMemoryConnectedComponentsFinder.kt`.
+4. **Pick a survivor.** Each component of size two or more (`markComponent`, lines 149-190) gets
+   one survivor via `CollectorSurvivorPolicy`; everyone else in the component is marked
+   `Duplicate(survivorId)`. Components smaller than two members produce no marks — a lone
+   proposition with no eligible edge just isn't a duplicate of anything.
+
+Marks are deduplicated by proposition id and sorted before being returned
+(`distinctBy { it.propositionId }.sortedBy { it.propositionId }`, line 112-113), so the result
+is deterministic regardless of iteration order upstream.
+
+### One run, sequence view
+
+A `CollectorRunner.run(contextId, dryRun)` call drives one full pass. The sequence below shows a
+live run (`dryRun = false`) collapsing one duplicate pair; a dry run follows the identical path
+except the final proposition writes and the `PropositionStatusChanged` event are skipped, and
+the recorded outcome is `MARKED` instead of `TRANSITIONED`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Runner as CollectorRunner
+    participant Strategy as MultiSignalCollectorStrategy
+    participant PairSrc as VectorCandidatePairSource
+    participant Scorers as 6× CollectorSignalScorer
+    participant Agg as CollectorEdgeAggregator
+    participant CCF as ConnectedComponentsFinder
+    participant Trace as CollectorTraceStore
+    participant Policy as MergingSweepPolicy
+    participant Repo as PropositionRepository
+
+    Runner->>Repo: query ACTIVE candidates for contextId
+    Repo-->>Runner: candidates
+    Runner->>Strategy: mark(candidates, repository, CollectorRunContext(runId, contextId, dryRun))
+    Strategy->>Trace: recordRunContext(runId, contextId)
+    Strategy->>PairSrc: propose(candidates, contextId)
+    PairSrc-->>Strategy: CandidatePair list (cosine attached)
+    loop each pair
+        Strategy->>Scorers: score(pair, contextId)
+        Scorers-->>Strategy: CollectorSignalScore? (or abstain)
+        Strategy->>Agg: aggregate(pair, signals)
+        Agg-->>Strategy: CollectorCandidateEdge
+    end
+    Strategy->>Trace: recordCandidateEdges(runId, edges)
+    Strategy->>CCF: findComponents(runId, candidateIds, eligibleEdges)
+    CCF-->>Strategy: propositionId -> componentId
+    Strategy->>Trace: recordComponents(runId, components)
+    loop each component (size >= 2)
+        Strategy->>Strategy: survivorPolicy.choose(members)
+        Strategy->>Trace: recordDecision(runId, CollectorDecision(survivorId, retired=losers))
+    end
+    Strategy-->>Runner: List<PropositionMark> (Duplicate(survivorId))
+    loop each marked proposition
+        Runner->>Policy: decide(proposition, marks)
+        Policy-->>Runner: MergeInto(survivorId, STALE)
+        alt dryRun = false
+            Runner->>Repo: survivor.absorbEvidence(loser), save survivor
+            Runner->>Repo: transition loser to STALE
+            Runner->>Runner: emit PropositionStatusChanged
+        else dryRun = true
+            Runner->>Runner: no writes — record outcome MARKED
+        end
+    end
+    Runner-->>Runner: CollectorRunResult(marks, applied, skipped, hardDeleted)
+```
+
+## The pair source
+
+`VectorCandidatePairSource` is the one pair source shipped today
+(`dice/src/main/kotlin/com/embabel/dice/projection/memory/collector/VectorCandidatePairSource.kt`).
+It reuses the repository's own vector clustering
+(`PropositionRepository.findClusters(similarityThreshold, topK, query)`) — the same recall path
+the older single-signal strategy used — and turns every anchor/member edge from a cluster into a
+`CandidatePair`, carrying the cluster's cosine along as `proposalScore` so `VectorSignalScorer`
+downstream doesn't have to re-embed anything. It re-derives canonicalization and dedup itself
+rather than trusting `findClusters`' own ordering (defensive, not free — see the comment at
+line 54 of the source). Only pairs where both propositions are in the runner's candidate
+snapshot are proposed; a cluster member outside that snapshot is silently dropped, mirroring the
+`byId` filter the older `DuplicateCollectorStrategy` used. Defaults: `similarityThreshold = 0.7`
+(matches dice's existing default so recall doesn't regress), `topK = 10`.
+
+The `CandidatePairSource` extension point exists so a deployment can add pair sources beyond vector
+recall — a name-similarity crawl, an external entity-linking pass, whatever else surfaces
+plausible duplicates worth scoring. `MultiSignalCollectorStrategy` pools every source's
+proposals before scoring, so adding a source only ever widens recall; it can't change how an
+existing pair gets scored.
+
+## The six signals
+
+Each scorer looks at one candidate pair and returns a `CollectorSignalScore` (`signal`, `score`,
+`weight`, `veto`, optional `explanation`/`evidenceRef`) or `null` to abstain. All but the veto
+scorer carry a configurable `weight` (via a `@JvmOverloads` constructor) used in the aggregate
+blend.
+
+| Signal | What it measures | Default weight | Abstains when |
+|---|---|---|---|
+| **Vector** | Reuses the pair source's own cosine (`proposalScore`) as the score | 1.0 | Pair didn't arrive with a `proposalScore` |
+| **Lexical** | Jaro-Winkler similarity over the propositions' normalized text | 0.5 | Never (always has text to compare) |
+| **Entity overlap** | Jaccard similarity of the two propositions' mention (entity) ids | 1.0 | Either side has no mentions at all |
+| **Grounding overlap** | Jaccard similarity of the two propositions' grounding sets | 0.5 | Either side has no grounding |
+| **Provenance overlap** | Jaccard similarity of the two propositions' provenance locators | 0.5 | Either side has no provenance entries |
+| **Polarity veto** | Shared entities + opposite negation cues ("works at Acme" vs. "no longer works at Acme") | n/a — **veto only** | No shared entities, or both sides agree on polarity |
+
+**Polarity veto is not a similarity score.** It never contributes a
+positive number to the blend; it either abstains (returns `null`) or fires with a fixed
+zero-weight veto score
+(`dice/src/main/kotlin/com/embabel/dice/projection/memory/collector/PolarityVetoSignalScorer.kt:49-55`):
+
+```kotlin
+return CollectorSignalScore(
+    signal = SIGNAL_NAME,
+    score = 0.0,
+    weight = VETO_WEIGHT,
+    veto = true,
+    explanation = "opposite polarity about shared entities",
+)
+```
+
+where `SIGNAL_NAME = "polarity-veto"` and `VETO_WEIGHT = 0.0`. The weight is pinned at `0.0` on
+purpose: a non-zero weight would drag a vetoed edge's blended
+`aggregateScore` toward zero, hiding what the other five signals actually thought of the pair.
+The veto works entirely through the `vetoed` flag on the edge — `CollectorEdgeAggregator` sets
+`vetoed = signals.any { it.veto }` independent of the score math — so a vetoed edge's
+`aggregateScore` still reflects real corroborating evidence; it's excluded from grouping by the
+`vetoed` flag, not by a suppressed number. That distinction matters for the trace: a reviewer
+looking at a vetoed edge later can still see "these two looked 0.9 similar, but were vetoed for
+polarity," rather than an uninformative near-zero score.
+
+The scorer's limits: it only fires when the two propositions' mention sets
+actually overlap (no shared subject, no veto check at all), and it's a lexical negation-cue scan
+(`NEGATION_WORDS`/`NEGATION_PHRASES`), not a semantic entailment model — it can misfire on cues
+used non-negatively ("left a message") and miss negation phrased without a recognized cue word.
+It's a guard rail against the worst kind of bad merge, not an NLI classifier.
+
+## Survivor selection and evidence merge
+
+Once a component has two or more members, `CollectorSurvivorPolicy.choose()` picks the one that
+survives; everyone else is marked `Duplicate(survivorId)`. The shipped default
+(`dice/src/main/kotlin/com/embabel/dice/projection/memory/collector/CollectorSurvivorPolicy.kt:32-36`):
+
+```kotlin
+val defaultCollectorSurvivorPolicy = CollectorSurvivorPolicy { members ->
+    members.maxWith(
+        compareBy<Proposition>({ it.effectiveConfidence() }, { it.reinforceCount }, { it.id }),
+    )
+}
+```
+
+Ordering is: highest effective confidence wins; ties broken by reinforcement count (a fact seen
+more often is a stronger anchor); a full tie broken by stable id, so the choice is deterministic
+even when two propositions are otherwise indistinguishable. `CollectorSurvivorPolicy` is a SAM
+interface — a deployment that wants a different ordering (e.g. prefer a specific source tier)
+supplies its own bean.
+
+Losing propositions aren't just discarded — their evidence is folded onto the survivor via
+`Proposition.absorbEvidence()`
+(`dice/src/main/kotlin/com/embabel/dice/proposition/Proposition.kt:303-313`):
+
+```kotlin
+fun absorbEvidence(other: Proposition): Proposition {
+    val alreadyContained = grounding.containsAll(other.grounding) &&
+        provenanceEntries.containsAll(other.provenanceEntries) &&
+        sourceIds.containsAll(other.sourceIds)
+    return withGrounding(other.grounding)
+        .withProvenanceEntries(other.provenanceEntries)
+        .copy(
+            sourceIds = (sourceIds + other.sourceIds).distinct(),
+            reinforceCount = if (alreadyContained) reinforceCount else reinforceCount + 1,
+        )
+}
+```
+
+Grounding and provenance entries are unioned (`withGrounding`/`withProvenanceEntries` presumably
+dedupe internally — they're additive, not replacing), source ids are unioned and deduped with
+`distinct()`, and `reinforceCount` bumps by exactly one *unless* the survivor already fully
+contained the loser's evidence — that guard makes repeated absorption idempotent: re-running a
+collapse (or absorbing the same loser twice through some retry) doesn't inflate the
+reinforcement count artificially. This is what makes evidence merge safe to call more than once
+with the same inputs.
+
+### A proposition's status through a collapse
+
+```mermaid
+stateDiagram-v2
+    [*] --> ACTIVE
+    state "Component found (size >= 2)" as component_check
+    ACTIVE --> component_check : eligible edge >= matchThreshold, not vetoed
+    component_check --> Survivor : chosen by CollectorSurvivorPolicy
+    component_check --> Loser : every other member
+
+    state Survivor {
+        [*] --> absorbing
+        absorbing --> ACTIVE_survivor : absorbEvidence(loser) for each loser\n(grounding/provenance/sourceIds unioned,\nreinforceCount bumped once per loser)
+    }
+    ACTIVE_survivor --> [*] : stays ACTIVE
+
+    state Loser {
+        [*] --> merge_decided
+        merge_decided --> STALE : MergingSweepPolicy -> MergeInto(survivorId)\n(evidence already folded onto survivor)
+    }
+    STALE --> [*]
+
+    note right of component_check
+        No component found, or component
+        has < 2 members: no mark at all,
+        proposition stays ACTIVE untouched
+    end note
+    note right of Loser
+        Fallback: if the mark names no usable
+        survivor (blank id, or self), the loser
+        still transitions to STALE via a plain
+        TransitionStatus - no evidence merge
+    end note
+```
+
+## Sweep policies
+
+The mark phase only *describes* what looks like a duplicate; the sweep phase decides what to do
+about it. Two `SweepPolicy` implementations exist
+(`dice/src/main/kotlin/com/embabel/dice/spi/SweepPolicy.kt`), and one sealed `SweepAction`
+family (`dice/src/main/kotlin/com/embabel/dice/spi/SweepAction.kt`) they choose from:
+`TransitionStatus(newStatus)`, `MergeInto(survivorId, thenStatus)`, `HardDelete`, `Skip`.
+
+**`MergingSweepPolicy` is `CollectorRunner.Builder`'s default policy — unconditionally, not
+gated on calling `withDuplicateDetection()`.** `CollectorRunner.Builder` initializes `policy: SweepPolicy = MergingSweepPolicy()` as a field
+default (`dice/src/main/kotlin/com/embabel/dice/projection/memory/CollectorRunner.kt:93`),
+regardless of which strategies get added to the builder. Add only a decay strategy and never
+call `withDuplicateDetection()` — you still get `MergingSweepPolicy` as your sweep policy; it
+just never sees a `Duplicate` mark to act on, so its `MergeInto` branch is dead code for that
+run, and it behaves identically to `StatusTransitionSweepPolicy` for every mark it processes.
+The distinction only becomes visible the moment a strategy in the run actually produces a
+`Duplicate` mark. A deployment that wants pure status flips even with duplicate detection
+enabled must call `withPolicy(StatusTransitionSweepPolicy())` explicitly to override the
+default.
+
+`MergingSweepPolicy.decide()` (`SweepPolicy.kt:101-123`):
+
+1. Pinned propositions are always skipped, regardless of marks — pinning is described further in
+   [proposition-lifecycle](proposition-lifecycle.md#pinning-permanent-protection-from-the-lifecycle).
+2. A proposition with no marks is skipped.
+3. It looks across the proposition's marks for the first `Duplicate` mark whose `survivorId` is
+   non-blank and not the proposition's own id, and returns `MergeInto(survivorId, targetStatus)`.
+4. If no mark names a usable survivor (a mark that isn't `Duplicate` at all, or a `Duplicate`
+   mark with a blank/self-referential survivor id — which shouldn't normally happen but is
+   defended against anyway), it falls back to a plain `TransitionStatus(targetStatus)` — so a
+   non-dedup mark, or a malformed one, still retires normally instead of silently being ignored.
+
+`StatusTransitionSweepPolicy` is the older, simpler policy: same pinned/unmarked skip rules, but
+it always returns `TransitionStatus(targetStatus)` and never merges evidence — it's what you get
+for decay-only marks, or for duplicate marks if a deployment opts out of merging via
+`withPolicy(StatusTransitionSweepPolicy())`. Neither policy ever returns `HardDelete` — that
+outcome exists in the `SweepAction` sealed family for a deployment-supplied policy to opt into,
+but nothing shipped in this subsystem produces it.
+
+Applying `MergeInto` is the runner's job, not the policy's: the runner calls
+`survivor.absorbEvidence(loser)`, saves the survivor, then transitions the loser to
+`thenStatus`. If a mark in the same run would also retire the survivor, the merge is applied
+first — so any later transition in the same pass reads the already-merged survivor state.
+
+## Configuration and autoconfiguration
+
+`dice-storage-autoconfigure` is a new module (Spring Boot autoconfiguration, depending on both
+`dice-storage` and `dice`) that turns the collector into wired beans from
+`embabel.dice.collector.*` properties, gated by
+`@ConditionalOnProperty(prefix = "embabel.dice.collector", name = ["enabled"], havingValue = "true", matchIfMissing = true)`
+on `CollectorAutoConfiguration` itself — the master switch. Every bean is
+`@ConditionalOnMissingBean`, so an application supplying its own implementation always wins over
+the built-in default.
+
+### `CollectorProperties` (prefix `embabel.dice.collector`)
+
+| Property | Type | Default | Notes |
+|---|---|---|---|
+| `enabled` | `Boolean` | `true` | Master switch; `false` disables the whole autoconfiguration |
+| `matchThreshold` | `Double` (`0.0`–`1.0`) | `0.6` | Minimum aggregate score for an edge to union its endpoints into a component |
+| `signals.<name>.enabled` | `Boolean` | `true` | Per-signal toggle, keyed by short name (`vector`, `lexical`, `entity-overlap`, `grounding-overlap`, `provenance-overlap`, `polarity-veto`) |
+| `signals.<name>.weight` | `Double?` | `null` | Overrides that scorer's blend weight; `null` keeps the scorer's own built-in default |
+| `signals.vector.similarityThreshold` | `Double?` | `null` (→ `0.7`) | Vector signal only — cosine floor passed to `findClusters` |
+| `signals.vector.topK` | `Int?` | `null` (→ `10`) | Vector signal only — max similar members per cluster seed |
+| `sweep.delta` | `Boolean` | `false` | Property placeholder — bound and validated, no periodic delta-sweep runner reads it yet |
+| `trace.enabled` | `Boolean` | `true` | Whether runs are recorded to a trace store at all |
+| `trace.detailRetentionDays` | `Int?` | `null` (indefinite) | Property placeholder — no retention job reads it yet |
+
+The `weight`/`similarityThreshold`/`topK` fields are nullable specifically so "not configured"
+is distinguishable from "configured to a specific number": an unset weight falls back to the
+scorer's own neutral default rather than some autoconfigure-level default fighting it.
+
+### Why the scorer registration order matters
+
+`CollectorAutoConfiguration` puts `@Order` on every scorer bean method — vector (1), lexical
+(2), entity-overlap (3), grounding-overlap (4), provenance-overlap (5), polarity-veto (6) — and
+that order becomes the order Spring injects them into `List<CollectorSignalScorer>`. The order
+doesn't change the aggregate math (the weighted mean is order-independent), but it does fix the
+order signals show up in a trace edge's `signals` list, and by extension in any trace-store
+query that iterates them positionally. Reordering the `@Order` values or adding a new scorer at
+the wrong position changes what old trace rows look like next to new ones for the same pair.
+
+### Graph vs. in-memory trace store selection
+
+Two trace-store beans compete for the same `CollectorTraceStore`/`CollectorTraceQuery`
+injection point:
+
+- `drivineCollectorTraceStore` — `@ConditionalOnProperty(embabel.dice.store.type=graph)` *and*
+  `@ConditionalOnProperty(embabel.dice.collector.trace.enabled, matchIfMissing=true)`.
+- `inMemoryCollectorTraceStore` — no conditions beyond `@ConditionalOnMissingBean`.
+
+Both beans return their *concrete* store type (`DrivineCollectorTraceStore` /
+`InMemoryCollectorTraceStore`), not the `CollectorTraceStore` interface — deliberately. Spring
+determines a bean's type from its factory method's declared return type before instantiating
+it; if the method were declared to return the interface, Spring wouldn't know at
+condition-evaluation time that the same bean also satisfies `CollectorTraceQuery` (the read
+side), so an injection point asking for `CollectorTraceQuery` specifically would fail to
+resolve. Returning the concrete type lets one bean instance satisfy both interfaces with no
+separate query bean. The graph bean is declared first in the class so it wins the fallback
+resolution order when both conditions could apply, matching the pattern
+`DiceStorageAutoConfiguration` already uses for the proposition store itself.
+
+The full detail of what gets persisted and how it's queried back lives in
+[collector-trace-store](collector-trace-store.md).
+
+## The `RunAwareCollectorStrategy` bridge
+
+`CollectorStrategy` is a plain SAM (`mark(candidates, repository, contextId)`);
+`RunAwareCollectorStrategy` extends it with a full-context `mark(candidates, repository, ctx)` and
+provides a default implementation of the plain SAM that builds an ephemeral
+`CollectorRunContext(runId = "", contextId = contextId)`
+(`dice/src/main/kotlin/com/embabel/dice/projection/memory/CollectorStrategy.kt:76-80`). Inside
+`MultiSignalCollectorStrategy.mark()`, `tracing = ctx.runId.isNotBlank()` gates every trace-store
+write — a blank runId means the run isn't queryable anywhere, so marks are still computed and
+returned normally, but none of the four `traceStore.record*` calls fire. This is what lets the
+same strategy serve both a fully traced `CollectorRunner.run()` pass and the untraced
+`collect()`/legacy-SAM path with no branching in the caller.
+
+`sweep.delta` and `trace.detailRetentionDays` are real, validated `CollectorProperties` fields
+today, but there's no periodic delta-sweep runner or retention job consuming them yet — they're
+wired ahead of the feature that will use them.

--- a/docs/design/oracle-and-query.md
+++ b/docs/design/oracle-and-query.md
@@ -1,0 +1,221 @@
+# Oracle and query: answering questions, not just retrieving facts
+
+[retrieval-and-discovery](retrieval-and-discovery.md) covers how DICE finds propositions —
+vector search, graph walks, temporal windows, routed through `RetrievalRouter` and `GraphQuery`.
+This note covers the layer above that: **answering a natural-language question**. Retrieval gets
+you a bag of relevant propositions or graph edges; an `Oracle` turns "who knows Kubernetes?" into
+"Alice, based on 2 propositions" — with grounding, confidence, and (where possible) a negative
+answer when the knowledge base genuinely has nothing.
+
+The two concerns are deliberately separate types. Retrieval is a search problem: which
+propositions match, ranked how. Q&A is a synthesis problem: given some facts, produce a sentence
+and say how sure you are. An `Oracle` is free to call into retrieval, Prolog, or both to get its
+facts — but its contract is "answer a question," not "find some records."
+
+## The `Oracle` abstraction
+
+```kotlin
+interface Oracle {
+    fun ask(question: Question): Answer
+    fun ask(questionText: String): Answer = ask(Question(questionText))
+}
+```
+
+`Question` is `text` plus an optional free-form `context` map — nothing DICE-specific, so an
+`Oracle` never forces a caller to know about propositions or contexts. `Answer` carries the
+synthesized `text`, a `confidence` (0.0–1.0), `grounding` (source proposition IDs — always trace
+an answer back to what produced it), a `negative` flag for "no, X isn't true" answers, and an
+`AnswerSource` (`PROLOG`, `PROPOSITIONS`, or `NONE`) recording which path produced it.
+
+Grounding and `AnswerSource` exist so a caller can decide how much to trust an answer without
+re-deriving it — a UI can show "via reasoning over 3 facts" differently from "no matching facts
+found." `Answer.unknown(question)` is the canonical empty answer: confidence 0, negative, source
+`NONE`. Prefer it over throwing — asking a question the knowledge base can't answer is a normal
+outcome, not an error, matching the "empty over exception" convention already established by
+`GraphQuery` and `RetrievalRouter`.
+
+## Two implementations, two strategies
+
+Both oracles work over the same substrate — a `PrologProjectionResult` (facts + grounding,
+projected from propositions per [extraction-pipeline](extraction-pipeline.md) and
+[architecture](architecture.md#projection)) and a `PrologSchema` (predicate mappings) — but they
+differ in *who* controls the reasoning loop.
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Oracle
+    participant LLM
+    participant Prolog as PrologEngine
+    participant Props as PropositionRepository
+
+    Caller->>Oracle: ask(Question)
+
+    alt LlmOracle: fixed pipeline
+        Oracle->>LLM: generate query plan (predicates, sample facts)
+        LLM-->>Oracle: QueryPlan(prologQuery, negativeAnswer)
+        Oracle->>Prolog: queryAll(prologQuery)
+        alt results found
+            Prolog-->>Oracle: bindings
+            Oracle->>LLM: generate answer from bindings
+            LLM-->>Oracle: answer text
+        else no results
+            Oracle->>Props: findSimilar(question text)
+            Props-->>Oracle: relevant propositions
+            Oracle->>LLM: synthesize from propositions
+            LLM-->>Oracle: answer text
+        end
+    else ToolOracle: LLM-driven loop
+        Oracle->>LLM: generateText with PrologTools bound
+        loop LLM decides which tool to call, zero or more times
+            LLM->>Prolog: show_facts / query_prolog / check_fact via tool call
+            Prolog-->>LLM: tool result
+        end
+        LLM-->>Oracle: final answer text
+    end
+
+    Oracle-->>Caller: Answer(text, confidence, grounding, source)
+```
+
+### `LlmOracle` — fixed plan-then-execute pipeline
+
+`LlmOracle` runs a scripted three-step strategy: ask the LLM once for a Prolog query plan, run it,
+and fall back to proposition similarity search if Prolog comes up empty. One extra LLM call
+formats the final answer in natural language.
+
+```kotlin
+val oracle = LlmOracle(
+    ai = ai,
+    prologResult = prologProjectionResult,
+    prologSchema = PrologSchema.withDefaults(),
+    propositionRepository = repository,   // optional: enables the fallback path
+    entityNames = entityIdToName,          // optional: humanizes bindings in the answer
+)
+val answer = oracle.ask("Who is an expert in Kubernetes?")
+// answer.source == AnswerSource.PROLOG, grounding == ["prop-1", "prop-2"]
+```
+
+Use `LlmOracle` when you want **predictable cost and latency** — at most three LLM calls per
+question (query plan, then either a Prolog-answer or a proposition-synthesis call) — and when the
+questions are the kind Prolog reasoning answers well: "who is X", "does A know B", "which experts
+work at C". The negative path is explicit: if the generated query returns no rows, `Answer` comes
+back `negative = true` with `AnswerSource.PROLOG`, not a guess.
+
+### `ToolOracle` — LLM drives its own reasoning loop
+
+`ToolOracle` hands the LLM a small tool belt (`PrologTools`, wrapped via `Tool.fromInstance`) and
+lets it decide how many queries to run and in what order — `show_facts` to orient itself, then
+zero or more `query_prolog` / `check_fact` / `list_entities` calls, then a final answer.
+
+```kotlin
+val oracle = ToolOracle(
+    ai = ai,
+    prologResult = prologProjectionResult,
+    prologSchema = PrologSchema.withDefaults(),
+    propositionRepository = repository,
+    entityNames = entityIdToName,
+)
+val answer = oracle.ask("Does Alice know anyone who works at TechCorp besides Bob?")
+```
+
+Use `ToolOracle` for **multi-hop or exploratory questions** where the right query isn't obvious
+up front and the LLM benefits from seeing intermediate results before deciding the next step.
+The tradeoff is variable cost (the LLM can call tools any number of times) and a coarser
+`AnswerSource` — it's inferred by scanning the response text for tool-call markers, not tracked
+structurally, so treat `ToolOracle`'s `source`/`grounding` as advisory rather than precise.
+
+**Choosing between them:** start with `LlmOracle` — it's cheaper, deterministic in call count, and
+gives precise grounding. Reach for `ToolOracle` only when questions genuinely need multiple,
+data-dependent lookups that a single generated query plan can't express.
+
+## `PrologTools` — the tool surface both paths sit on
+
+`PrologTools` is the tool surface that makes Prolog queryable by an LLM tool-calling loop. It wraps a
+`PrologEngine` (built once via `PrologEngine.fromProjection(result, schema)`) and exposes five
+`@LlmTool`-annotated methods: `show_facts`, `list_predicates`, `list_entities`, `query_prolog`,
+`check_fact`. `ToolOracle` uses it directly as its tool belt; nothing stops a caller from wiring
+`PrologTools` into a different agent or tool-calling context — it depends on nothing from
+`ToolOracle` itself.
+
+Two details matter for correctness, both defensive against an LLM's imprecise Prolog:
+
+- **Name ↔ ID translation.** Prolog facts store resolved entity IDs, not human names, but an LLM
+  naturally writes queries with names (`works_at('Alice', X)`). `translateNamesToIds` rewrites
+  quoted names to IDs before querying; `resolveEntityName` reverses that when formatting results
+  back out, with a truncated-UUID prefix match as a last resort (Prolog identifiers get shortened
+  in some engines).
+- **Query generalization fallback.** If a specific query returns nothing, `makeQueryGeneral`
+  retries with quoted literal names replaced by a variable — turning `expert_in('nonexistent',
+  X)` into `expert_in(X, Y)` style broadening — before giving up. This is a best-effort recovery
+  for an LLM getting an entity name slightly wrong, not a substitute for the name/ID translation
+  above.
+
+## Where Prolog facts come from
+
+Both oracles are read-only consumers of `PrologProjectionResult` — they never write Prolog facts
+themselves. Facts arrive via `PrologProjector`, one of the projection targets described in
+[architecture](architecture.md#projection) and detailed in
+[extraction-pipeline](extraction-pipeline.md): propositions remain the system of record, and the
+Prolog fact base is a derived, disposable view rebuilt from them. If a projection is stale or
+incomplete, re-run the projector — never hand-edit facts to patch an oracle's answer.
+
+## Relationship to retrieval
+
+Both oracles route to `PropositionRepository.findSimilar` for their fallback path — the same
+kind of vector search `RetrievalRouter` performs for `RetrievalMode.VECTOR`, but called directly
+rather than through the router. This is intentional scope-narrowing: an `Oracle` needs a handful
+of relevant propositions to synthesize an answer, not a full paginated, mode-routed discovery
+result with `topK`/`depth` clamping. If a future oracle needs graph-neighborhood or temporal
+context to answer richer questions, prefer composing with `RetrievalRouter`/`GraphQuery` (passing
+a `DiscoveryQuery`) over reimplementing retrieval logic inside the oracle.
+
+```mermaid
+erDiagram
+    QUESTION ||--|| ORACLE : "ask(Question)"
+    ORACLE ||--|| ANSWER : produces
+    ORACLE ||--o| PROLOG_PROJECTION_RESULT : reasons-over
+    ORACLE ||--o| PROLOG_SCHEMA : uses
+    ORACLE ||--o| PROPOSITION_REPOSITORY : "falls back to (findSimilar)"
+    TOOL_ORACLE ||--|| PROLOG_TOOLS : "delegates via @LlmTool"
+    PROLOG_TOOLS ||--|| PROLOG_ENGINE : queries
+    DISCOVERY_QUERY ||--|| RETRIEVAL_MODE : "mode field"
+    DISCOVERY_QUERY ||--o| RETRIEVAL_ROUTER : "routed by (separate path, see retrieval-and-discovery)"
+
+    QUESTION {
+        string text
+        map context
+    }
+    ANSWER {
+        string text
+        double confidence
+        list grounding
+        boolean negative
+        enum source
+    }
+    PROLOG_PROJECTION_RESULT {
+        list facts
+        list confidenceFacts
+        list groundingFacts
+    }
+    DISCOVERY_QUERY {
+        enum mode
+        string text
+        string entityId
+        int topK
+        int depth
+    }
+```
+
+## Best practice checklist
+
+- Prefer `LlmOracle` by default; escalate to `ToolOracle` only for exploratory multi-hop questions.
+- Always pass `entityNames` when you have them — without it, answers surface raw entity IDs
+  instead of human-readable names, and `PrologTools`' name→ID translation has nothing to reverse.
+- Pass `propositionRepository` unless you specifically want "Prolog or nothing" behavior — the
+  fallback is what keeps an oracle from going straight to `Answer.unknown` on a question the
+  Prolog schema doesn't model.
+- Treat `Answer.negative == true` as a real, informative result, not a failure to handle — it
+  means the knowledge base was queried and came back empty, which is worth showing a user as-is.
+- Never bypass `Question`/`Answer` to call `PrologEngine` or `PropositionRepository` directly from
+  a caller that wants an answer — that's exactly the synthesis-plus-grounding step the `Oracle`
+  contract exists to centralize.

--- a/docs/design/prolog-projection.md
+++ b/docs/design/prolog-projection.md
@@ -1,0 +1,180 @@
+# Prolog projection: logical inference over propositions
+
+DICE projects propositions into a typed graph so they can be queried as entities and
+relationships (see [graph-projection](graph-projection.md)). Some questions are awkward to
+answer with a graph query but natural to answer with a rule: "who can this person consult,
+transitively, through friends of friends or reporting chains?" is a graph traversal you'd have
+to hand-write and re-write every time the notion of "can consult" changes. A Horn-clause engine
+lets you state that once, as a rule, and get every derived fact for free. That's what the Prolog
+projection is for: a second, rule-driven view of the same propositions, optimized for transitive
+closure and multi-hop derivation rather than for storage or visualization.
+
+It is not a replacement for the graph projection — it's built on top of it. Classifying a
+proposition into a typed relationship (`WORKS_AT`, `EXPERT_IN`, ...) is an LLM-inference step
+that the graph projector already does; the Prolog projector reuses that classification rather
+than re-deriving it, and adds a layer of *pure logical* inference on top: chains, transitive
+closures, and derived predicates that follow deterministically from the classified facts.
+
+## Where it sits
+
+```mermaid
+flowchart LR
+    PROP["Propositions<br/>(source of truth)"] --> GP[GraphProjector]
+    GP -->|"classifies into<br/>ProjectedRelationship"| REL[ProjectedRelationship]
+    REL --> PP[PrologProjector]
+    PP -->|"projectAll"| FACTS["PrologProjectionResult<br/>facts + confidence + grounding"]
+    RULES["dice-rules.pl<br/>(base inference rules)"] --> ENGINE
+    FACTS -->|"toTheory(schema)"| ENGINE[PrologEngine / tuProlog solver]
+    ENGINE -->|"query / queryAll / findAll"| DERIVED["Derived facts<br/>(transitive chains, can_help_with, ...)"]
+    ENGINE -.->|"wrapped as LLM tools"| TOOLS["PrologTools<br/>(see oracle & query design, forthcoming)"]
+```
+
+Each box on the left is a concrete type in
+`dice/src/main/kotlin/com/embabel/dice/projection/prolog/`:
+
+- **`GraphProjector`** (from `projection.graph`) classifies a `Proposition` into a
+  `ProjectedRelationship` — a typed, directed edge (`sourceId`, `targetId`, `type`, confidence,
+  grounding). The Prolog projector deliberately does not duplicate this classification; see
+  `DefaultPrologProjector.project()` in `PrologProjector.kt`, which delegates straight to a
+  configured `GraphProjector` and fails loudly if none is configured.
+- **`PrologProjector`** turns a classified relationship into a `PrologFact` — a ground Prolog
+  term with no variables (`PrologProjector.kt`, `PrologTypes.kt`).
+- **`PrologSchema`** maps relationship types to predicate names (`WORKS_AT` → `works_at`) and
+  carries the base rule set loaded from the classpath (`PrologTypes.kt`).
+- **`PrologEngine`** wraps a tuProlog `Solver` over the combined theory (rules + facts) and
+  exposes `query`, `queryAll`, `queryFirst`, `findAll` (`PrologEngine.kt`).
+- **`dice-rules.pl`** (`dice/src/main/resources/prolog/dice-rules.pl`) is the base rule set:
+  hand-written Horn clauses that define derived predicates in terms of the projected facts.
+
+## From proposition to fact
+
+A relationship becomes a fact by looking up its predicate name in the schema and quoting its
+arguments as Prolog atoms:
+
+```prolog
+% ProjectedRelationship(sourceId="alice-1", targetId="acme-corp", type="WORKS_AT", confidence=0.92)
+% becomes, via PrologSchema.getPredicate("WORKS_AT") -> "works_at":
+works_at('alice_1', 'acme_corp').
+confidence(works_at('alice_1', 'acme_corp'), 0.92).
+grounded_by(works_at('alice_1', 'acme_corp'), 'prop-4471').
+```
+
+`PrologFact.quoteAtom` normalizes IDs into safe Prolog atoms (lowercase, non-alphanumeric
+characters collapsed to `_`), which is why entity IDs with dashes show up with underscores in
+the theory — `PrologTools` undoes this normalization when it needs to show a human a result (see
+below).
+
+The `confidence` and `grounded_by` facts are optional companions (`includeConfidence`,
+`includeGrounding` on `DefaultPrologProjector`) — they let a rule or a query filter on how much to
+trust a fact, or trace it back to the proposition that produced it, without polluting the base
+predicate's arity. This mirrors the same provenance discipline the graph projection uses (see
+[graph-projection § Edge lineage](graph-projection.md#edge-lineage)): a Prolog fact is never just
+an assertion, it's an assertion plus a way to ask "why do we believe this."
+
+`PrologProjectionResult.toTheory(schema)` assembles the complete theory that gets loaded into the
+solver: the base rules from `dice-rules.pl`, then the projected facts, then the confidence facts,
+then the grounding facts, each in its own commented section.
+
+## The rule set: derived facts from ground facts
+
+`dice-rules.pl` doesn't project anything by itself — it defines Horn clauses that only ever
+succeed if enough ground facts exist to satisfy them. Two patterns recur:
+
+**Transitive closure**, recursion over a direct relationship:
+
+```prolog
+% Transitive management: X manages Y directly or indirectly
+manages_chain(X, Y) :- manages(X, Y).
+manages_chain(X, Y) :- manages(X, Z), manages_chain(Z, Y).
+```
+
+**Composite derivation**, combining two predicates into a new one:
+
+```prolog
+% Coworkers: people who work at the same company
+coworker(X, Y) :- works_at(X, Company), works_at(Y, Company), X \= Y.
+
+% You can consult a coworker who is an expert
+can_consult(Person, Expert, Topic) :-
+    coworker(Person, Expert),
+    expert_in(Expert, Topic).
+```
+
+Neither `manages_chain/2` nor `can_consult/3` is ever asserted as a fact — they only exist as
+rule heads, and the solver proves them at query time by walking whatever `manages/2`,
+`works_at/2`, and `expert_in/2` facts happen to be in the theory. That's the point of using
+Prolog here rather than hand-rolling BFS/DFS in Kotlin: the rule is the whole implementation, and
+it composes with other rules for free (`can_consult` reuses `coworker`, which reuses `works_at`).
+
+## Adding a rule
+
+To add a new derived relationship:
+
+1. Add a clause to `dice/src/main/resources/prolog/dice-rules.pl`, in the section that matches
+   its shape (transitive chain, composite derivation, or a new query family).
+2. If it derives from a relationship type the schema doesn't already map, add a
+   `PredicateMapping` to `PrologSchema.DEFAULT_MAPPINGS` (or pass `additionalMappings` to
+   `PrologSchema.withDefaults()` at the call site) so the graph-classified relationship type
+   turns into the predicate name your rule expects.
+3. Add a test alongside `PrologEngineTest.kt` / `PrologProjectorTest.kt` that builds a schema with
+   `PrologSchema.withRules(...)` (bypassing the classpath resource) and asserts the derived
+   predicate holds for a small hand-built theory.
+
+No code change is needed to make a new rule queryable — `PrologEngine` loads the whole
+`dice-rules.pl` file as part of the theory, so a new clause is live the next time the schema is
+built from `PrologSchema.withDefaults()`.
+
+## Querying derived facts
+
+`PrologEngine` exposes four query shapes, from simplest to richest:
+
+- `query(goal)` — does at least one solution exist? (boolean)
+- `queryFirst(goal)` — the first solution's variable bindings, or `QueryResult.FAILURE`
+- `queryAll(goal)` — every solution's bindings
+- `findAll(goal, "X")` — just the values bound to one variable, across all solutions
+
+```kotlin
+val schema = PrologSchema.withDefaults()
+val engine = PrologEngine.fromProjection(projectionResult, schema)
+
+// Is there any expert this person can consult on Kubernetes?
+engine.query("can_consult('alice_1', X, 'kubernetes')")
+
+// Who, exactly, and through what chain of coworker/friend/colleague?
+val experts = engine.findAll("can_consult('alice_1', X, 'kubernetes')", "X")
+```
+
+Queries are plain Prolog syntax (no trailing period) — `Struct.parse` turns the string into a
+goal, and the solver runs it against the loaded theory. A malformed query or a parse failure
+degrades to an empty/failed result rather than throwing, which keeps a bad LLM-generated query
+string from taking down a whole tool call.
+
+## Relationship to the graph projection
+
+The two projections are peers over the same source facts, not a pipeline where one replaces the
+other:
+
+| | Graph projection | Prolog projection |
+|---|---|---|
+| Optimized for | entity/relationship storage, visualization, durable lineage | transitive closure, multi-hop derivation, ad hoc logical queries |
+| Backend | Neo4j (via `GraphProjector`), durable and reconciled against existing nodes | in-memory tuProlog theory, ephemeral and rebuilt per query session |
+| Derived facts | none — a graph edge is exactly what was classified | `dice-rules.pl` rule heads, proved at query time |
+
+Because the Prolog engine is rebuilt from a `PrologProjectionResult` rather than reconciled like
+the graph, it has no equivalent to `ProjectionRecord` lineage or stale-cascade — the theory is
+disposable and cheap to regenerate whenever the underlying propositions change. If you need
+durable, queryable lineage for a derived fact, that's a graph-projection concern
+(see [graph-projection § Edge lineage](graph-projection.md#edge-lineage)), not a Prolog one.
+
+## LLM-facing access: PrologTools
+
+An LLM oracle needs to query this knowledge base without knowing Prolog syntax rules by heart or
+the internal ID normalization scheme. `PrologTools`
+(`dice/src/main/kotlin/com/embabel/dice/query/oracle/PrologTools.kt`) wraps a `PrologEngine` as a
+set of `@LlmTool`-annotated methods — `query_prolog`, `list_predicates`, `list_entities`,
+`show_facts`, `check_fact` — that an LLM tool-caller can invoke directly. It also undoes the
+`quoteAtom` normalization (`alice_1` → `Alice`) when it echoes results back, and translates
+human-readable entity names in an incoming query into the underlying IDs before running it. The
+full design of the query oracle that composes these tools is covered in a companion design doc,
+forthcoming as `oracle-and-query.md` — this doc stops at the boundary of "how facts get from
+propositions into a queryable theory."

--- a/docs/design/proposition-lifecycle.md
+++ b/docs/design/proposition-lifecycle.md
@@ -16,11 +16,10 @@ design decision — most exits are one-way, and almost none of them actually des
 ```mermaid
 stateDiagram-v2
     [*] --> ACTIVE : ingested
-    ACTIVE --> PROMOTED : projected into the typed graph
     ACTIVE --> CONTRADICTED : a newer fact clashes with it (revision or ContradictionResolutionPass)
     ACTIVE --> SUPERSEDED : folded into a higher-level abstraction (AbstractionPass)
-    ACTIVE --> STALE : effectiveConfidence decays past threshold (DecaySweepPass / collector)
-    STALE --> ACTIVE : reinforced when the fact is seen again
+    ACTIVE --> STALE : DecayStatusPolicy.evaluate — utility drops below stalenessThreshold
+    STALE --> ACTIVE : DecayStatusPolicy.evaluate — utility recovers above recoveryThreshold
     STALE --> [*] : deliberately retired by hard delete
     CONTRADICTED --> [*] : kept for audit, no auto-revival
     SUPERSEDED --> [*] : kept for audit, no auto-revival
@@ -33,13 +32,16 @@ stateDiagram-v2
 What triggers each transition:
 - **ACTIVE → CONTRADICTED**: `LlmPropositionReviser` at ingest time, or `ContradictionResolutionPass` during a dream-loop cycle.
 - **ACTIVE → SUPERSEDED**: `AbstractionPass` during a dream-loop cycle, when a cluster of facts is folded into a higher-level proposition.
-- **ACTIVE → STALE**: `DecaySweepPass` (via the mark-and-sweep collector), or the scheduled decay tick in `GraphDecayManager`.
-- **STALE → ACTIVE**: `PropositionReviser` on re-ingest, which reinforces the existing proposition and resets its confidence.
-- **PROMOTED**: set by `GraphProjector` on successful projection into the typed graph; it complements ACTIVE rather than replacing it.
+- **ACTIVE → STALE**: `StatusTransitionPolicy.evaluate` (default `DecayStatusPolicy`), run per-proposition by `DecayManager`/`DecaySweeper` (`sweep` / `sweepAll` / `tick`), or by a mark-and-sweep collector run.
+- **STALE → ACTIVE**: the same `DecayStatusPolicy.evaluate` call, when a proposition's decayed utility recovers back above `recoveryThreshold`. The reviser itself never flips status — `reinforceProposition` only boosts confidence and resets the decay clock, which is what lets the next sweep's utility calculation cross back over the threshold.
+A projected proposition keeps its ACTIVE status so it stays retrievable — projection records the
+lineage on the graph side rather than moving the proposition off ACTIVE. `PROMOTED` is a reserved
+status in the enum for a projected fact, and the decay sweep and collector already exclude it from
+their ACTIVE candidate sets, but the lifecycle does not enter it; projection leaves status alone.
 
 The rest of this document is the reasoning behind those transitions.
 
-## Trust and authority SPI seams
+## Trust and authority SPIs
 
 ```mermaid
 classDiagram
@@ -54,7 +56,7 @@ classDiagram
     class AuthorityTier {
         <<enum>>
         PRIMARY
-        NAMED_EXTERNAL
+        SECONDARY
         DERIVED
         UNKNOWN
     }
@@ -68,17 +70,22 @@ classDiagram
 
 ## Trust scoring is advisory
 
-Every proposition can be scored for how much its *source* should be believed, but that score
-never deletes, rewrites, or hides anything. It's advisory: it ranks, and the consumer decides
-what to do with the ranking.
+Every proposition can be scored for how much its *source* should be believed, but the score is
+advisory — it never deletes, rewrites, or hides anything, it just ranks, and the consumer
+decides what to do with the ranking. Destructive automation on a knowledge base is hard to undo,
+so a confident-sounding extraction from a sketchy source shouldn't silently erase a quieter fact
+from a good one; trust should just lose when something has to choose.
 
-The reason is that destructive automation on a knowledge base is hard to undo and easy to get
-wrong. A confident-sounding extraction from a sketchy source shouldn't silently erase a quieter
-fact from a good one — it should just lose when something has to choose. So trust is a number a
-query filter or a ranker can lean on, not a gate baked into the store.
+The shipped scorer, `NeutralTrustScorer`, is deliberately trivial — it returns `1.0` for every
+proposition, so trust scoring is a no-op until a deployment opts in to a real model. `TrustScorer`
+is a `fun interface`, so a custom scorer can be a lambda:
 
-This is why the shipped scorer is deliberately neutral (it trusts everything equally). The seam
-exists so that real deployments opt *in* to a judgment model; nothing changes until they do.
+```kotlin
+// Trust primary sources fully; halve everything else. Ignores conflictType.
+val scorer = TrustScorer { proposition, authorityTier, _ ->
+    if (authorityTier == AuthorityTier.PRIMARY) 1.0 else 0.5
+}
+```
 
 ## Source authority from provenance
 
@@ -165,18 +172,13 @@ flowchart TB
     end
 ```
 
-**Contradiction** happens in the moment a new proposition arrives and is judged to conflict with an
-existing one. The loser is demoted — its confidence is cut and it's marked contradicted. The
-statement we're making is "this is no longer believed."
-
-**Supersession** happens later and for the opposite reason. During background consolidation, a
-cluster of true, low-level facts about the same thing gets abstracted into a single higher-level
-proposition. The originals aren't wrong — they've been *absorbed* — so they're marked superseded
-rather than contradicted. The statement is "there's now a better way to say all of this at once."
-
-Two consequences fall out of keeping them distinct: each transition answers a different question
-("was this wrong?" versus "is there a better summary now?"), and in both cases the original record
-is kept for audit. We don't pretend we never believed something.
+**Contradiction** says "this is no longer believed" — a new proposition arrives and clashes, so
+the loser is demoted on the spot. **Supersession** says "there's now a better way to say all of
+this at once" — during background consolidation a cluster of true, low-level facts is folded into
+one higher-level proposition, and the originals are marked superseded because they've been
+*absorbed*, not disproven. Keeping the two distinct means each transition answers a different
+question ("was this wrong?" vs. "is there a better summary now?"), and either way the original
+record is kept for audit — we don't pretend we never believed something.
 
 ## Decay instead of deletion
 
@@ -192,16 +194,19 @@ is seeing it again (reinforcement), not the passage of time. Hard removal exists
 separate, deliberate step: the default preference is "cold" over "gone," because a knowledge base
 that quietly deletes things is one you stop trusting.
 
-## End-to-end walkthrough
+`Proposition.effectiveConfidence()` is what a sweep's utility calculation actually reads — raw
+`confidence` never changes on its own, only the decayed view of it does:
 
-Follow one fact through its life. It's ingested **active** and scored by the authority of its
-source. It may get **promoted** when it's projected into the typed graph. Later a conflicting fact
-arrives; the reviser demotes the older fact (its confidence cut and its status set to contradicted)
-and a conflict detector labels what kind of clash it was. If nothing references the fact for a while its
-effective confidence decays until it goes **stale**, where it waits to be either reinforced back to
-active or eventually retired. Or, if many siblings about the same entity pile up, a consolidation
-pass folds them into one abstraction and our fact is marked **superseded** — still true, now said
-more concisely.
+```kotlin
+// Same proposition, decay applied against "now" vs. against a fixed past instant.
+val nowConfidence = proposition.effectiveConfidence()
+val lastWeekConfidence = proposition.effectiveConfidenceAt(Instant.now().minus(7, ChronoUnit.DAYS))
+
+// Pinning doesn't change the math above — effectiveConfidence keeps decaying either way.
+// What pinning does is stop DecayStatusPolicy from acting on the result:
+val pinned = proposition.withPinned(true)
+check(DecayStatusPolicy().evaluate(pinned) == null) // sweep-exempt regardless of utility
+```
 
 ## Pinning: permanent protection from the lifecycle
 
@@ -216,6 +221,22 @@ Concretely, the `pinned` field on `Proposition` is a boolean flag you set via `P
 - The dream-loop's contradiction resolution pass (`ContradictionResolutionPass`) inherits the same skip-if-pinned behavior, so background consolidation also respects the pin.
 
 Pinning is an *administrative* operation — it touches only `metadataRevised` and never resets the decay clock (`contentRevised` stays untouched).
+
+```kotlin
+val proposition = Proposition(
+    contextId = contextId,
+    text = "Alice's employee id is E-4471",
+    mentions = listOf(subjectMention, objectMention),
+    confidence = 0.95,
+)
+
+// Pin in place (no store round-trip yet)...
+val pinnedLocally = proposition.withPinned(true)
+
+// ...or pin the persisted record by id.
+propositionStore.save(proposition)
+propositionStore.pin(proposition.id)
+```
 
 ```mermaid
 stateDiagram-v2

--- a/docs/design/reclamation-and-collector.md
+++ b/docs/design/reclamation-and-collector.md
@@ -18,21 +18,23 @@ flowchart LR
     end
     M --> SWEEP{"SweepPolicy.decide"}
     SWEEP -->|TransitionStatus| T["-> STALE (reversible default)"]
+    SWEEP -->|MergeInto| MG["fold loser onto survivor,<br/>then retire"]
     SWEEP -->|HardDelete| D["remove (opt-in only)"]
     SWEEP -->|Skip| K["leave untouched"]
     T --> REC[CollectorRecordStore]
+    MG --> REC
     D --> REC
     K --> REC
 ```
 
-## Collector SPI seams
+## Collector extension points
 
 ```mermaid
 classDiagram
     class CollectorRunner {
         <<interface>>
         +run(contextId, dryRun) CollectorRunResult
-        +collect(contextId) List
+        +collect(contextId) CollectorRunResult
     }
     class CollectorStrategy {
         <<interface>>
@@ -56,6 +58,7 @@ classDiagram
     class SweepAction {
         <<sealed>>
         TransitionStatus(status)
+        MergeInto(survivorId, status)
         HardDelete
         Skip
     }
@@ -76,9 +79,30 @@ skips anything unmarked, and otherwise transitions to `STALE`. It never returns 
 ## The mark phase: strategies and marks
 
 A `CollectorStrategy` inspects the candidate set and flags propositions, producing `PropositionMark`s
-— each carries the proposition id, the strategy name, and a typed `MarkReason` (`Stale`, `Duplicate`,
-or a domain-specific `Custom`). Marking is **purely descriptive**: a strategy never mutates anything,
-it only reports what looks reclaimable. Two strategies ship:
+— each carries the proposition id, the strategy name, and a typed `MarkReason`. `MarkReason` is a
+sealed hierarchy, closed for the built-in strategies but open for consumer-specific signals:
+
+```kotlin
+sealed interface MarkReason {
+    val key: String
+
+    data object Stale : MarkReason {
+        override val key: String = "stale"
+    }
+
+    data class Duplicate(val survivorId: String) : MarkReason {
+        override val key: String = RESERVED_KEY
+        companion object {
+            const val RESERVED_KEY = "duplicate"
+        }
+    }
+
+    data class Custom(override val key: String, val description: String) : MarkReason
+}
+```
+
+Marking is **purely descriptive**: a strategy never mutates anything, it only reports what looks
+reclaimable. Two strategies ship:
 
 **`DecayCollectorStrategy`** marks a proposition whose `effectiveConfidence()` has fallen below a
 retirement threshold — the decay path into staleness (decay itself is covered in
@@ -108,7 +132,7 @@ flowchart TB
 ## The sweep phase: policy and actions
 
 A `SweepPolicy` looks at a proposition and its marks and returns a `SweepAction` — `TransitionStatus`,
-`HardDelete`, or `Skip`. The policy only *decides*; applying the action is the runner's job, which
+`MergeInto`, `HardDelete`, or `Skip`. The policy only *decides*; applying the action is the runner's job, which
 keeps "what counts as garbage" (strategies) independent from "what happens to it" (policy).
 
 The default `StatusTransitionSweepPolicy` is deliberately safe: it skips pinned propositions no matter
@@ -116,7 +140,26 @@ what marks they carry, skips anything unmarked, and otherwise transitions to `ST
 returns `HardDelete` — the shipped default is reversible, and destructive removal is something a
 deployment opts into with a different policy.
 
+`MergingSweepPolicy` is actually the builder's default policy — unconditional, not gated on calling
+`withDuplicateDetection()`. It returns `MergeInto` for duplicates marked by the
+`DuplicateCollectorStrategy`: it folds the loser's grounding, provenance, and source IDs onto the
+survivor before retiring the loser to `STALE`. Without this merge, the loser's evidence would become
+invisible from retrieval the instant STALE propositions are excluded, even though that evidence was
+real. The policy still skips pinned propositions and unmarked ones, and falls back to a plain
+status transition when a mark doesn't name a usable survivor (no duplicate mark, or a duplicate mark
+pointing at a blank id or itself) — so a non-dedup mark still retires normally. A deployment that
+wants pure status flips even for duplicates can swap it out via `withPolicy(StatusTransitionSweepPolicy())`.
+
 ## Entry points: collect, dry run, live run
+
+A runner is assembled with `CollectorRunner.withRepository(...)`'s fluent builder:
+
+```kotlin
+val runner = CollectorRunner.withRepository(repository)
+    .withStrategy(DecayCollectorStrategy(retireBelow = 0.1))
+    .withDuplicateDetection()
+    .build()
+```
 
 The `CollectorRunner` has two entry points and the run has two modes, separating "what would happen"
 from "make it happen":
@@ -133,8 +176,24 @@ flowchart TB
 **dry run** decides every fate and writes the audit trail but mutates nothing, so a policy can be
 previewed against real data before it's let loose. A **live run** applies each decision, emits a
 `PropositionStatusChanged` per transition (the same event the store emits, so a collector transition
-looks identical to any other — see [events](events.md)), and records every outcome. A
-`CollectorRunResult` partitions what happened into `marks`, `applied`, `skipped`, and `hardDeleted`.
+looks identical to any other — see [events](events.md)), and records every outcome. Both entry points
+return the same shape:
+
+```kotlin
+data class CollectorRunResult(
+    val runId: String,
+    val dryRun: Boolean,
+    val marks: List<PropositionMark>,
+    val applied: List<PropositionMark>,
+    val skipped: List<PropositionMark>,
+    val hardDeleted: List<String>,
+    val startedAt: Instant,
+    val finishedAt: Instant = Instant.now(),
+)
+```
+
+`collect()` only ever populates `marks` — `applied`/`skipped`/`hardDeleted` stay empty and `runId` is
+blank, since nothing was persisted.
 
 ## The audit trail
 
@@ -142,6 +201,12 @@ Reclamation is built to be explainable after the fact. When a `CollectorRecordSt
 each run writes one `CollectorRun` header and a `CollectorRecord` per acted-upon proposition. A record
 carries the typed reason, the `CollectorOutcome`, and the before/after status, so a reviewer can trace
 exactly why each proposition was touched and what happened to it.
+
+`CollectorRecordStore` and `CollectorTraceStore` (see
+[collector-trace-store](collector-trace-store.md)) are two independent, coexisting audit systems, not
+two descriptions of the same thing: the record store logs a per-proposition outcome for any collector
+strategy's mark-and-sweep, while the trace store logs the per-run signal/edge/component/decision detail
+that only `MultiSignalCollectorStrategy` produces.
 
 The store is **append-only**, and a run header is written even for a zero-mark run, so "the collector
 ran and found nothing" is a retrievable fact rather than silence. The outcome vocabulary keeps a

--- a/docs/design/report.md
+++ b/docs/design/report.md
@@ -1,0 +1,126 @@
+# Report: projecting propositions into human-facing artifacts
+
+`dice-report` turns a set of propositions the caller has already queried into something a person
+reads: a structured breakdown, a discovered link between entities that aren't directly connected,
+or LLM-generated prose explaining why something is believed. Every projector here is a pure
+function over the propositions it's handed — none of them query the store, and none of them
+decide *which* propositions to include. That's always the caller's job (typically via
+`PropositionQuery` against `PropositionStore` — see [architecture](architecture.md)).
+
+```mermaid
+flowchart LR
+    QUERY["Caller queries store<br/>PropositionQuery"] --> PROPS["List&lt;Proposition&gt;"]
+    PROPS --> SRP["StructuredReportProjector<br/>(deterministic, no LLM)"]
+    PROPS --> SLD["TwoHopSemanticLinkDiscoverer<br/>(deterministic, no LLM)"]
+    SRP --> REPORT["Report<br/>(byStatus, byLevel, topByConfidence)"]
+    SLD --> LINKS["List&lt;SemanticLink&gt;<br/>(reviewable, CANDIDATE by default)"]
+    PROPS --> RAT["LlmRationaleProjector<br/>(LLM-backed)"]
+    LINKS -.optional.-> RAT
+    RAT --> ARTIFACT["RationaleArtifact<br/>(prose + confidence)"]
+```
+
+Two of the three projectors are deliberately LLM-free: `StructuredReportProjector` and
+`TwoHopSemanticLinkDiscoverer` are pure structural aggregation, so they're deterministic,
+reproducible, and safe to run in a demo or a test without mocking a model. `LlmRationaleProjector`
+is the one place in this module that calls out to an LLM, and it's opt-in — a report or a set of
+discovered links is useful on its own without rationale prose.
+
+## Core types
+
+| Type | Role |
+|---|---|
+| `ReportProjector` | `report(propositions, title) -> Report`. Single method, deterministic contract. |
+| `StructuredReportProjector` | The shipped `ReportProjector`: groups by status and level, takes top-N by effective confidence. |
+| `Report` | A `Projection` — groups plus `sourcePropositionIds` tracing back to every input proposition. Has `.summary()` for a plain-text breakdown. |
+| `SemanticLinkDiscoverer` | `discover(propositions) -> List<SemanticLink>`. Finds indirect connections between entities. |
+| `TwoHopSemanticLinkDiscoverer` | The shipped discoverer: two entities never directly co-mentioned but sharing a common neighbor get linked, with that neighbor as evidence. |
+| `SemanticLink` | A reviewable, `Projection`-backed link: endpoints, connecting entities, `LinkKind` (EXPLICIT/INFERRED/AMBIGUOUS), `ReviewStatus` (CANDIDATE → ACCEPTED/REJECTED/STALE/SUPERSEDED), plain evidence `confidence`, optional `rationale`. |
+| `RationaleProjector` | `rationale(proposition)` / `rationale(group)` -> `RationaleArtifact`. Interpretive, expected to be LLM-backed. |
+| `LlmRationaleProjector` | The shipped `RationaleProjector`, built via `withLlm(options).withAi(ai)`. |
+| `RationaleArtifact` | A `Projection`: generated prose, `sourcePropositionIds`, self-reported `confidence`. |
+
+## Projection pipeline
+
+```mermaid
+flowchart TB
+    subgraph input ["Caller-controlled input"]
+        Q["PropositionStore.query(...)"] --> P["List&lt;Proposition&gt;"]
+    end
+    P --> A{"What's needed?"}
+    A -->|"structural summary"| B["StructuredReportProjector.report(props, title)"]
+    A -->|"hidden connections"| C["TwoHopSemanticLinkDiscoverer.discover(props)"]
+    A -->|"human explanation"| D["LlmRationaleProjector.rationale(prop or group)"]
+    B --> R1["Report<br/>confidence=1.0, decay=0.0"]
+    C --> R2["List&lt;SemanticLink&gt;<br/>reviewStatus=CANDIDATE"]
+    D --> R3["RationaleArtifact<br/>confidence from LLM"]
+    R2 -.human review.-> R2B["ACCEPTED / REJECTED / STALE / SUPERSEDED"]
+    R2 -.optional enrich.-> D
+```
+
+All three outputs implement `Projection`, so every one traces back to the propositions that
+produced it via `sourcePropositionIds` — the same grounding discipline used throughout DICE (see
+[architecture: store and trust/authority](architecture.md#store-and-trustauthority)).
+`Report` and `SemanticLink` fix `confidence=1.0`/`decay=0.0` or plain evidence confidence
+respectively — neither carries a surprise or ranking score; that's an explicitly separate,
+later concern for `SemanticLink`.
+
+## StructuredReportProjector: grouping and ranking
+
+Given a non-empty list, it groups by `PropositionStatus` and by abstraction `level` (both
+preserving encounter order within a group), and separately ranks the *whole* input by effective
+confidence descending, ties broken by id, taking the top N (default 5). An empty input short
+circuits to `Report.EMPTY` with the title substituted. No LLM, vector store, or graph call is
+involved — same input always yields the same report.
+
+## TwoHopSemanticLinkDiscoverer: indirect links only
+
+Only `ACTIVE` propositions participate. It builds direct co-mention edges (canonical
+`min <= max` id ordering) and per-entity neighbor sets, then for every entity pair *not* directly
+connected, checks whether their neighbor sets intersect. A shared neighbor becomes a connecting
+entity on an `INFERRED` link; evidence is the union of the two edges' backing proposition ids.
+Multiple intermediaries for the same pair merge into one link (sorted connecting-id list) rather
+than emitting duplicates. Path length is fixed at two hops — multi-hop discovery is out of scope
+here. Output is sorted by `(sourceEntityId, targetEntityId, connectingEntityIds)` for a stable,
+reproducible order.
+
+## LlmRationaleProjector: the one interpretive projector
+
+Turns a proposition or a `PropositionGroup` into prose via a templated LLM call
+(`dice/explain_rationale`), returning a self-reported confidence clamped to `[0.0, 1.0]`.
+
+**Security note.** Proposition text is embedded directly in the prompt. Since that text
+typically originates from ingested source documents (see [ingestion](ingestion.md)), it must be
+treated as untrusted — a crafted document could embed instructions the rationale model might
+follow. The template wraps proposition data in a labelled block as a mitigation, not a guarantee;
+sanitizing ingested content and not granting rationale output undue authority downstream is the
+caller's responsibility.
+
+## Common use case: generating a report
+
+```kotlin
+val props = repository.query(PropositionQuery.forContextId(ctxId))
+
+val report = StructuredReportProjector().report(props, "Context Overview")
+println(report.summary())
+
+val links = TwoHopSemanticLinkDiscoverer().discover(props)
+
+val rationaleProjector = LlmRationaleProjector.withLlm(llmOptions).withAi(ai)
+links.firstOrNull()?.let { link ->
+    val group = PropositionGroup(label = "shared context", propositions = props.filter {
+        it.id in link.sourcePropositionIds
+    })
+    val explained = link.withRationale(rationaleProjector.rationale(group).text)
+}
+```
+
+## Design notes
+
+- **Determinism where it's free, LLM only where it's the point** (see the intro above) — rationale
+  generation is kept behind its own interface so a caller can skip it entirely.
+- **Query is always upstream.** None of these types touch `PropositionStore` — that keeps report
+  projection reusable across whatever query shape a caller needs, and keeps this module testable
+  with plain in-memory proposition lists.
+- **Review lifecycle lives on the link, not the discoverer.** `SemanticLink.reviewStatus`
+  defaults to `CANDIDATE`; `TwoHopSemanticLinkDiscoverer` never mutates it further — moving a
+  link to `ACCEPTED`/`REJECTED`/etc. is a downstream human-review concern, not discovery's.

--- a/docs/design/retrieval-and-discovery.md
+++ b/docs/design/retrieval-and-discovery.md
@@ -16,7 +16,7 @@ REST controller that wrap both.
 classDiagram
     class RetrievalRouter {
         +retrieve(DiscoveryQuery) DiscoveryResult
-        +graphPath(fromId, toId) List
+        +graphPath(entityIdA, entityIdB) List
         +whyExplain(propositionId) LineageDto
     }
     class DiscoveryQuery {
@@ -44,9 +44,12 @@ classDiagram
     class GraphQueryCapable {
         <<interface>>
         +honorsAuthorityFilter Boolean
+        +honorsContextFilter Boolean
+        +neighborhood(entityId, depth, contextId)
         +neighborhood(entityId, depth, minAuthority)
+        +pathBetween(entityIdA, entityIdB, contextId)
         +pathBetween(entityIdA, entityIdB, minAuthority)
-        +whyExplain(propositionId)
+        +whyExplain(propositionId, contextId)
     }
     RetrievalRouter --> GraphQuery : delegates graph ops
     RetrievalRouter --> DiscoveryQuery : parameterized by
@@ -66,38 +69,42 @@ Neighborhood, path, and lineage queries don't require a graph database. A propos
 two resolved entities already *is* an edge between them, so the portable query surface answers
 graph-shaped questions by walking propositions one hop at a time over whatever store is underneath.
 A native graph backend gets routed to first when it can do the traversal faster, but the portable
-walk is always there as the floor.
-
-The decision behind this is that graph-shaped *reasoning* shouldn't be chained to graph
+walk is always there as the floor — graph-shaped *reasoning* shouldn't be chained to graph
 *infrastructure*. A lightweight in-memory setup should still answer "how is A connected to B?"
-without standing up Neo4j. And when a capability genuinely isn't there, these operations return
-empty or null rather than throwing — asking a question the backend can't fully answer gives you
-"nothing found," not an error.
+without standing up Neo4j.
+
+The durable Neo4j backend implements `GraphQueryCapable`, so graph queries there run as native
+Cypher — for both unscoped and context-scoped queries. The context is pushed straight into the
+traversal (a `contextId` predicate on every hop), so the production callers, which are all
+context-scoped (`DiscoveryController`, `GraphQueryTools`, and downstream consumers), still get the
+native Cypher rather than dropping to the portable walk. A store without the capability, or one that
+doesn't confine a walk to a context itself, falls back to the portable walk below.
 
 ```mermaid
 flowchart TD
     GQ["GraphQuery.neighborhood(entityId, depth)"] --> CAP{"store implements<br/>GraphQueryCapable?"}
-    CAP -->|"yes AND honorsAuthorityFilter"| NATIVE["route to native neighborhood()<br/>with minAuthority"]
-    CAP -->|"yes, no authority filter"| NATIVEPLAIN["route to native neighborhood()"]
-    CAP -->|"no"| PORTABLE["portable walk: follow proposition<br/>mentions hop by hop"]
+    CAP -->|"no"| PORTABLE["portable walk: follow proposition<br/>mentions hop by hop (context-scoped)"]
+    CAP -->|"yes"| SCOPE{"context-scoped query?"}
+    SCOPE -->|"no (unscoped)"| AUTH
+    SCOPE -->|"yes AND honorsContextFilter"| AUTH{"authority floor set?"}
+    SCOPE -->|"yes, no honorsContextFilter"| PORTABLE
+    AUTH -->|"no floor"| NATIVEPLAIN["route to native neighborhood()<br/>with contextId"]
+    AUTH -->|"floor AND honorsAuthorityFilter"| NATIVE["route to native neighborhood()<br/>with minAuthority"]
+    AUTH -->|"floor, no honorsAuthorityFilter"| PORTABLE
     NATIVE --> RESULT[GraphNeighborhood]
     NATIVEPLAIN --> RESULT
     PORTABLE --> RESULT
 ```
 
-## Query-time authority filtering
-
-Graph queries take an optional authority floor. Edges below it are dropped *during* the traversal,
-with authority re-resolved from each proposition's provenance as the walk proceeds — nothing is
-filtered out at write time.
-
-This is a deliberate tradeoff. Trust policy changes more often than data does, and different callers
-want different floors over the same facts. Baking a trust cutoff into stored edges would mean
-re-ingesting everything whenever the policy moved, and would force one global standard on every
-consumer. Filtering at read time keeps the stored graph complete and lets each query decide how
-cautious to be. The safe-fail detail matters here: a proposition with no provenance resolves to the
-weakest tier, so any non-trivial floor drops it — unknown provenance is treated as low trust, not
-waved through.
+Graph queries also take an optional authority floor. Edges below it are dropped *during* the
+traversal, with authority re-resolved from each proposition's provenance as the walk proceeds —
+nothing is filtered out at write time. Trust policy changes more often than data does, and different
+callers want different floors over the same facts; baking a trust cutoff into stored edges would
+mean re-ingesting everything whenever the policy moved, and would force one global standard on every
+consumer. A proposition with no provenance resolves to the weakest tier, so any non-trivial floor
+drops it — unknown provenance is treated as low trust, not waved through. And when a capability
+genuinely isn't there, these operations return empty or null rather than throwing — asking a
+question the backend can't fully answer gives you "nothing found," not an error.
 
 The `GraphQueryCapable.honorsAuthorityFilter` flag is how a native backend opts in to handling the
 filtering itself. When it is false (the default), the portable facade applies authority filtering
@@ -105,6 +112,14 @@ on its own proposition-walk, so the correct result comes back either way. A back
 only after it genuinely honours the `minAuthority` argument in its `neighborhood` and `pathBetween`
 overloads — and if it sets the flag without overriding those overloads, the default bodies throw
 rather than silently returning unfiltered results.
+
+`GraphQueryCapable.honorsContextFilter` works the same way for context scoping. When it is false (the
+default), the facade keeps a context-scoped query on its own proposition-walk, which already confines
+the walk to the context — so a backend that ignores context never receives a scoped query and can't
+leak another context's edges. A backend sets it to true only once its context-aware `neighborhood`,
+`pathBetween`, and `whyExplain` overloads genuinely confine the walk to the supplied `contextId`; the
+Neo4j backend does exactly that, adding a `contextId` predicate to every hop. An unscoped query (null
+context) behaves identically down either path.
 
 ## Single retrieval entry point
 
@@ -138,14 +153,14 @@ capabilities; that's exactly the knowledge the router is there to hold.
 
 Everything that crosses out to a caller is a DTO of primitives and enums — never an internal type
 like a proposition or a store handle. And the request itself never carries a context of its own: the
-agent tools fix the context when they're constructed, and the REST layer takes it from the URL path.
+agent tools fix the context when they're constructed, the REST layer takes it from the URL path, and
+the request body has no context field, so a caller *cannot* ask one context's endpoint for another
+context's data. Cross-context reads aren't forbidden by a check; they're structurally impossible, and
+an LLM given the agent tools can't wander across context boundaries either.
 
-Two concerns drive this. One is a stable external contract: internal types can evolve without
-breaking the wire, and a leak-check guards against a domain type sneaking into a DTO by accident. The
-other is isolation — because the request body has no context field, a caller *cannot* ask one
-context's endpoint for another context's data. Cross-context reads aren't forbidden by a check;
-they're structurally impossible, and an LLM given the agent tools can't wander across context
-boundaries either.
+Two concerns drive this: a stable external contract (internal types can evolve without breaking the
+wire, and a leak-check guards against a domain type sneaking into a DTO by accident) and that
+structural isolation.
 
 ```mermaid
 sequenceDiagram
@@ -166,6 +181,111 @@ sequenceDiagram
     end
     Router-->>Entry: results
     Entry-->>Caller: DTOs only — primitives and enums, no internal types
+```
+
+## The discovery DTO shapes
+
+The request/result DTOs (`com.embabel.dice.query.discovery.DiscoveryDtos`, plus `DiscoveryQuery`
+and `RetrievalMode` alongside them) are the concrete shapes that make the "DTO boundary" above real.
+Every one of them is primitives, `String`, `Instant`, enums, or another DTO in this same file — the
+`from()` factory on each one is the only place a domain type (`Proposition`, `GraphPath`,
+`GraphNeighborhood`, `PropositionLineage`) is read, and a reflection-based leak-check test
+(`DiscoveryDtoLeakTest`) fails the build if a future field reintroduces one.
+
+```mermaid
+classDiagram
+    class DiscoveryQuery {
+        +mode RetrievalMode
+        +text String
+        +entityId String
+        +from Instant
+        +to Instant
+        +topK Int
+        +depth Int
+        +similarityThreshold Double
+    }
+    class RetrievalMode {
+        <<enum>>
+        VECTOR
+        ENTITY
+        GRAPH_WALK
+        TEMPORAL
+        HYBRID
+    }
+    class DiscoveryResult {
+        +mode RetrievalMode
+        +supported Boolean
+        +propositions List~PropositionSummaryDto~
+    }
+    class PropositionSummaryDto {
+        +id String
+        +text String
+        +confidence Double
+        +status String
+        +mentions List~EntityMentionSummaryDto~
+        +grounding List~String~
+    }
+    class EntityMentionSummaryDto {
+        +name String
+        +type String
+        +resolvedId String
+        +role String
+    }
+    class PathDto {
+        +entityIds List~String~
+        +edges List~PropositionSummaryDto~
+    }
+    class NeighborhoodDto {
+        +centerEntityId String
+        +via List~PropositionSummaryDto~
+    }
+    class LineageDto {
+        +propositionId String
+        +text String
+        +status String
+        +reinforceCount Int
+        +groundingChunkIds List~String~
+        +sourceSummaries List~String~
+    }
+    DiscoveryQuery --> RetrievalMode : mode
+    DiscoveryResult --> RetrievalMode : mode
+    DiscoveryResult --> PropositionSummaryDto : propositions
+    PropositionSummaryDto --> EntityMentionSummaryDto : mentions
+    PathDto --> PropositionSummaryDto : edges
+    NeighborhoodDto --> PropositionSummaryDto : via
+```
+
+`DiscoveryQuery` is the one request shape for every mode in `RetrievalMode` — the router reads only
+the fields the mode needs (see the retrieval-router flowchart above for which) and clamps
+`topK`/`depth`/`similarityThreshold` before doing any work, so a caller can't force an unbounded scan
+or traversal. `PropositionSummaryDto` is the leaf every
+discovery result bottoms out to — `DiscoveryResult.propositions`, `PathDto.edges`, and
+`NeighborhoodDto.via` are all lists of it, each entry carrying its own leak-free
+`EntityMentionSummaryDto` mentions. `LineageDto` is the odd one out: it flattens a
+`PropositionLineage` (proposition + status + reinforcement count + grounding + abstraction sources)
+into one record rather than nesting further DTOs, because "why is this held" is meant to read as a
+flat explanation, not a graph to walk.
+
+A minimal discovery query, issued through `RetrievalRouter` directly (the same call an agent tool or
+the REST controller makes underneath):
+
+```kotlin
+val router = RetrievalRouter(store, graphQuery, contextId)
+
+val result = router.retrieve(
+    DiscoveryQuery(
+        mode = RetrievalMode.HYBRID,
+        text = "who reviewed the Q3 budget",
+        entityId = "entity:alice",
+        depth = 2,
+        topK = 5,
+    ),
+)
+
+if (!result.supported) {
+    // store has no VectorSearchCapable fragment — HYBRID degraded to the graph-only arm
+}
+result.propositions.forEach { println("${it.text} (confidence=${it.confidence})") }
 ```
 
 ## Agent tools and REST surface
@@ -191,9 +311,10 @@ flowchart TB
 ```
 
 `DiscoveryTools` and `GraphQueryTools` are registered as `List<Tool>` via their `asTools()` factory
-and added to an agent's tool set alongside `Memory`. `DiscoveryController` activates only when
-`spring-webmvc` is on the classpath and a `PropositionStore` bean is present; it is not
-component-scanned and must be imported via `DiceRestConfiguration`.
+and added to an agent's tool set alongside `Memory`. `DiscoveryController` activates only when beans
+for `PropositionStore`, `ProjectionRecordStore`, and `CollectorRunner` are all present
+(`@ConditionalOnBean(value = [...])`); it is not component-scanned and must be imported via
+`DiceRestConfiguration`.
 
 ## Serendipitous link discovery
 
@@ -211,11 +332,11 @@ flowchart LR
 
 The design decision is that this is *proactive* rather than reactive — anchorless discovery instead of
 anchored lookup. It's kept purely structural and deterministic (two hops over co-mention edges, over
-active propositions only), which makes it cheap and reproducible. And it deliberately reports only
-evidence quality, not a "surprise" ranking — the confidence on a discovered link reflects how well
-the evidence supports it, and judging which links are *interesting* is left to the consumer. Each
-discovered link starts as a candidate and carries a review state, because suggesting a connection and
-accepting it as known are different acts.
+active propositions only), which makes it cheap and reproducible. And it deliberately doesn't try to
+rank links by "surprise" — that judgement is left to the consumer. `TwoHopSemanticLinkDiscoverer`
+gives every discovered link a neutral `confidence = 0.5`: a starting point for review, not an
+evidence-strength score. Each link starts as a candidate and carries a review state, because
+suggesting a connection and accepting it as known are different acts.
 
 ## Explainability: rationale and reports
 

--- a/docs/design/web-api.md
+++ b/docs/design/web-api.md
@@ -1,0 +1,230 @@
+# Web API surface
+
+DICE is a library, not a service — everything so far (extraction, storage, retrieval) is a Kotlin
+API meant to be embedded. This note covers the one part that's meant to be called over HTTP: an
+opt-in REST surface over the pipeline, memory, and discovery layers, gated by a single API-key
+filter. The design goal is the same "opt-in, nothing by default" posture the rest of DICE uses —
+a consuming app decides whether to expose HTTP at all, and decides how to authenticate it.
+
+## Opt-in by import, not by classpath
+
+None of the three controllers are component-scanned. They activate only when a consumer imports
+`DiceRestConfiguration`, and even then each controller only registers if its required beans are
+present — `@ConditionalOnBean` on `PropositionStore`/`ProjectionRecordStore`/`CollectorRunner` for
+discovery, `PropositionPipeline` for extraction. `MemoryController` is the one exception: it has no
+`@ConditionalOnBean` guard, so it activates whenever `DiceRestConfiguration` is imported and a
+`PropositionRepository` bean exists (which any DICE consumer will have).
+
+```java
+@Configuration
+@Import(DiceRestConfiguration.class)
+public class MyAppConfiguration { }
+```
+
+The same pattern the agent-tools layer uses for opt-in tool registration — the controllers exist
+in the jar but never intercept a request unless a consumer explicitly wires them in.
+
+```mermaid
+flowchart TD
+    subgraph ServletFilterChain["Servlet filter chain (order HIGHEST_PRECEDENCE+100)"]
+        FILTER["ApiKeyAuthenticationFilter<br/>urlPatterns: /*"]
+    end
+    FILTER -->|"path matches dice.security.api-key.path-patterns<br/>(default /api/v1/**)"| GATE{"X-API-Key header valid?"}
+    FILTER -->|"path does not match"| PASS["pass through unauthenticated"]
+    GATE -->|"no"| REJECT["401 Unauthorized JSON"]
+    GATE -->|"yes"| ATTRS["set principal + metadata request attributes"]
+    ATTRS --> ROUTE{"which controller"}
+    PASS --> ROUTE
+
+    subgraph RestSurface["Opt-in REST surface, imported via DiceRestConfiguration"]
+        ROUTE -->|"/memory/**"| MEM["MemoryController<br/>always active, needs PropositionRepository"]
+        ROUTE -->|"/discovery/**"| DISC["DiscoveryController<br/>needs PropositionStore + ProjectionRecordStore + CollectorRunner"]
+        ROUTE -->|"/extract, /extract/file"| PIPE["PropositionPipelineController<br/>needs PropositionPipeline"]
+    end
+
+    MEM --> REPO["PropositionRepository"]
+    DISC --> ROUTER["RetrievalRouter / GraphQuery<br/>scoped to path contextId"]
+    PIPE --> PIPELINE["PropositionPipeline"]
+```
+
+All three controllers hang off `com.embabel.dice.web.rest`. Every path starts with
+`/api/v1/contexts/{contextId}/...` — the context always comes from the path variable, never from
+the request body, so a caller can't smuggle a different context in through JSON and read or write
+across a boundary they weren't given.
+
+## API-key authentication
+
+Auth is a plain servlet filter, not Spring Security — `ApiKeyAuthenticationFilter` extends
+`OncePerRequestFilter` and is registered directly as a `FilterRegistrationBean`, so it works whether
+or not the consumer has Spring Security on the classpath at all.
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant F as ApiKeyAuthenticationFilter
+    participant A as ApiKeyAuthenticator
+    participant Ctrl as DiscoveryController
+    participant R as RetrievalRouter
+
+    C->>F: POST /api/v1/contexts/ctx-1/discovery/query, X-API-Key header
+    F->>F: shouldAuthenticate path against pathPatterns
+    alt path not protected
+        F->>Ctrl: doFilter, request passes through unauthenticated
+    else path protected
+        F->>A: authenticate(apiKey)
+        alt key missing or invalid
+            A-->>F: AuthResult.Unauthorized(reason)
+            F-->>C: 401, error JSON body
+        else key valid
+            A-->>F: AuthResult.Authorized(principal, metadata)
+            F->>F: set PRINCIPAL_ATTRIBUTE, AUTH_METADATA_ATTRIBUTE on request
+            F->>Ctrl: doFilter, request continues
+            Ctrl->>R: router(contextId).retrieve(DiscoveryQuery)
+            R-->>Ctrl: DiscoveryResult
+            Ctrl-->>C: 200 OK, DiscoveryResult body
+        end
+    end
+```
+
+Key points:
+
+- **Off by default.** `ApiKeySecurityAutoConfiguration` only activates on
+  `dice.security.api-key.enabled=true`. With it off, none of the REST endpoints check anything —
+  auth is the consuming app's responsibility if it doesn't opt in here.
+- **Pluggable validator.** `ApiKeyAuthenticator` is an interface; `InMemoryApiKeyAuthenticator`
+  (a `Set<String>` lookup) is the default and is meant for dev/test. Production should supply its
+  own `ApiKeyAuthenticator` bean (`@ConditionalOnMissingBean` lets a consumer override it) backed
+  by a real key store:
+
+  ```kotlin
+  @Configuration
+  class MyApiKeyConfiguration {
+      @Bean
+      fun apiKeyAuthenticator(vaultClient: VaultClient): ApiKeyAuthenticator =
+          object : ApiKeyAuthenticator {
+              override fun authenticate(apiKey: String): AuthResult =
+                  if (vaultClient.isValid(apiKey)) {
+                      AuthResult.Authorized(principal = vaultClient.principalFor(apiKey))
+                  } else {
+                      AuthResult.Unauthorized("Invalid API key")
+                  }
+          }
+  }
+  ```
+
+  A missing or invalid key gets back:
+
+  ```json
+  {"error": "Unauthorized", "message": "Missing API key header: X-API-Key"}
+  ```
+- **Path-scoped, not endpoint-scoped.** `pathPatterns` (default `["/api/v1/**"]`) decides which
+  requests need a key at all; everything outside that prefix — actuator endpoints, a consumer's
+  own controllers — passes straight through the filter untouched.
+- **Principal flows via request attributes, not a `SecurityContext`.** A validated key sets
+  `dice.auth.principal` and `dice.auth.metadata` as servlet request attributes
+  (`ApiKeyAuthenticationFilter.PRINCIPAL_ATTRIBUTE` / `AUTH_METADATA_ATTRIBUTE`). Controllers don't
+  currently read these — there's no per-key authorization narrowing (e.g. restricting a key to
+  certain contexts) yet, just presence/absence of a valid key.
+- **Config shape:**
+
+  ```yaml
+  dice:
+    security:
+      api-key:
+        enabled: true
+        keys: ["dev-key-123"]
+        header-name: X-API-Key   # default
+        path-patterns: ["/api/v1/**"]  # default
+  ```
+
+## Controllers
+
+### `PropositionPipelineController` — run extraction over HTTP
+
+`@RequestMapping("/api/v1/contexts/{contextId}")`, gated on a `PropositionPipeline` bean.
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/extract` | Run the pipeline on raw text, persist and return propositions + entity/revision summary |
+| POST | `/extract/file` (multipart) | Parse a file with Tika, chunk it, run each chunk through the pipeline, persist, return an aggregated summary |
+
+`/extract/file` calls `propositionPipeline.process(chunks, context)` — the batch entry point, not
+`processChunk()` per chunk — specifically because `process()` isolates a failing chunk into a typed
+`Failed` result instead of letting one bad chunk 500 the whole upload, and it's the only path that
+honors the configured extraction execution strategy (Serial/Parallel/Batched).
+
+```bash
+curl -X POST http://localhost:8080/api/v1/contexts/acme-corp/extract \
+  -H "X-API-Key: dev-key-123" -H "Content-Type: application/json" \
+  -d '{"text": "Acme acquired Globex in March.", "sourceId": "press-release-1"}'
+```
+
+```bash
+curl -X POST http://localhost:8080/api/v1/contexts/acme-corp/extract/file \
+  -H "X-API-Key: dev-key-123" \
+  -F "file=@press-release.pdf" \
+  -F "sourceId=press-release-1"
+```
+
+### `MemoryController` — read/write stored propositions directly
+
+`@RequestMapping("/api/v1/contexts/{contextId}/memory")`, always active once
+`DiceRestConfiguration` is imported (no `@ConditionalOnBean` guard beyond needing the repository).
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/memory` | List propositions for a context, filterable by status/minConfidence/limit |
+| POST | `/memory/search` | Similarity search, filtered post-hoc by context/status/confidence/mention type |
+| GET | `/memory/entity/{entityType}/{entityId}` | Propositions mentioning a specific entity |
+| POST | `/memory` | Create a proposition directly, bypassing extraction |
+| GET | `/memory/{propositionId}` | Fetch one proposition (404 if it belongs to a different context) |
+| DELETE | `/memory/{propositionId}` | Retract a proposition (marks `CONTRADICTED`, doesn't hard-delete) |
+
+Every read that takes a `propositionId` checks `contextIdValue != contextId` and returns 404 rather
+than 403 — the same "don't confirm existence of things outside your context" posture used
+elsewhere in DICE.
+
+```bash
+curl http://localhost:8080/api/v1/contexts/acme-corp/memory?status=ACTIVE&limit=20 \
+  -H "X-API-Key: dev-key-123"
+```
+
+### `DiscoveryController` — the retrieval and maintenance surface
+
+`@RequestMapping("/api/v1/contexts/{contextId}/discovery")`, gated on
+`PropositionStore` + `ProjectionRecordStore` + `CollectorRunner` beans. See
+[retrieval-and-discovery.md](retrieval-and-discovery.md) for what `RetrievalRouter` and
+`GraphQuery` do underneath — this controller is a thin, context-scoped wrapper over both.
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/discovery/query` | Mode-routed retrieval (`DiscoveryQuery` body: mode/text/entity/window/topK/depth) |
+| GET | `/discovery/path?from=&to=` | Leak-free path summary between two entities |
+| GET | `/discovery/why/{propositionId}` | Lineage explanation for a stored fact (404 if unknown) |
+| GET | `/discovery/projection-health` | Per-target projection lifecycle counts for this context |
+| POST | `/discovery/collector/dry-run` | Preview what mark-and-sweep would do, without mutating anything |
+
+Every operation builds its own `RetrievalRouter`/`GraphQuery` scoped to the path `contextId` — there
+is no shared, unscoped router a handler could accidentally reuse across contexts. A blanket
+`@ExceptionHandler(Exception::class)` turns any store/driver failure (timeouts, query errors) into
+a fixed-message 500; the real cause is logged server-side only, so internal detail never reaches
+the caller regardless of a consumer's own global error handling.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/contexts/acme-corp/discovery/query \
+  -H "X-API-Key: dev-key-123" -H "Content-Type: application/json" \
+  -d '{"mode": "HYBRID", "text": "Globex acquisition", "topK": 10}'
+```
+
+## Design choices
+
+- **Leak-free DTOs, not domain objects.** The discovery layer returns `*Dto` types
+  (`DiscoveryResult`, `PathDto`, `LineageDto`, `ProjectionHealthDto`) rather than the internal
+  `GraphNeighborhood`/`PropositionLineage` types — the REST boundary is a translation layer, same
+  as the agent tools layer.
+- **Auth is orthogonal to controller activation.** A controller can be active with the API-key
+  filter disabled (open endpoints) or the filter can be enabled while a controller's own
+  `@ConditionalOnBean` guard keeps it dark (404, not 401). The two opt-ins are independent knobs —
+  check both when an endpoint doesn't behave as expected.
+- Context scoping (path-only, never the body) is covered above under "Opt-in by import, not by
+  classpath" and doesn't need repeating here.


### PR DESCRIPTION
Two independent commits, reviewable separately.

**Resolver levels** — `EscalatingEntityResolver` labelled confident matches by searcher *index* (0/1/2, else HEURISTIC), which mislabels the default six-searcher chain: a normalized-name match reported as EMBEDDING_MATCH, a real vector match as HEURISTIC_MATCH. Each `CandidateSearcher` now declares its own `resolutionLevel` (interface default HEURISTIC_MATCH; the exact, vector, and agentic searchers override), so per-level telemetry is accurate for any chain length or order. Also corrects the `ConsolidationPass` KDoc: passes run once per scheduled cycle — there is no run-until-settled loop.

**Design docs** — full audit of `docs/design/` against source: fixes signature/type/enum drift (wrong capability-fragment methods, nonexistent return types, phantom `NAMED_EXTERNAL` authority tier, misattributed lifecycle transitions), trims duplicated prose in the long notes, adds verified code examples to the seven docs that had none, and completes `INDEX.md` coverage. The docs describe the end state including the `feat/56-dedup-grounding-merge` behavior (native graph queries); that window closes when #56 merges.

**Verification**
- Full `dice` module suite green on this branch's tree (1050 tests), incl. new `ResolutionLevels` tests pinning each searcher's tier.
- Regression-tested against a downstream consumer: its full suite shows no new failures vs baseline; app boot, memory retrieval, graph exploration, and live chat turns exercised manually against this exact artifact.
- New public API is additive with default bodies (`CandidateSearcher.resolutionLevel`), safe for external implementers.

