### PR TITLE
2.0.0

### DIFF
--- a/dice-storage-autoconfigure/pom.xml
+++ b/dice-storage-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.dice</groupId>
         <artifactId>dice-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>dice-storage-autoconfigure</artifactId>
     <packaging>jar</packaging>

--- a/dice-storage/pom.xml
+++ b/dice-storage/pom.xml
@@ -20,6 +20,8 @@
             so depending on dice-core / embabel-agent is fine.
         -->
         <kotlin.version>2.2.0</kotlin.version>
+        <!-- Gradle wrapper for the KSP codegen step; overridden to gradlew.bat on Windows (see profiles) -->
+        <gradlew.executable>${project.basedir}/codegen-gradle/gradlew</gradlew.executable>
     </properties>
 
     <dependencies>
@@ -107,7 +109,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.basedir}/codegen-gradle/gradlew</executable>
+                            <executable>${gradlew.executable}</executable>
                             <workingDirectory>${project.basedir}/codegen-gradle</workingDirectory>
                             <arguments>
                                 <argument>kspKotlin</argument>
@@ -184,5 +186,20 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- On Windows the exec plugin must invoke gradlew.bat (the Unix gradlew script errors with CreateProcess 193) -->
+        <profile>
+            <id>windows-codegen</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <gradlew.executable>${project.basedir}/codegen-gradle/gradlew.bat</gradlew.executable>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/dice-storage/pom.xml.versionsBackup
+++ b/dice-storage/pom.xml.versionsBackup
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.dice</groupId>
         <artifactId>dice-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>dice-storage</artifactId>
     <packaging>jar</packaging>

--- a/dice/pom.xml
+++ b/dice/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.dice</groupId>
         <artifactId>dice-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>dice</artifactId>
     <packaging>jar</packaging>
@@ -50,6 +50,12 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <!-- Jackson 2 Kotlin module: no longer provided transitively under Spring Boot 4.1 -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
 
         <!-- JetBrains annotations for @ApiStatus -->

--- a/dice/src/main/kotlin/com/embabel/dice/web/rest/security/ApiKeySecurityAutoConfiguration.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/web/rest/security/ApiKeySecurityAutoConfiguration.kt
@@ -88,8 +88,7 @@ class ApiKeySecurityAutoConfiguration {
             pathPatterns = properties.pathPatterns,
         )
 
-        return FilterRegistrationBean<ApiKeyAuthenticationFilter>().apply {
-            this.filter = filter
+        return FilterRegistrationBean(filter).apply {
             this.order = Ordered.HIGHEST_PRECEDENCE + 100
             this.urlPatterns = listOf("/*")
             log.info(

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.10-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.dice</groupId>
     <artifactId>dice-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Dice Parent</name>
     <description>Knowledge graph construction and reasoning library (multi-module aggregator)</description>
@@ -29,7 +29,7 @@
     </modules>
 
     <properties>
-        <embabel-agent.version>0.5.0-SNAPSHOT</embabel-agent.version>
+        <embabel-agent.version>2.0.0-SNAPSHOT</embabel-agent.version>
         <!--
             tuProlog version is pinned to 1.0.4 due to Kotlin version incompatibility.
             tuProlog 1.1.x series is built with Kotlin 2.2.x, causing binary incompatibility


### PR DESCRIPTION
This pull request updates the Dice project to use version `2.0.0-SNAPSHOT` across all modules and introduces improvements for cross-platform Gradle code generation, along with a few dependency and configuration updates. The main changes are grouped below.

### Version Upgrades

* Updated the parent POM version to `2.0.0-SNAPSHOT` in `pom.xml`, `dice/pom.xml`, `dice-storage/pom.xml`, and `dice-storage-autoconfigure/pom.xml` to ensure all modules are aligned with the new release version. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R12) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L32-R32) [[3]](diffhunk://#diff-ec3082cc55e29ca6befbf9103af66b4e180676c634d92ff18f565121b6706e00L8-R8) [[4]](diffhunk://#diff-ec8a5a198b25092f5314fa3a8cdc03dc45530ff82b396c2d417efdbfdb14d0e0L8-R8) [[5]](diffhunk://#diff-ecfa3a5bbc7c37c0def544d0996eb5bf11bba5c5f781c3986e078db5083beb41L8-R8)

### Dependency Management

* Added the `jackson-module-kotlin` dependency to `dice/pom.xml` to restore Kotlin support for Jackson, which is no longer provided transitively in Spring Boot 4.1.
* Updated the `embabel-agent.version` property to `2.0.0-SNAPSHOT` in the parent POM.

### Build and Code Generation Improvements

* Introduced a `gradlew.executable` property and Maven profile in `dice-storage/pom.xml` to automatically select the correct Gradle wrapper script (`gradlew` or `gradlew.bat`) depending on the operating system, improving cross-platform compatibility for the KSP code generation step. [[1]](diffhunk://#diff-ecfa3a5bbc7c37c0def544d0996eb5bf11bba5c5f781c3986e078db5083beb41R23-R24) [[2]](diffhunk://#diff-ecfa3a5bbc7c37c0def544d0996eb5bf11bba5c5f781c3986e078db5083beb41L110-R112) [[3]](diffhunk://#diff-ecfa3a5bbc7c37c0def544d0996eb5bf11bba5c5f781c3986e078db5083beb41R190-R204)
* Added a backup file `dice-storage/pom.xml.versionsBackup` reflecting the previous POM configuration.

### Code Quality

* Simplified the instantiation of `FilterRegistrationBean` in `ApiKeySecurityAutoConfiguration.kt` for better readability and alignment with Kotlin idioms.