### PR TITLE
Stop cross-chunk resolver caching entities that are never minted

### DIFF
--- a/dice/src/main/kotlin/com/embabel/dice/pipeline/PropositionPipeline.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/pipeline/PropositionPipeline.kt
@@ -449,9 +449,20 @@ class PropositionPipeline private constructor(
 
         // Wrap the resolver with InMemoryEntityResolver for cross-chunk entity resolution.
         // Order: user's resolver first (for pre-existing entities), then in-memory (for this run's entities)
-        val crossChunkResolver = ChainedEntityResolver(
-            listOf(context.entityResolver, InMemoryEntityResolver())
-        )
+        //
+        // Only do this when minting is actually enabled. InMemoryEntityResolver remembers every
+        // entity it's asked to resolve so a later chunk's mention comes back as ExistingEntity
+        // rather than minting a duplicate - but that memory only makes sense if the entity it
+        // remembers is actually going to be created. When minting is disabled, resolveStage vetoes
+        // every NewEntity instead of minting it, so nothing the in-memory resolver remembers will
+        // ever exist in any repository. Wrapping the resolver anyway would let a later chunk's
+        // mention resolve to ExistingEntity pointing at an id that was never created and will never
+        // be found - the entity equivalent of a dangling pointer.
+        val crossChunkResolver = if (context.mintNewEntities) {
+            ChainedEntityResolver(listOf(context.entityResolver, InMemoryEntityResolver()))
+        } else {
+            context.entityResolver
+        }
         val crossChunkContext = context.copy(entityResolver = crossChunkResolver)
 
         // Extraction stage — resolver-free extraction, dispatched via the execution strategy (parallelizable).

--- a/dice/src/test/kotlin/com/embabel/dice/pipeline/PropositionPipelineTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/pipeline/PropositionPipelineTest.kt
@@ -612,6 +612,60 @@ class PropositionPipelineTest {
     }
 
     @Nested
+    inner class MintingGateInvariantTests {
+
+        /**
+         * With minting disabled, an unmatched mention is vetoed rather than minted (see the
+         * comment in `resolveStage`). The cross-chunk `InMemoryEntityResolver` used by `process()`
+         * doesn't know about that gate, though: it remembers every entity it's asked to resolve,
+         * regardless of whether the pipeline actually commits to creating it. A repeat mention in a
+         * later chunk was hitting that memory and coming back as `ExistingEntity` pointing at an id
+         * that was never minted (because the first mention got vetoed) and will never exist in any
+         * repository - so `updatedEntities()` produced ids that `persist()` could never find.
+         */
+        @Test
+        fun `repeated mention across chunks never resolves to ExistingEntity when minting is disabled`() {
+            val extractor = MockPropositionExtractor()
+            val pipeline = PropositionPipeline.withExtractor(extractor)
+
+            val chunks = listOf(
+                Chunk(id = "chunk-1", text = "mentions:Alice", metadata = emptyMap(), parentId = ""),
+                Chunk(id = "chunk-2", text = "mentions:Alice", metadata = emptyMap(), parentId = ""),
+            )
+            val context = SourceAnalysisContext(
+                schema = schema,
+                entityResolver = AlwaysCreateEntityResolver,
+                contextId = testContextId,
+                mintNewEntities = false,
+            )
+
+            val result = pipeline.process(chunks, context)
+
+            // Minting is disabled, so nothing was ever committed to being created.
+            assertEquals(0, result.newEntities().size, "minting is disabled: nothing should be minted")
+
+            // Therefore nothing can legitimately be "existing" either - there is no row anywhere
+            // for any resolution to point at.
+            assertEquals(
+                0,
+                result.updatedEntities().size,
+                "no entity was ever minted, so none should resolve as ExistingEntity: ${result.updatedEntities()}",
+            )
+
+            // Direct invariant on the resolution types themselves: AlwaysCreateEntityResolver never
+            // finds a match, so every resolution must be NewEntity (then vetoed) - never ExistingEntity.
+            val resolutionTypeNames = result.chunkResults
+                .filterIsInstance<ChunkPropositionResult.Success>()
+                .flatMap { it.entityResolutions.resolutions }
+                .map { it::class.simpleName }
+            assertTrue(
+                resolutionTypeNames.none { it == "ExistingEntity" },
+                "no suggestion should ever resolve to ExistingEntity here: $resolutionTypeNames",
+            )
+        }
+    }
+
+    @Nested
     inner class EntityDeduplicationTests {
 
         @Test


### PR DESCRIPTION


## The bug

`PropositionPipeline.process()` unconditionally wraps the entity resolver with `InMemoryEntityResolver` (via `ChainedEntityResolver`) to dedup entities across the chunks of one batch. That cache memoizes every would-be-new entity it sees.

But the minting gate (`SourceAnalysisContext.mintNewEntities`, default `false`) converts an unmatched `NewEntity` into a `VetoedEntity` *after* the resolver chain — and therefore after the cache — has already run.

So within one batch:
1. Chunk 1 mentions a new entity. The resolver returns `NewEntity` and the cache records it. The minting gate then vetoes it: nothing is persisted.
2. Chunk 2 mentions the same thing. It hits the stale cache and comes back as an `ExistingEntity` — carrying a freshly minted UUID for a row that was never created.

`PersistablePropositions.persist()` calls the strict `NamedEntityDataRepository.update()` on updated entities, which throws `NoSuchElementException: Entity not found: <uuid>`. One phantom aborts the whole chunk, so **every proposition in that batch is silently lost**.

Nothing on this path logs, which is why it presented as "extraction runs fine, propositions never appear."

## The fix

Only build the cross-chunk `InMemoryEntityResolver` wrapper when `context.mintNewEntities` is true. When minting is off, nothing is created during the run, so there is nothing sound to cache across chunks.

This restores the invariant the persistence layer already assumes: **an `ExistingEntity` refers to a row that exists in the repository.**

`persist()` is deliberately left strict — no `update()` → `save()` swap, no swallowing the exception. The resolver was lying; the repository was right to complain.

## Tests

`PropositionPipelineTest` — new test reproduces the phantom (a mention repeated across chunks with minting off resolves to an `ExistingEntity` whose id is in no repository). Confirmed RED on unmodified code, green after the fix.

Full `dice` module suite: 1187 tests, 0 failures (1186 baseline + 1 new).
