### PR TITLE
Feature/conversation segmenter

### DIFF
--- a/dice/src/main/kotlin/com/embabel/dice/incremental/ConversationSegmenter.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/incremental/ConversationSegmenter.kt
@@ -19,54 +19,151 @@ import java.time.Duration
 import java.time.Instant
 
 /**
- * Splits a timestamped item stream (e.g. a chat channel's messages) into coherent
- * conversation segments by time-silence, so each segment can be handed to
- * [IncrementalSource]-based extraction as one conversation.
+ * Splits a timestamped item stream (e.g. a chat channel's messages) into conversation
+ * segments, so each segment can be handed to [IncrementalSource]-based extraction as
+ * one conversation.
  *
- * This decides conversation *boundaries*; it deliberately does NOT window by size
- * or overlap — that is the incremental analyzer's job (see `WindowConfig`), which
- * chunks *within* a conversation. Feeding a firehose straight to the analyzer
- * would window by index and cut mid-conversation; segmenting first keeps each
- * extraction unit coherent.
+ * Silence is deliberately **not** a conversation boundary. In async chat a thread
+ * routinely goes quiet for eight or twenty-four hours while contributors sleep across
+ * timezones, and cutting on that silence would shred exactly the long-running
+ * conversations most worth extracting. Segments are instead bounded by *size*: a run
+ * is cut only once it exceeds [maxSize], and the cut lands on the largest interior
+ * gap, so the seam falls in a lull rather than mid-exchange.
  *
- * A segment is **closed** — safe to extract — when a gap longer than [gap] follows
- * it, or (the final run) its last item is older than [gap] before `now`. The still-
- * open trailing run is withheld until it closes, so an in-progress conversation
- * isn't extracted then re-extracted when the rest arrives. Segments with fewer than
- * [minItems] items are dropped.
+ * This decides conversation *boundaries*; it deliberately does NOT window by size or
+ * overlap — that is the incremental analyzer's job (see [WindowConfig]), which chunks
+ * *within* a segment. Those windows, not whole segments, are what an LLM sees.
+ *
+ * A segment is **closed** — safe to extract — once further content follows it, or, for
+ * the trailing segment, once it has been quiet for longer than [settle]. The still-open
+ * trailing segment is withheld so an in-progress conversation isn't extracted and then
+ * re-extracted when the rest arrives. Segments with fewer than [minItems] items are
+ * dropped.
  *
  * Pure and deterministic — no LLM, no I/O. Generic over the item type: the caller
- * supplies a timestamp accessor.
+ * supplies a timestamp accessor and, optionally, a size accessor.
+ *
+ * @param maxSize ceiling on a single segment, expressed in whatever units the `size`
+ *   accessor passed to [closedSegments] returns. Under the default accessor (one unit
+ *   per item) it is a message count; a caller supplying a token estimator must scale
+ *   this accordingly.
+ * @param settle how long the trailing segment must be quiet before it is extractable.
+ * @param minItems segments holding fewer items than this are dropped.
+ * @param maxSilence optional ceiling beyond which a silence *is* taken as a boundary,
+ *   for channels that go dormant and are later revived. Null — the default — means
+ *   segmentation is driven purely by size.
  */
 class ConversationSegmenter(
-    private val gap: Duration,
+    private val maxSize: Int = DEFAULT_MAX_SIZE,
+    private val settle: Duration = DEFAULT_SETTLE,
     private val minItems: Int = 1,
+    private val maxSilence: Duration? = null,
 ) {
 
+    init {
+        require(maxSize > 0) { "maxSize must be positive" }
+        require(minItems > 0) { "minItems must be positive" }
+        require(!settle.isNegative) { "settle must not be negative" }
+        require(maxSilence == null || !maxSilence.isNegative) { "maxSilence must not be negative" }
+    }
+
     /**
-     * The closed conversation segments in [items] (a single stream, e.g. one
-     * channel), each a time-ordered sub-list. [now] is the reference "current
-     * time" used to decide whether the final run has gone quiet.
+     * The closed conversation segments in [items] (a single stream, e.g. one channel),
+     * each a time-ordered sub-list. [now] is the reference "current time" used to decide
+     * whether the trailing segment has settled. [size] weights each item against
+     * [maxSize]; the default counts items.
      */
-    fun <T> closedSegments(items: List<T>, now: Instant, at: (T) -> Instant): List<List<T>> {
+    fun <T> closedSegments(
+        items: List<T>,
+        now: Instant,
+        at: (T) -> Instant,
+        size: (T) -> Int = { 1 },
+    ): List<List<T>> {
         if (items.isEmpty()) return emptyList()
         val sorted = items.sortedWith(compareBy(at))
+        val segments = dormancyRuns(sorted, at).flatMap { capBySize(it, at, size) }
 
-        // Split into runs wherever the inter-item gap exceeds `gap`.
+        return segments.filterIndexed { idx, segment ->
+            // Only the final segment can still be growing; everything before it is closed
+            // by the content that follows.
+            val settled = idx != segments.lastIndex ||
+                Duration.between(at(segment.last()), now) > settle
+            settled && segment.size >= minItems
+        }
+    }
+
+    /** Split only where a silence exceeds [maxSilence]; one run throughout when it is null. */
+    private fun <T> dormancyRuns(sorted: List<T>, at: (T) -> Instant): List<List<T>> {
+        val ceiling = maxSilence ?: return listOf(sorted)
         val runs = mutableListOf<MutableList<T>>()
         for (item in sorted) {
-            val last = runs.lastOrNull()?.last()
-            if (last == null || Duration.between(at(last), at(item)) > gap) {
+            val previous = runs.lastOrNull()?.last()
+            if (previous == null || Duration.between(at(previous), at(item)) > ceiling) {
                 runs.add(mutableListOf(item))
             } else {
                 runs.last().add(item)
             }
         }
+        return runs
+    }
 
-        return runs.filterIndexed { idx, run ->
-            // The last run is closed only once it's gone quiet (older than `gap`).
-            val closed = idx != runs.lastIndex || Duration.between(at(run.last()), now) > gap
-            closed && run.size >= minItems
+    /** Repeatedly carve [maxSize]-bounded segments off the front of [run]. */
+    private fun <T> capBySize(run: List<T>, at: (T) -> Instant, size: (T) -> Int): List<List<T>> {
+        val segments = mutableListOf<List<T>>()
+        var rest = run
+        while (rest.isNotEmpty()) {
+            if (rest.sumOf { size(it) } <= maxSize) {
+                segments.add(rest)
+                break
+            }
+            val cut = cutIndex(rest, at, size)
+            segments.add(rest.subList(0, cut))
+            rest = rest.subList(cut, rest.size)
         }
+        return segments
+    }
+
+    /**
+     * Where to cut an over-sized run: the largest gap within the longest prefix that
+     * still fits in [maxSize], constrained to leave at least [minItems] behind so a big
+     * lull near the head can't strand items in a sub-[minItems] fragment that gets
+     * dropped. Ties favour the later index, keeping segments full.
+     */
+    private fun <T> cutIndex(rest: List<T>, at: (T) -> Instant, size: (T) -> Int): Int {
+        var accumulated = 0
+        var limit = 0
+        for ((index, item) in rest.withIndex()) {
+            val weight = size(item)
+            // Always take at least one item, even one heavier than maxSize on its own.
+            if (index > 0 && accumulated + weight > maxSize) break
+            accumulated += weight
+            limit = index + 1
+        }
+
+        var cut = limit
+        var widest = Duration.ofSeconds(-1)
+        // `limit` reaches rest.size only when a lone over-sized item fills the prefix,
+        // in which case there is no interior gap to consider.
+        for (index in minItems..minOf(limit, rest.size - 1)) {
+            val gap = Duration.between(at(rest[index - 1]), at(rest[index]))
+            if (gap >= widest) {
+                widest = gap
+                cut = index
+            }
+        }
+        return cut
+    }
+
+    companion object {
+        /**
+         * Segment ceiling under the default one-unit-per-item size accessor, i.e. messages.
+         * Comfortably many analyzer windows ([WindowConfig.windowSize]) wide, while small
+         * enough that a segment remains plausibly a single conversation.
+         */
+        const val DEFAULT_MAX_SIZE: Int = 500
+
+        /** Quiet period after which a trailing conversation is taken to be finished. */
+        @JvmField
+        val DEFAULT_SETTLE: Duration = Duration.ofHours(24)
     }
 }

--- a/dice/src/main/kotlin/com/embabel/dice/incremental/ConversationSegmenter.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/incremental/ConversationSegmenter.kt
@@ -23,12 +23,17 @@ import java.time.Instant
  * segments, so each segment can be handed to [IncrementalSource]-based extraction as
  * one conversation.
  *
- * Silence is deliberately **not** a conversation boundary. In async chat a thread
+ * Brief silence is deliberately **not** a conversation boundary. In async chat a thread
  * routinely goes quiet for eight or twenty-four hours while contributors sleep across
  * timezones, and cutting on that silence would shred exactly the long-running
- * conversations most worth extracting. Segments are instead bounded by *size*: a run
- * is cut only once it exceeds [maxSize], and the cut lands on the largest interior
- * gap, so the seam falls in a lull rather than mid-exchange.
+ * conversations most worth extracting. Within a conversation, segments are bounded by
+ * *size*: a run is cut only once it exceeds [maxSize], and the cut lands on the largest
+ * interior gap, so the seam falls in a lull rather than mid-exchange.
+ *
+ * A silence longer than [settle] *is* a boundary, because [settle] is already the point
+ * at which a trailing conversation is declared finished and handed to extraction. Once a
+ * conversation has been extracted, a later reply must begin a new segment rather than
+ * re-open the extracted one — so the same duration necessarily governs both.
  *
  * This decides conversation *boundaries*; it deliberately does NOT window by size or
  * overlap — that is the incremental analyzer's job (see [WindowConfig]), which chunks
@@ -37,121 +42,158 @@ import java.time.Instant
  * A segment is **closed** — safe to extract — once further content follows it, or, for
  * the trailing segment, once it has been quiet for longer than [settle]. The still-open
  * trailing segment is withheld so an in-progress conversation isn't extracted and then
- * re-extracted when the rest arrives. Segments with fewer than [minItems] items are
- * dropped.
+ * re-extracted when the rest arrives.
  *
  * Pure and deterministic — no LLM, no I/O. Generic over the item type: the caller
- * supplies a timestamp accessor and, optionally, a size accessor.
+ * supplies a timestamp accessor and, optionally, a size accessor. Segmentation of a given
+ * prefix is stable as later items arrive, so repeated calls over a growing stream emit
+ * each closed segment exactly once — provided items are ingested in timestamp order. An
+ * item back-dated to within [settle] of an already-extracted segment will re-open it.
  *
  * @param maxSize ceiling on a single segment, expressed in whatever units the `size`
- *   accessor passed to [closedSegments] returns. Under the default accessor (one unit
- *   per item) it is a message count; a caller supplying a token estimator must scale
- *   this accordingly.
- * @param settle how long the trailing segment must be quiet before it is extractable.
- * @param minItems segments holding fewer items than this are dropped.
- * @param maxSilence optional ceiling beyond which a silence *is* taken as a boundary,
- *   for channels that go dormant and are later revived. Null — the default — means
- *   segmentation is driven purely by size.
+ *   accessor passed to [closedSegments] returns. Under the default accessor (one unit per
+ *   item) it is a message count; a caller supplying a token estimator must scale this
+ *   accordingly. A segment absorbing an undersized tail (see [minItems]) may exceed it by
+ *   up to `minItems - 1` items: [maxSize] is a coherence cap, not a hard limit.
+ * @param settle how long a conversation must be quiet before it is taken to be finished:
+ *   the trailing segment becomes extractable, and any later item starts a new segment.
+ * @param minItems segments holding fewer items than this are dropped. Cuts are placed so
+ *   that no segment falls below the floor, and an undersized tail is folded back into the
+ *   segment before it, so only a whole conversation shorter than [minItems] is dropped.
+ *   Setting [minItems] above the number of items [maxSize] admits leaves every segment
+ *   below the floor, discarding the stream entirely.
  */
 class ConversationSegmenter(
     private val maxSize: Int = DEFAULT_MAX_SIZE,
     private val settle: Duration = DEFAULT_SETTLE,
     private val minItems: Int = 1,
-    private val maxSilence: Duration? = null,
 ) {
 
     init {
         require(maxSize > 0) { "maxSize must be positive" }
         require(minItems > 0) { "minItems must be positive" }
         require(!settle.isNegative) { "settle must not be negative" }
-        require(maxSilence == null || !maxSilence.isNegative) { "maxSilence must not be negative" }
     }
 
     /**
-     * The closed conversation segments in [items] (a single stream, e.g. one channel),
-     * each a time-ordered sub-list. [now] is the reference "current time" used to decide
-     * whether the trailing segment has settled. [size] weights each item against
-     * [maxSize]; the default counts items.
+     * The closed conversation segments in [items] (a single stream, e.g. one channel), each
+     * a time-ordered sub-list. [now] is the reference "current time" used to decide whether
+     * the trailing segment has settled; a [now] preceding the last item leaves that segment
+     * open. [size] weights each item against [maxSize]; the default counts items. Both
+     * accessors are invoked exactly once per item.
      */
     fun <T> closedSegments(
         items: List<T>,
         now: Instant,
-        at: (T) -> Instant,
+        timestamp: (T) -> Instant,
         size: (T) -> Int = { 1 },
     ): List<List<T>> {
         if (items.isEmpty()) return emptyList()
-        val sorted = items.sortedWith(compareBy(at))
-        val segments = dormancyRuns(sorted, at).flatMap { capBySize(it, at, size) }
+        // Sort indices against cached instants: a comparator over `timestamp` would re-invoke
+        // it on every comparison, and the accessor may be costly (a token estimator, say).
+        val unsorted = Array(items.size) { timestamp(items[it]) }
+        val order = items.indices.sortedBy { unsorted[it] }
+        val sorted = order.map { items[it] }
+        val instants = Array(order.size) { unsorted[order[it]] }
+        val weights = IntArray(sorted.size) { size(sorted[it]) }
 
-        return segments.filterIndexed { idx, segment ->
-            // Only the final segment can still be growing; everything before it is closed
-            // by the content that follows.
-            val settled = idx != segments.lastIndex ||
-                Duration.between(at(segment.last()), now) > settle
-            settled && segment.size >= minItems
+        val conversations = conversations(instants)
+        val segments = mutableListOf<Span>()
+        for ((index, conversation) in conversations.withIndex()) {
+            val carved = capBySize(conversation, instants, weights)
+            // Only the final conversation can still be growing; everything before it is
+            // closed by the content that follows.
+            val open = index == conversations.lastIndex &&
+                Duration.between(instants[conversation.endExclusive - 1], now) <= settle
+            if (open) carved.removeAt(carved.lastIndex) else mergeUndersizedTail(carved)
+            segments += carved
         }
+        return segments
+            .filter { it.size >= minItems }
+            .map { sorted.slice(it.start until it.endExclusive) }
     }
 
-    /** Split only where a silence exceeds [maxSilence]; one run throughout when it is null. */
-    private fun <T> dormancyRuns(sorted: List<T>, at: (T) -> Instant): List<List<T>> {
-        val ceiling = maxSilence ?: return listOf(sorted)
-        val runs = mutableListOf<MutableList<T>>()
-        for (item in sorted) {
-            val previous = runs.lastOrNull()?.last()
-            if (previous == null || Duration.between(at(previous), at(item)) > ceiling) {
-                runs.add(mutableListOf(item))
-            } else {
-                runs.last().add(item)
+    /** A half-open index range into the sorted item list. */
+    private data class Span(val start: Int, val endExclusive: Int) {
+        val size: Int get() = endExclusive - start
+    }
+
+    /** Split wherever a silence exceeds [settle]: each resulting run is one conversation. */
+    private fun conversations(instants: Array<Instant>): List<Span> {
+        val spans = mutableListOf<Span>()
+        var start = 0
+        for (index in 1 until instants.size) {
+            if (Duration.between(instants[index - 1], instants[index]) > settle) {
+                spans += Span(start, index)
+                start = index
             }
         }
-        return runs
+        return spans + Span(start, instants.size)
     }
 
-    /** Repeatedly carve [maxSize]-bounded segments off the front of [run]. */
-    private fun <T> capBySize(run: List<T>, at: (T) -> Instant, size: (T) -> Int): List<List<T>> {
-        val segments = mutableListOf<List<T>>()
-        var rest = run
-        while (rest.isNotEmpty()) {
-            if (rest.sumOf { size(it) } <= maxSize) {
-                segments.add(rest)
+    /** Repeatedly carve [maxSize]-bounded segments off the front of [conversation]. */
+    private fun capBySize(conversation: Span, instants: Array<Instant>, weights: IntArray): MutableList<Span> {
+        val segments = mutableListOf<Span>()
+        var start = conversation.start
+        while (start < conversation.endExclusive) {
+            val limit = prefixLimit(start, conversation.endExclusive, weights)
+            if (limit == conversation.endExclusive) {
+                segments += Span(start, limit)
                 break
             }
-            val cut = cutIndex(rest, at, size)
-            segments.add(rest.subList(0, cut))
-            rest = rest.subList(cut, rest.size)
+            val cut = cutIndex(start, limit, instants)
+            segments += Span(start, cut)
+            start = cut
         }
         return segments
     }
 
     /**
-     * Where to cut an over-sized run: the largest gap within the longest prefix that
-     * still fits in [maxSize], constrained to leave at least [minItems] behind so a big
-     * lull near the head can't strand items in a sub-[minItems] fragment that gets
-     * dropped. Ties favour the later index, keeping segments full.
+     * One past the last item of the longest prefix from [start] that fits within [maxSize].
+     * Always takes at least one item, so an item heavier than [maxSize] on its own still
+     * makes progress.
      */
-    private fun <T> cutIndex(rest: List<T>, at: (T) -> Instant, size: (T) -> Int): Int {
-        var accumulated = 0
-        var limit = 0
-        for ((index, item) in rest.withIndex()) {
-            val weight = size(item)
-            // Always take at least one item, even one heavier than maxSize on its own.
-            if (index > 0 && accumulated + weight > maxSize) break
+    private fun prefixLimit(start: Int, endExclusive: Int, weights: IntArray): Int {
+        var accumulated = 0L
+        var index = start
+        while (index < endExclusive) {
+            val weight = weights[index]
+            if (index > start && accumulated + weight > maxSize) break
             accumulated += weight
-            limit = index + 1
+            index++
         }
+        return index
+    }
 
+    /**
+     * Where to cut an over-sized conversation: the largest gap within the prefix that fits,
+     * constrained to leave at least [minItems] behind so a big lull near the head can't
+     * strand items in a sub-[minItems] fragment. Ties favour the later index, keeping
+     * segments full. Falls back to [limit] when the floor admits no gap — either a lone
+     * over-sized item fills the prefix, or [minItems] exceeds what [maxSize] holds.
+     */
+    private fun cutIndex(start: Int, limit: Int, instants: Array<Instant>): Int {
         var cut = limit
-        var widest = Duration.ofSeconds(-1)
-        // `limit` reaches rest.size only when a lone over-sized item fills the prefix,
-        // in which case there is no interior gap to consider.
-        for (index in minItems..minOf(limit, rest.size - 1)) {
-            val gap = Duration.between(at(rest[index - 1]), at(rest[index]))
+        var widest = Duration.ZERO
+        for (index in start + minItems..limit) {
+            val gap = Duration.between(instants[index - 1], instants[index])
             if (gap >= widest) {
                 widest = gap
                 cut = index
             }
         }
         return cut
+    }
+
+    /**
+     * Fold a trailing segment that falls below [minItems] into the one before it, rather than
+     * let the item-count filter discard those items. A conversation carved into a single
+     * undersized segment has nothing to fold into, and is dropped.
+     */
+    private fun mergeUndersizedTail(segments: MutableList<Span>) {
+        if (segments.size < 2 || segments.last().size >= minItems) return
+        val tail = segments.removeAt(segments.lastIndex)
+        segments[segments.lastIndex] = segments.last().copy(endExclusive = tail.endExclusive)
     }
 
     companion object {
@@ -162,7 +204,7 @@ class ConversationSegmenter(
          */
         const val DEFAULT_MAX_SIZE: Int = 500
 
-        /** Quiet period after which a trailing conversation is taken to be finished. */
+        /** Quiet period after which a conversation is taken to be finished. */
         @JvmField
         val DEFAULT_SETTLE: Duration = Duration.ofHours(24)
     }

--- a/dice/src/main/kotlin/com/embabel/dice/incremental/ConversationSegmenter.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/incremental/ConversationSegmenter.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.incremental
+
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Splits a timestamped item stream (e.g. a chat channel's messages) into coherent
+ * conversation segments by time-silence, so each segment can be handed to
+ * [IncrementalSource]-based extraction as one conversation.
+ *
+ * This decides conversation *boundaries*; it deliberately does NOT window by size
+ * or overlap — that is the incremental analyzer's job (see `WindowConfig`), which
+ * chunks *within* a conversation. Feeding a firehose straight to the analyzer
+ * would window by index and cut mid-conversation; segmenting first keeps each
+ * extraction unit coherent.
+ *
+ * A segment is **closed** — safe to extract — when a gap longer than [gap] follows
+ * it, or (the final run) its last item is older than [gap] before `now`. The still-
+ * open trailing run is withheld until it closes, so an in-progress conversation
+ * isn't extracted then re-extracted when the rest arrives. Segments with fewer than
+ * [minItems] items are dropped.
+ *
+ * Pure and deterministic — no LLM, no I/O. Generic over the item type: the caller
+ * supplies a timestamp accessor.
+ */
+class ConversationSegmenter(
+    private val gap: Duration,
+    private val minItems: Int = 1,
+) {
+
+    /**
+     * The closed conversation segments in [items] (a single stream, e.g. one
+     * channel), each a time-ordered sub-list. [now] is the reference "current
+     * time" used to decide whether the final run has gone quiet.
+     */
+    fun <T> closedSegments(items: List<T>, now: Instant, at: (T) -> Instant): List<List<T>> {
+        if (items.isEmpty()) return emptyList()
+        val sorted = items.sortedWith(compareBy(at))
+
+        // Split into runs wherever the inter-item gap exceeds `gap`.
+        val runs = mutableListOf<MutableList<T>>()
+        for (item in sorted) {
+            val last = runs.lastOrNull()?.last()
+            if (last == null || Duration.between(at(last), at(item)) > gap) {
+                runs.add(mutableListOf(item))
+            } else {
+                runs.last().add(item)
+            }
+        }
+
+        return runs.filterIndexed { idx, run ->
+            // The last run is closed only once it's gone quiet (older than `gap`).
+            val closed = idx != runs.lastIndex || Duration.between(at(run.last()), now) > gap
+            closed && run.size >= minItems
+        }
+    }
+}

--- a/dice/src/test/kotlin/com/embabel/dice/incremental/ConversationSegmenterTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/incremental/ConversationSegmenterTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.incremental
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+class ConversationSegmenterTest {
+
+    private val base: Instant = Instant.parse("2026-01-01T00:00:00Z")
+
+    private data class Msg(val id: String, val minute: Long)
+
+    private fun at(m: Msg): Instant = base.plusSeconds(m.minute * 60)
+
+    private fun segmenter(min: Int = 2) = ConversationSegmenter(gap = Duration.ofMinutes(45), minItems = min)
+
+    private fun ids(seg: List<Msg>) = seg.map { it.id }
+
+    @Test
+    fun `gap-splits into runs, both returned when both have gone quiet`() {
+        val msgs = listOf(Msg("m0", 0), Msg("m1", 1), Msg("m2", 2), Msg("m3", 62), Msg("m4", 63), Msg("m5", 64))
+        val segs = segmenter().closedSegments(msgs, base.plusSeconds(200 * 60), ::at)
+        assertEquals(2, segs.size)
+        assertEquals(listOf("m0", "m1", "m2"), ids(segs[0]))
+        assertEquals(listOf("m3", "m4", "m5"), ids(segs[1]))
+    }
+
+    @Test
+    fun `withholds the still-open trailing run`() {
+        val msgs = listOf(Msg("m0", 0), Msg("m1", 1), Msg("m2", 2), Msg("m3", 62), Msg("m4", 63), Msg("m5", 64))
+        // now only 1 min after the last message → the second run is still open.
+        val segs = segmenter().closedSegments(msgs, base.plusSeconds(65 * 60), ::at)
+        assertEquals(1, segs.size)
+        assertEquals(listOf("m0", "m1", "m2"), ids(segs[0]))
+    }
+
+    @Test
+    fun `does not split a long continuous run (windowing is the analyzer's job)`() {
+        val msgs = (0..99).map { Msg("m$it", it.toLong()) } // 100 consecutive minutes → one run
+        val segs = segmenter().closedSegments(msgs, base.plusSeconds(500 * 60), ::at)
+        assertEquals(1, segs.size)
+        assertEquals(100, segs[0].size)
+    }
+
+    @Test
+    fun `drops runs below the min-item floor`() {
+        val msgs = listOf(Msg("m0", 0), Msg("m1", 100)) // two gap-isolated singletons
+        assertTrue(segmenter(min = 2).closedSegments(msgs, base.plusSeconds(500 * 60), ::at).isEmpty())
+    }
+
+    @Test
+    fun `empty input yields nothing`() {
+        assertEquals(emptyList<List<Msg>>(), segmenter().closedSegments(emptyList<Msg>(), base, ::at))
+    }
+}

--- a/dice/src/test/kotlin/com/embabel/dice/incremental/ConversationSegmenterTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/incremental/ConversationSegmenterTest.kt
@@ -34,15 +34,36 @@ class ConversationSegmenterTest {
     private fun minutesFromBase(minutes: Long): Instant = base.plusSeconds(minutes * 60)
 
     /** Far enough past the last message that every segment has settled. */
-    private val longAfter: Instant = base.plusSeconds(Duration.ofDays(30).seconds)
+    private val longAfter: Instant = base.plusSeconds(Duration.ofDays(90).seconds)
 
     @Test
     fun `an overnight lull does not split a conversation`() {
-        // Someone replies 24h later, across timezones: still one conversation.
+        // Someone replies just under settle later, across timezones: still one conversation.
         val msgs = listOf(Msg("m0", 0), Msg("m1", 1), Msg("m2", 24 * 60), Msg("m3", 24 * 60 + 1))
         val segments = ConversationSegmenter().closedSegments(msgs, longAfter, ::at)
         assertEquals(1, segments.size)
         assertEquals(listOf("m0", "m1", "m2", "m3"), ids(segments[0]))
+    }
+
+    @Test
+    fun `a silence beyond settle splits a dormant channel`() {
+        val msgs = listOf(Msg("m0", 0), Msg("m1", 1), Msg("m2", 30 * 24 * 60), Msg("m3", 30 * 24 * 60 + 1))
+        val segments = ConversationSegmenter(settle = Duration.ofHours(24)).closedSegments(msgs, longAfter, ::at)
+        assertEquals(2, segments.size)
+        assertEquals(listOf("m0", "m1"), ids(segments[0]))
+        assertEquals(listOf("m2", "m3"), ids(segments[1]))
+    }
+
+    @Test
+    fun `each conversation is independently capped by maxSize`() {
+        // Six rapid messages, a month of silence, then three more.
+        val first = (0..5).map { Msg("m$it", it.toLong()) }
+        val second = (0..2).map { Msg("n$it", 30 * 24 * 60 + it.toLong()) }
+        val segments = ConversationSegmenter(maxSize = 5).closedSegments(first + second, longAfter, ::at)
+        assertEquals(3, segments.size)
+        assertEquals(listOf("m0", "m1", "m2", "m3", "m4"), ids(segments[0]))
+        assertEquals(listOf("m5"), ids(segments[1]))
+        assertEquals(listOf("n0", "n1", "n2"), ids(segments[2]))
     }
 
     @Test
@@ -63,7 +84,7 @@ class ConversationSegmenterTest {
 
     @Test
     fun `a run at or under maxSize is never split, however lulled`() {
-        val msgs = (0..9).map { Msg("m$it", it * 500L) } // ~8h between each
+        val msgs = (0..9).map { Msg("m$it", it * 500L) } // ~8h between each, under settle
         val segments = ConversationSegmenter(maxSize = 10).closedSegments(msgs, longAfter, ::at)
         assertEquals(1, segments.size)
         assertEquals(10, segments[0].size)
@@ -83,6 +104,12 @@ class ConversationSegmenterTest {
     }
 
     @Test
+    fun `a now preceding the last item leaves the trailing segment open`() {
+        val msgs = listOf(Msg("m0", 0), Msg("m1", 10))
+        assertTrue(ConversationSegmenter().closedSegments(msgs, base, ::at).isEmpty())
+    }
+
+    @Test
     fun `earlier segments are closed even while the trailing one is open`() {
         val msgs = (0..6).map { Msg("m$it", it.toLong()) }
         val segments = ConversationSegmenter(maxSize = 5, settle = Duration.ofHours(24))
@@ -93,24 +120,30 @@ class ConversationSegmenterTest {
     }
 
     @Test
-    fun `maxSilence, when set, does split a dormant channel`() {
-        val msgs = listOf(Msg("m0", 0), Msg("m1", 1), Msg("m2", 30 * 24 * 60), Msg("m3", 30 * 24 * 60 + 1))
-        val segments = ConversationSegmenter(maxSilence = Duration.ofDays(14))
-            .closedSegments(msgs, longAfter.plusSeconds(Duration.ofDays(60).seconds), ::at)
+    fun `the cut leaves at least minItems behind`() {
+        // The widest gap sits after m0, but minItems=3 forbids cutting there.
+        val msgs = listOf(Msg("m0", 0)) + (1..8).map { Msg("m$it", 99 + it.toLong()) }
+        val segments = ConversationSegmenter(maxSize = 5, minItems = 3).closedSegments(msgs, longAfter, ::at)
         assertEquals(2, segments.size)
-        assertEquals(listOf("m0", "m1"), ids(segments[0]))
-        assertEquals(listOf("m2", "m3"), ids(segments[1]))
+        assertEquals(listOf("m0", "m1", "m2", "m3", "m4"), ids(segments[0]))
+        assertEquals(listOf("m5", "m6", "m7", "m8"), ids(segments[1]))
     }
 
     @Test
-    fun `the cut leaves at least minItems behind`() {
-        // The widest gap sits after m0, but minItems=3 forbids cutting there.
-        val msgs = listOf(
-            Msg("m0", 0),
-            Msg("m1", 100), Msg("m2", 101), Msg("m3", 102), Msg("m4", 103), Msg("m5", 104), Msg("m6", 105),
-        )
+    fun `a settled tail below minItems is folded into the preceding segment`() {
+        // Carving would leave m5 alone, below the floor; it is absorbed rather than dropped.
+        val msgs = (0..5).map { Msg("m$it", it.toLong()) }
         val segments = ConversationSegmenter(maxSize = 5, minItems = 3).closedSegments(msgs, longAfter, ::at)
-        assertEquals(listOf("m0", "m1", "m2", "m3", "m4"), ids(segments[0]))
+        assertEquals(listOf("m0", "m1", "m2", "m3", "m4", "m5"), ids(segments.single()))
+    }
+
+    @Test
+    fun `an open tail below minItems is withheld rather than folded`() {
+        val msgs = (0..5).map { Msg("m$it", it.toLong()) }
+        val segments = ConversationSegmenter(maxSize = 5, minItems = 3)
+            .closedSegments(msgs, minutesFromBase(6), ::at)
+        // m5 may yet grow into a segment of its own, so the closed prefix stands alone.
+        assertEquals(listOf("m0", "m1", "m2", "m3", "m4"), ids(segments.single()))
     }
 
     @Test
@@ -124,6 +157,21 @@ class ConversationSegmenterTest {
     }
 
     @Test
+    fun `accessors are invoked once per item`() {
+        val msgs = (0..20).map { Msg("m$it", it.toLong()) }
+        var timestamps = 0
+        var sizes = 0
+        ConversationSegmenter(maxSize = 5).closedSegments(
+            msgs,
+            longAfter,
+            { timestamps++; at(it) },
+            { sizes++; it.weight },
+        )
+        assertEquals(msgs.size, timestamps)
+        assertEquals(msgs.size, sizes)
+    }
+
+    @Test
     fun `a lone item heavier than maxSize becomes its own segment`() {
         val msgs = listOf(Msg("m0", 0, weight = 99), Msg("m1", 1, weight = 1))
         val segments = ConversationSegmenter(maxSize = 10)
@@ -133,9 +181,17 @@ class ConversationSegmenterTest {
     }
 
     @Test
-    fun `drops segments below the min-item floor`() {
+    fun `drops a whole conversation below the min-item floor`() {
         val msgs = listOf(Msg("m0", 0))
         assertTrue(ConversationSegmenter(minItems = 2).closedSegments(msgs, longAfter, ::at).isEmpty())
+    }
+
+    @Test
+    fun `minItems above what maxSize admits discards the stream`() {
+        val msgs = (0..9).map { Msg("m$it", it.toLong()) }
+        assertTrue(
+            ConversationSegmenter(maxSize = 2, minItems = 5).closedSegments(msgs, longAfter, ::at).isEmpty(),
+        )
     }
 
     @Test
@@ -148,5 +204,20 @@ class ConversationSegmenterTest {
         val msgs = listOf(Msg("m2", 2), Msg("m0", 0), Msg("m1", 1))
         val segments = ConversationSegmenter().closedSegments(msgs, longAfter, ::at)
         assertEquals(listOf("m0", "m1", "m2"), ids(segments.single()))
+    }
+
+    @Test
+    fun `items sharing a timestamp keep their input order`() {
+        val msgs = listOf(Msg("m0", 0), Msg("m1", 0), Msg("m2", 0))
+        val segments = ConversationSegmenter().closedSegments(msgs, longAfter, ::at)
+        assertEquals(listOf("m0", "m1", "m2"), ids(segments.single()))
+    }
+
+    @Test
+    fun `zero gaps throughout still cut at maxSize`() {
+        val msgs = (0..6).map { Msg("m$it", 0) }
+        val segments = ConversationSegmenter(maxSize = 5).closedSegments(msgs, longAfter, ::at)
+        assertEquals(listOf("m0", "m1", "m2", "m3", "m4"), ids(segments[0]))
+        assertEquals(listOf("m5", "m6"), ids(segments[1]))
     }
 }

--- a/dice/src/test/kotlin/com/embabel/dice/incremental/ConversationSegmenterTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/incremental/ConversationSegmenterTest.kt
@@ -25,48 +25,128 @@ class ConversationSegmenterTest {
 
     private val base: Instant = Instant.parse("2026-01-01T00:00:00Z")
 
-    private data class Msg(val id: String, val minute: Long)
+    private data class Msg(val id: String, val minute: Long, val weight: Int = 1)
 
     private fun at(m: Msg): Instant = base.plusSeconds(m.minute * 60)
 
-    private fun segmenter(min: Int = 2) = ConversationSegmenter(gap = Duration.ofMinutes(45), minItems = min)
+    private fun ids(segment: List<Msg>) = segment.map { it.id }
 
-    private fun ids(seg: List<Msg>) = seg.map { it.id }
+    private fun minutesFromBase(minutes: Long): Instant = base.plusSeconds(minutes * 60)
+
+    /** Far enough past the last message that every segment has settled. */
+    private val longAfter: Instant = base.plusSeconds(Duration.ofDays(30).seconds)
 
     @Test
-    fun `gap-splits into runs, both returned when both have gone quiet`() {
-        val msgs = listOf(Msg("m0", 0), Msg("m1", 1), Msg("m2", 2), Msg("m3", 62), Msg("m4", 63), Msg("m5", 64))
-        val segs = segmenter().closedSegments(msgs, base.plusSeconds(200 * 60), ::at)
-        assertEquals(2, segs.size)
-        assertEquals(listOf("m0", "m1", "m2"), ids(segs[0]))
-        assertEquals(listOf("m3", "m4", "m5"), ids(segs[1]))
+    fun `an overnight lull does not split a conversation`() {
+        // Someone replies 24h later, across timezones: still one conversation.
+        val msgs = listOf(Msg("m0", 0), Msg("m1", 1), Msg("m2", 24 * 60), Msg("m3", 24 * 60 + 1))
+        val segments = ConversationSegmenter().closedSegments(msgs, longAfter, ::at)
+        assertEquals(1, segments.size)
+        assertEquals(listOf("m0", "m1", "m2", "m3"), ids(segments[0]))
     }
 
     @Test
-    fun `withholds the still-open trailing run`() {
-        val msgs = listOf(Msg("m0", 0), Msg("m1", 1), Msg("m2", 2), Msg("m3", 62), Msg("m4", 63), Msg("m5", 64))
-        // now only 1 min after the last message → the second run is still open.
-        val segs = segmenter().closedSegments(msgs, base.plusSeconds(65 * 60), ::at)
-        assertEquals(1, segs.size)
-        assertEquals(listOf("m0", "m1", "m2"), ids(segs[0]))
+    fun `splits only once over maxSize, cutting at the largest interior gap`() {
+        // A 98-minute lull between m2 and m3 is the natural seam.
+        val msgs = listOf(
+            Msg("m0", 0), Msg("m1", 1), Msg("m2", 2),
+            Msg("m3", 100), Msg("m4", 101), Msg("m5", 102),
+            Msg("m6", 103), Msg("m7", 104), Msg("m8", 105), Msg("m9", 106),
+        )
+        val segments = ConversationSegmenter(maxSize = 5).closedSegments(msgs, longAfter, ::at)
+        assertEquals(3, segments.size)
+        assertEquals(listOf("m0", "m1", "m2"), ids(segments[0]))
+        // No further lull, so the next cut simply fills to maxSize.
+        assertEquals(listOf("m3", "m4", "m5", "m6", "m7"), ids(segments[1]))
+        assertEquals(listOf("m8", "m9"), ids(segments[2]))
     }
 
     @Test
-    fun `does not split a long continuous run (windowing is the analyzer's job)`() {
-        val msgs = (0..99).map { Msg("m$it", it.toLong()) } // 100 consecutive minutes → one run
-        val segs = segmenter().closedSegments(msgs, base.plusSeconds(500 * 60), ::at)
-        assertEquals(1, segs.size)
-        assertEquals(100, segs[0].size)
+    fun `a run at or under maxSize is never split, however lulled`() {
+        val msgs = (0..9).map { Msg("m$it", it * 500L) } // ~8h between each
+        val segments = ConversationSegmenter(maxSize = 10).closedSegments(msgs, longAfter, ::at)
+        assertEquals(1, segments.size)
+        assertEquals(10, segments[0].size)
     }
 
     @Test
-    fun `drops runs below the min-item floor`() {
-        val msgs = listOf(Msg("m0", 0), Msg("m1", 100)) // two gap-isolated singletons
-        assertTrue(segmenter(min = 2).closedSegments(msgs, base.plusSeconds(500 * 60), ::at).isEmpty())
+    fun `withholds the still-open trailing segment until it settles`() {
+        val msgs = listOf(Msg("m0", 0), Msg("m1", 1))
+        val segmenter = ConversationSegmenter(settle = Duration.ofHours(24))
+
+        // Two hours after the last message: still in progress, so nothing is emitted.
+        assertTrue(segmenter.closedSegments(msgs, minutesFromBase(121), ::at).isEmpty())
+
+        // Two days later it has gone quiet.
+        val settled = segmenter.closedSegments(msgs, minutesFromBase(2 * 24 * 60), ::at)
+        assertEquals(listOf("m0", "m1"), ids(settled.single()))
+    }
+
+    @Test
+    fun `earlier segments are closed even while the trailing one is open`() {
+        val msgs = (0..6).map { Msg("m$it", it.toLong()) }
+        val segments = ConversationSegmenter(maxSize = 5, settle = Duration.ofHours(24))
+            .closedSegments(msgs, minutesFromBase(7), ::at)
+        // m5, m6 are still open; the capped prefix is safe to extract.
+        assertEquals(1, segments.size)
+        assertEquals(listOf("m0", "m1", "m2", "m3", "m4"), ids(segments[0]))
+    }
+
+    @Test
+    fun `maxSilence, when set, does split a dormant channel`() {
+        val msgs = listOf(Msg("m0", 0), Msg("m1", 1), Msg("m2", 30 * 24 * 60), Msg("m3", 30 * 24 * 60 + 1))
+        val segments = ConversationSegmenter(maxSilence = Duration.ofDays(14))
+            .closedSegments(msgs, longAfter.plusSeconds(Duration.ofDays(60).seconds), ::at)
+        assertEquals(2, segments.size)
+        assertEquals(listOf("m0", "m1"), ids(segments[0]))
+        assertEquals(listOf("m2", "m3"), ids(segments[1]))
+    }
+
+    @Test
+    fun `the cut leaves at least minItems behind`() {
+        // The widest gap sits after m0, but minItems=3 forbids cutting there.
+        val msgs = listOf(
+            Msg("m0", 0),
+            Msg("m1", 100), Msg("m2", 101), Msg("m3", 102), Msg("m4", 103), Msg("m5", 104), Msg("m6", 105),
+        )
+        val segments = ConversationSegmenter(maxSize = 5, minItems = 3).closedSegments(msgs, longAfter, ::at)
+        assertEquals(listOf("m0", "m1", "m2", "m3", "m4"), ids(segments[0]))
+    }
+
+    @Test
+    fun `size accessor weights items against maxSize`() {
+        val msgs = listOf(Msg("m0", 0, weight = 4), Msg("m1", 1, weight = 4), Msg("m2", 2, weight = 4))
+        val segments = ConversationSegmenter(maxSize = 10)
+            .closedSegments(msgs, longAfter, ::at) { it.weight }
+        assertEquals(2, segments.size)
+        assertEquals(listOf("m0", "m1"), ids(segments[0]))
+        assertEquals(listOf("m2"), ids(segments[1]))
+    }
+
+    @Test
+    fun `a lone item heavier than maxSize becomes its own segment`() {
+        val msgs = listOf(Msg("m0", 0, weight = 99), Msg("m1", 1, weight = 1))
+        val segments = ConversationSegmenter(maxSize = 10)
+            .closedSegments(msgs, longAfter, ::at) { it.weight }
+        assertEquals(listOf("m0"), ids(segments[0]))
+        assertEquals(listOf("m1"), ids(segments[1]))
+    }
+
+    @Test
+    fun `drops segments below the min-item floor`() {
+        val msgs = listOf(Msg("m0", 0))
+        assertTrue(ConversationSegmenter(minItems = 2).closedSegments(msgs, longAfter, ::at).isEmpty())
     }
 
     @Test
     fun `empty input yields nothing`() {
-        assertEquals(emptyList<List<Msg>>(), segmenter().closedSegments(emptyList<Msg>(), base, ::at))
+        assertEquals(emptyList<List<Msg>>(), ConversationSegmenter().closedSegments(emptyList<Msg>(), base, ::at))
+    }
+
+    @Test
+    fun `items are segmented in time order regardless of input order`() {
+        val msgs = listOf(Msg("m2", 2), Msg("m0", 0), Msg("m1", 1))
+        val segments = ConversationSegmenter().closedSegments(msgs, longAfter, ::at)
+        assertEquals(listOf("m0", "m1", "m2"), ids(segments.single()))
     }
 }


### PR DESCRIPTION
# PR: Conversation segmentation for incremental extraction

## Summary

Adds `ConversationSegmenter`, a pure utility that splits a timestamped item stream
(e.g. a chat channel's messages) into conversation segments, so each segment can be
handed to `IncrementalSource`-based extraction as one conversation.

## Motivation

Feeding a raw firehose of messages into the incremental analyzer would window purely
by index, cutting mid-conversation. Segmenting first keeps each extraction unit
coherent. This separates two concerns:

- **`ConversationSegmenter`** decides conversation *boundaries*.
- **The incremental analyzer** (`WindowConfig`) chunks *within* a segment by
  size/overlap. Those windows, not whole segments, are what an LLM sees.

### Why brief silence is not a boundary

The obvious heuristic — start a new conversation after N minutes of quiet — is wrong
for async chat. On Discord a thread routinely goes quiet for eight or twenty-four
hours while contributors sleep across timezones. Cutting on that silence would shred
exactly the long-running conversations most worth extracting.

So *within* a conversation, segments are bounded by **size**, not silence. When size
forces a cut, the cut lands on the **largest interior gap**, so the seam falls in a
lull rather than mid-exchange.

### Why long silence *is* a boundary

`settle` is the point at which a trailing conversation is declared finished and handed
to extraction. Once a conversation has been extracted, a later reply must begin a new
segment rather than re-open the extracted one — otherwise the next call re-emits a
superset of what was already consumed. The same duration therefore has to govern both:
a silence longer than `settle` ends the conversation, and a conversation quiet for
longer than `settle` is extractable.

A single knob keeps the two consistent. (An earlier draft had a separate `maxSilence`
ceiling defaulting to null, which contradicted `settle`: a 24h gap would simultaneously
close a conversation and not be a boundary.)

## Behavior

`closedSegments(items, now, timestamp, size)` returns the closed segments, each a
time-ordered sub-list:

- Items are sorted by timestamp; ties keep input order.
- A silence longer than `settle` starts a new conversation.
- Within a conversation, a run is split only once it exceeds `maxSize`, cutting at the
  largest interior gap within the longest prefix that fits. The cut is constrained to
  leave at least `minItems` behind, so a lull near the head can't strand items in a
  sub-`minItems` fragment. Ties favour the later index, keeping segments full.
- A segment is **closed** — safe to extract — once further content follows it, or, for
  the trailing segment, once it has been quiet longer than `settle`. The still-open
  trailing segment is withheld so an in-progress conversation isn't extracted and then
  re-extracted when the rest arrives.
- An undersized *tail* segment is folded back into the segment before it rather than
  dropped, so no message is silently lost. Only a whole conversation shorter than
  `minItems` is dropped.

Pure and deterministic — no LLM, no I/O. Generic over the item type; the caller
supplies a timestamp accessor and, optionally, a size accessor. Each accessor is
invoked exactly once per item, so a costly one (a token estimator) is affordable.

## API

```kotlin
class ConversationSegmenter(
    maxSize: Int = DEFAULT_MAX_SIZE,      // 500
    settle: Duration = DEFAULT_SETTLE,    // 24h
    minItems: Int = 1,
) {
    fun <T> closedSegments(
        items: List<T>,
        now: Instant,
        timestamp: (T) -> Instant,
        size: (T) -> Int = { 1 },
    ): List<List<T>>
}
```

### On the defaults

`maxSize` is **not** a context-window constraint — the analyzer chunks a segment into
`WindowConfig.windowSize` (10–20) message windows, and only those reach the model. It
is a *coherence* cap: past some length, a run of messages is no longer plausibly one
conversation.

The default of **500** is 25–50 analyzer windows wide, is a genuinely long thread, and
— should a whole segment ever be sent to a model — is roughly 20k tokens at typical
message length, comfortably inside any modern context window. A segment absorbing an
undersized tail may exceed it by up to `minItems - 1` items; it is a cap on coherence,
not a hard limit.

`maxSize` is expressed in whatever units the `size` accessor returns. The default
accessor counts one unit per item, making it a message count; a caller supplying a
token estimator must scale `maxSize` accordingly. Note that `minItems` always counts
items — setting it above the number of items `maxSize` admits discards the stream.

`settle` defaults to 24h: long enough to respect timezone-spanning replies, short
enough that extraction isn't perpetually stalled.

### Idempotency

Segmentation of a given prefix is stable as later items arrive, so repeated calls over
a growing stream emit each closed segment exactly once — provided items are ingested in
timestamp order. An item back-dated to within `settle` of an already-extracted segment
will re-open it.

## Tests

`ConversationSegmenterTest` (20 tests) covers:

- An overnight (24h) lull does not split a conversation.
- A silence beyond `settle` splits a dormant channel, and each conversation is then
  independently capped by `maxSize`.
- Splitting only once over `maxSize`, cutting at the largest interior gap.
- A run at or under `maxSize` is never split, however lulled.
- Withholding the still-open trailing segment until it settles; a `now` preceding the
  last item leaves it open.
- Earlier segments are closed even while the trailing one is open.
- The cut leaves at least `minItems` behind.
- A settled undersized tail is folded into the preceding segment; an open one is
  withheld rather than folded.
- The `size` accessor weights items against `maxSize`, and each accessor is invoked
  once per item.
- A lone item heavier than `maxSize` becomes its own segment.
- Dropping a whole conversation below the min-item floor; `minItems` above what
  `maxSize` admits; empty input; out-of-order input; tied timestamps; zero gaps
  throughout.

## Files

- `dice/src/main/kotlin/com/embabel/dice/incremental/ConversationSegmenter.kt` (new)
- `dice/src/test/kotlin/com/embabel/dice/incremental/ConversationSegmenterTest.kt` (new)
