### PR TITLE
fix(resolver): escape entity names before they hit Lucene fulltext queries

### DIFF
--- a/dice/pom.xml
+++ b/dice/pom.xml
@@ -143,6 +143,35 @@
             <scope>test</scope>
         </dependency>
 
+        <!--
+            Test-only: lets the candidate-searcher tests parse a built query with the
+            real Lucene classic QueryParser, so we're proving the query is actually
+            parseable rather than trusting our own escaping logic. Not a main-scope
+            dependency — dice doesn't otherwise talk to Lucene directly, it goes
+            through Neo4j's fulltext procedure, which does its own Lucene parsing
+            internally. Version matches embabel-agent-rag-lucene's.
+        -->
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>9.11.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analysis-common</artifactId>
+            <version>9.11.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+            <version>9.11.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/ByExactNameCandidateSearcher.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/ByExactNameCandidateSearcher.kt
@@ -45,7 +45,7 @@ class ByExactNameCandidateSearcher(
         suggested: SuggestedEntity,
         schema: DataDictionary,
     ): SearchResult {
-        val exactQuery = "\"${suggested.name}\""
+        val exactQuery = luceneExactPhraseQuery(suggested.name)
 
         return try {
             val labelFilter = EntityFilter.hasAnyLabel(suggested.labels.toSet())

--- a/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/FuzzyNameCandidateSearcher.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/FuzzyNameCandidateSearcher.kt
@@ -58,7 +58,7 @@ class FuzzyNameCandidateSearcher(
             val labelFilter = EntityFilter.hasAnyLabel(suggested.labels.toSet())
             val results = repository.textSearch(
                 TextSimilaritySearchRequest(
-                    query = suggested.name,
+                    query = luceneEscape(suggested.name),
                     similarityThreshold = similarityThreshold,
                     topK = topK,
                 ),

--- a/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/LuceneQueryEscaping.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/LuceneQueryEscaping.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.common.resolver.searcher
+
+/**
+ * Characters Lucene's classic query parser treats as syntax, not literal text.
+ * Mirrors `org.apache.lucene.queryparser.classic.QueryParserBase.escape` exactly.
+ */
+private val LUCENE_SPECIAL_CHARS = setOf(
+    '\\', '+', '-', '!', '(', ')', ':', '^', '[', ']', '"', '{', '}', '~', '*', '?', '|', '&', '/',
+)
+
+/**
+ * Escapes Lucene special characters in [s] so it can be dropped into a fulltext
+ * query as literal text.
+ *
+ * Entity names come from arbitrary source text — they can contain any of `+ -
+ * ! ( ) : ^ [ ] " { } ~ * ? | & /` and a backslash itself. Those all mean
+ * something to Lucene's query syntax. A name that reaches
+ * `db.index.fulltext.queryNodes` unescaped can crash the query outright (a
+ * dangling `~` or `/` throws a lexical error) or, worse, silently change what
+ * the query means (an embedded `"` ends a phrase early). Cypher parameter
+ * binding doesn't help here: Neo4j hands the string straight to Lucene's
+ * `QueryParser`, which re-parses it as query syntax regardless of how it got
+ * there.
+ *
+ * A name with none of these characters passes through unchanged, so existing
+ * plain-name matching behaves exactly as before.
+ *
+ * We don't depend on Lucene here — dice never talks to it directly, it only
+ * ever reaches Lucene indirectly through whichever store backs
+ * [com.embabel.agent.rag.service.NamedEntityDataRepository.textSearch] (e.g.
+ * Neo4j's fulltext index). Pulling in `lucene-queryparser` for one static
+ * method isn't worth the dependency, so this reimplements it.
+ */
+internal fun luceneEscape(s: String): String = buildString(s.length) {
+    for (c in s) {
+        if (c in LUCENE_SPECIAL_CHARS) {
+            append('\\')
+        }
+        append(c)
+    }
+}
+
+/**
+ * Builds an exact-phrase Lucene query for [name]: escape first, then wrap in
+ * quotes. Escaping first means any quote already in [name] is itself escaped,
+ * so it can't close the phrase early — without this ordering, a name like
+ * `Acme "Legacy" Corp` would silently turn into three OR'd terms instead of
+ * one exact phrase.
+ */
+internal fun luceneExactPhraseQuery(name: String): String = "\"${luceneEscape(name)}\""

--- a/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/NormalizedNameCandidateSearcher.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/NormalizedNameCandidateSearcher.kt
@@ -58,7 +58,7 @@ class NormalizedNameCandidateSearcher(
             val labelFilter = EntityFilter.hasAnyLabel(suggested.labels.toSet())
             val results = repository.textSearch(
                 TextSimilaritySearchRequest(
-                    query = normalizedSuggested,
+                    query = luceneEscape(normalizedSuggested),
                     similarityThreshold = similarityThreshold,
                     topK = topK,
                 ),

--- a/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/PartialNameCandidateSearcher.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/common/resolver/searcher/PartialNameCandidateSearcher.kt
@@ -60,7 +60,7 @@ class PartialNameCandidateSearcher(
             val labelFilter = EntityFilter.hasAnyLabel(suggested.labels.toSet())
             val results = repository.textSearch(
                 TextSimilaritySearchRequest(
-                    query = suggested.name,
+                    query = luceneEscape(suggested.name),
                     similarityThreshold = similarityThreshold,
                     topK = topK,
                 ),

--- a/dice/src/test/kotlin/com/embabel/dice/common/resolver/searcher/CandidateSearcherLuceneEscapingTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/common/resolver/searcher/CandidateSearcherLuceneEscapingTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.common.resolver.searcher
+
+import com.embabel.agent.core.DataDictionary
+import com.embabel.agent.rag.service.NamedEntityDataRepository
+import com.embabel.common.core.types.TextSimilaritySearchRequest
+import com.embabel.dice.common.SuggestedEntity
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.apache.lucene.analysis.standard.StandardAnalyzer
+import org.apache.lucene.queryparser.classic.QueryParser
+import org.apache.lucene.search.PhraseQuery
+import org.apache.lucene.search.Query
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+
+/**
+ * Entity names come from arbitrary source text, so they can contain any of the
+ * characters Lucene's classic QueryParser treats as syntax: `: " / - ( ) ~ *`
+ * and friends. Each of these searchers builds a fulltext query straight from an
+ * entity name and hands it to [NamedEntityDataRepository.textSearch] — where it
+ * ultimately reaches Neo4j's `db.index.fulltext.queryNodes`, which re-parses the
+ * string with Lucene internally. Cypher parameter binding doesn't protect it: to
+ * Lucene, the string is still query syntax, not a literal.
+ *
+ * These tests capture the query each searcher actually builds for a hostile name
+ * and feed it to the real Lucene [QueryParser], proving it parses cleanly rather
+ * than trusting our own escaping.
+ */
+class CandidateSearcherLuceneEscapingTest {
+
+    // Real-world-shaped hostile name: colon, ampersand, parens, slash, trailing tilde.
+    private val hostileName = "Acme Corp: R&D (NY/Boston)~"
+
+    private lateinit var repository: NamedEntityDataRepository
+    private val schema: DataDictionary = DataDictionary.fromClasses("test")
+
+    private fun suggested(name: String) = SuggestedEntity(
+        labels = listOf("Organization"),
+        name = name,
+        summary = "",
+        chunkId = "chunk-1",
+    )
+
+    private fun capturedQuery(slot: CapturingSlot<TextSimilaritySearchRequest>): String {
+        if (!slot.isCaptured) {
+            fail<Unit>("textSearch was never called — searcher swallowed an earlier failure")
+        }
+        return slot.captured.query
+    }
+
+    private fun assertLuceneParseable(query: String) {
+        val analyzer = StandardAnalyzer()
+        try {
+            QueryParser("name", analyzer).parse(query)
+        } catch (e: Exception) {
+            fail<Unit>("query '$query' is not valid Lucene syntax: ${e.message}")
+        } finally {
+            analyzer.close()
+        }
+    }
+
+    private fun parse(query: String): Query {
+        val analyzer = StandardAnalyzer()
+        return try {
+            QueryParser("name", analyzer).parse(query)
+        } catch (e: Exception) {
+            fail<Unit>("query '$query' is not valid Lucene syntax: ${e.message}")
+            throw e
+        } finally {
+            analyzer.close()
+        }
+    }
+
+    @Test
+    fun `ByExactNameCandidateSearcher builds a Lucene-parseable query for a hostile name`() {
+        repository = mockk(relaxed = true)
+        val slot = slot<TextSimilaritySearchRequest>()
+        every { repository.textSearch(capture(slot), any(), any()) } returns emptyList()
+
+        ByExactNameCandidateSearcher(repository).search(suggested(hostileName), schema)
+
+        assertLuceneParseable(capturedQuery(slot))
+    }
+
+    @Test
+    fun `PartialNameCandidateSearcher builds a Lucene-parseable query for a hostile name`() {
+        repository = mockk(relaxed = true)
+        val slot = slot<TextSimilaritySearchRequest>()
+        every { repository.textSearch(capture(slot), any(), any()) } returns emptyList()
+
+        PartialNameCandidateSearcher(repository).search(suggested(hostileName), schema)
+
+        assertLuceneParseable(capturedQuery(slot))
+    }
+
+    @Test
+    fun `FuzzyNameCandidateSearcher builds a Lucene-parseable query for a hostile name`() {
+        repository = mockk(relaxed = true)
+        val slot = slot<TextSimilaritySearchRequest>()
+        every { repository.textSearch(capture(slot), any(), any()) } returns emptyList()
+
+        FuzzyNameCandidateSearcher(repository).search(suggested(hostileName), schema)
+
+        assertLuceneParseable(capturedQuery(slot))
+    }
+
+    @Test
+    fun `NormalizedNameCandidateSearcher builds a Lucene-parseable query for a hostile name`() {
+        repository = mockk(relaxed = true)
+        val slot = slot<TextSimilaritySearchRequest>()
+        every { repository.textSearch(capture(slot), any(), any()) } returns emptyList()
+
+        NormalizedNameCandidateSearcher(repository).search(suggested(hostileName), schema)
+
+        assertLuceneParseable(capturedQuery(slot))
+    }
+
+    @Test
+    fun `ByExactNameCandidateSearcher keeps a name with an embedded quote as one exact phrase`() {
+        // A naive quote-wrap doesn't throw here — the embedded quote closes the
+        // phrase early and Lucene happily reparses the rest as loose OR'd terms.
+        // No exception, but "exact match" semantics are gone: it's no longer a
+        // PhraseQuery. Assert the real invariant, not just "didn't throw".
+        repository = mockk(relaxed = true)
+        val slot = slot<TextSimilaritySearchRequest>()
+        every { repository.textSearch(capture(slot), any(), any()) } returns emptyList()
+
+        ByExactNameCandidateSearcher(repository).search(suggested("""Acme "Legacy" Corp"""), schema)
+
+        val query = parse(capturedQuery(slot))
+        assertTrue(query is PhraseQuery, "expected an exact-phrase query, got ${query.javaClass.simpleName}: $query")
+    }
+
+    @Test
+    fun `ByExactNameCandidateSearcher still produces an exact-phrase query for a plain name`() {
+        repository = mockk(relaxed = true)
+        val slot = slot<TextSimilaritySearchRequest>()
+        every { repository.textSearch(capture(slot), any(), any()) } returns emptyList()
+
+        ByExactNameCandidateSearcher(repository).search(suggested("Johannes Brahms"), schema)
+
+        assertEquals("\"Johannes Brahms\"", capturedQuery(slot))
+    }
+}

--- a/dice/src/test/kotlin/com/embabel/dice/common/resolver/searcher/LuceneQueryEscapingTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/common/resolver/searcher/LuceneQueryEscapingTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.common.resolver.searcher
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer
+import org.apache.lucene.queryparser.classic.QueryParser
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class LuceneQueryEscapingTest {
+
+    @Test
+    fun `passes a plain name through unchanged`() {
+        assertEquals("Johannes Brahms", luceneEscape("Johannes Brahms"))
+    }
+
+    @Test
+    fun `escapes a colon`() {
+        assertEquals("""Acme Corp\: R\&D""", luceneEscape("Acme Corp: R&D"))
+    }
+
+    @Test
+    fun `escapes an embedded quote`() {
+        assertEquals("""Acme \"Legacy\" Corp""", luceneEscape("""Acme "Legacy" Corp"""))
+    }
+
+    @Test
+    fun `escapes a slash`() {
+        assertEquals("""NY\/Boston""", luceneEscape("NY/Boston"))
+    }
+
+    @Test
+    fun `escapes a hyphen`() {
+        assertEquals("""R\-D""", luceneEscape("R-D"))
+    }
+
+    @Test
+    fun `escapes parens`() {
+        assertEquals("""\(NY\)""", luceneEscape("(NY)"))
+    }
+
+    @Test
+    fun `escapes a trailing tilde`() {
+        assertEquals("""Boston\~""", luceneEscape("Boston~"))
+    }
+
+    @Test
+    fun `escaped output is valid Lucene query syntax for a hostile name`() {
+        val analyzer = StandardAnalyzer()
+        val hostile = "Acme Corp: R&D (NY/Boston)~"
+        try {
+            QueryParser("name", analyzer).parse(luceneEscape(hostile))
+        } finally {
+            analyzer.close()
+        }
+    }
+
+    @Test
+    fun `exact phrase query escapes first so an embedded quote cannot close the phrase early`() {
+        val query = luceneExactPhraseQuery("""Acme "Legacy" Corp""")
+        assertEquals("\"Acme \\\"Legacy\\\" Corp\"", query)
+
+        val analyzer = StandardAnalyzer()
+        try {
+            val parsed = QueryParser("name", analyzer).parse(query)
+            assertEquals("name:\"acme legacy corp\"", parsed.toString())
+        } finally {
+            analyzer.close()
+        }
+    }
+
+    @Test
+    fun `exact phrase query for a plain name matches today's unescaped quote-wrap`() {
+        assertEquals("\"Johannes Brahms\"", luceneExactPhraseQuery("Johannes Brahms"))
+    }
+}


### PR DESCRIPTION
## The bug

Entity resolution puts raw entity names into a Neo4j fulltext query without escaping them for Lucene. Any name containing a Lucene operator — `: " / - ( ) ~ * ?` and friends — breaks the query parser:

```
Failed to invoke procedure `db.index.fulltext.queryNodes`:
  org.apache.lucene.queryparser.classic.TokenMgrError:
  Lexical error at line 1, column 162. Encountered: <EOF> after prefix
```

Resolution then fails, and the caller gets a confusing downstream `NoSuchElementException: Entity not found: <uuid>` rather than the parse error that caused it.

Binding the term as a Cypher parameter does **not** protect it: Neo4j's fulltext procedure re-parses the string with Lucene's classic `QueryParser`, so escaping has to happen before it gets there.

Names extracted from arbitrary prose contain punctuation routinely, so in practice every batch of real-world text fails. Synthetic fixtures don't have punctuation, which is why the suite stayed green.

`ByExactNameCandidateSearcher` had a second, quieter version of the same bug: it wrapped the name in quotes by hand, so an embedded quote didn't throw — it silently degraded a `PhraseQuery` into a 3-term `BooleanQuery`, changing what the searcher matched.

## The fix

One shared helper, used by all four searchers:

- `luceneEscape()` — escapes exactly the character set `QueryParser.escape` does (verified against the Lucene 9.11.1 sources).
- `luceneExactPhraseQuery()` — escapes, *then* quote-wraps, so an embedded quote can't terminate the phrase.

Wired into `ByExactName`, `PartialName`, `Fuzzy`, and `NormalizedName` candidate searchers.

Lucene is not on dice's runtime classpath, so the helper is a standalone implementation rather than a new runtime dependency. Lucene is added at **test scope only**, so the tests can assert the built queries actually parse with the real parser instead of trusting a hand-rolled expectation.

## Tests

`CandidateSearcherLuceneEscapingTest` and `LuceneQueryEscapingTest` (new).

Both were watched failing before the fix: 4 of 6 searcher cases failed on unmodified code — three with lexical errors on a hostile name, and the embedded-quote case caught only because the test asserts the resulting **query type**, not merely "no exception thrown".

A name with no special characters must produce the same query it does today; that's asserted, since a regression there would silently change entity resolution for every caller.

Full suite: 1186 tests, 0 failures.

## Related, not fixed here

The same unescaped-term pattern exists at the repository layer in `embabel-agent-rag-graph` (`DrivineNamedEntityDataRepository`) and `embabel-agent-rag-neo-ogm` (`OgmRagFacetProvider`). Escaping at the caller stops malformed queries reaching Neo4j from this path, but those sites are worth the same treatment.
