### PR TITLE
Embabel Agent 1.5.0

### DIFF
--- a/dice-ingestion/pom.xml
+++ b/dice-ingestion/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.dice</groupId>
         <artifactId>dice-parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>dice-ingestion</artifactId>
     <packaging>jar</packaging>

--- a/dice-integration-tests/pom.xml
+++ b/dice-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.dice</groupId>
         <artifactId>dice-parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>dice-integration-tests</artifactId>
     <packaging>jar</packaging>

--- a/dice-report/pom.xml
+++ b/dice-report/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.dice</groupId>
         <artifactId>dice-parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>dice-report</artifactId>
     <packaging>jar</packaging>

--- a/dice-storage-autoconfigure/pom.xml
+++ b/dice-storage-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.dice</groupId>
         <artifactId>dice-parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>dice-storage-autoconfigure</artifactId>
     <packaging>jar</packaging>

--- a/dice-storage/pom.xml
+++ b/dice-storage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.dice</groupId>
         <artifactId>dice-parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>dice-storage</artifactId>
     <packaging>jar</packaging>
@@ -20,6 +20,8 @@
             so depending on dice-core / embabel-agent is fine.
         -->
         <kotlin.version>2.2.0</kotlin.version>
+        <!-- Gradle wrapper for the KSP codegen step; overridden to gradlew.bat on Windows (see profiles) -->
+        <gradlew.executable>${project.basedir}/codegen-gradle/gradlew</gradlew.executable>
     </properties>
 
     <dependencies>
@@ -107,7 +109,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.basedir}/codegen-gradle/gradlew</executable>
+                            <executable>${gradlew.executable}</executable>
                             <workingDirectory>${project.basedir}/codegen-gradle</workingDirectory>
                             <arguments>
                                 <argument>kspKotlin</argument>
@@ -153,24 +155,7 @@
                         <!-- allow the 2.2 compiler to read 2.1.10 metadata from dice-core / embabel-agent -->
                         <arg>-Xskip-metadata-version-check</arg>
                     </args>
-                    <!--
-                      Re-declare the all-open (spring) plugin. This module overrides the plugin's
-                      <configuration> to add the <args> above, which drops the compilerPlugins the
-                      build parent sets by default. Without it the @Transactional Drivine*Store /
-                      repository classes stay final and Spring can't create their CGLIB proxies
-                      ("Cannot subclass final class ...").
-                    -->
-                    <compilerPlugins>
-                        <plugin>spring</plugin>
-                    </compilerPlugins>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jetbrains.kotlin</groupId>
-                        <artifactId>kotlin-maven-allopen</artifactId>
-                        <version>${kotlin.version}</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -201,5 +186,20 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- On Windows the exec plugin must invoke gradlew.bat (the Unix gradlew script errors with CreateProcess 193) -->
+        <profile>
+            <id>windows-codegen</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <gradlew.executable>${project.basedir}/codegen-gradle/gradlew.bat</gradlew.executable>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/dice-storage/pom.xml
+++ b/dice-storage/pom.xml
@@ -155,7 +155,24 @@
                         <!-- allow the 2.2 compiler to read 2.1.10 metadata from dice-core / embabel-agent -->
                         <arg>-Xskip-metadata-version-check</arg>
                     </args>
+                    <!--
+                      Re-declare the all-open (spring) plugin defensively. The build parent's
+                      pluginManagement declares it and Maven's config merge currently preserves it
+                      through this module's <configuration> override, but if that ever changes the
+                      @Transactional Drivine*Store / repository classes would stay final and Spring
+                      couldn't create their CGLIB proxies ("Cannot subclass final class ...").
+                    -->
+                    <compilerPlugins>
+                        <plugin>spring</plugin>
+                    </compilerPlugins>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-allopen</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>compile</id>

--- a/dice/pom.xml
+++ b/dice/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.dice</groupId>
         <artifactId>dice-parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>dice</artifactId>
     <packaging>jar</packaging>
@@ -50,6 +50,11 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
 
         <!-- JetBrains annotations for @ApiStatus -->

--- a/dice/src/main/kotlin/com/embabel/dice/web/rest/security/ApiKeySecurityAutoConfiguration.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/web/rest/security/ApiKeySecurityAutoConfiguration.kt
@@ -88,8 +88,7 @@ class ApiKeySecurityAutoConfiguration {
             pathPatterns = properties.pathPatterns,
         )
 
-        return FilterRegistrationBean<ApiKeyAuthenticationFilter>().apply {
-            this.filter = filter
+        return FilterRegistrationBean(filter).apply {
             this.order = Ordered.HIGHEST_PRECEDENCE + 100
             this.urlPatterns = listOf("/*")
             log.info(

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.10-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.dice</groupId>
     <artifactId>dice-parent</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Dice Parent</name>
     <description>Knowledge graph construction and reasoning library (multi-module aggregator)</description>
@@ -32,7 +32,7 @@
     </modules>
 
     <properties>
-        <embabel-agent.version>0.5.0-SNAPSHOT</embabel-agent.version>
+        <embabel-agent.version>1.5.0-SNAPSHOT</embabel-agent.version>
         <!--
             tuProlog version is pinned to 1.0.4 due to Kotlin version incompatibility.
             tuProlog 1.1.x series is built with Kotlin 2.2.x, causing binary incompatibility


### PR DESCRIPTION
This pull request updates project versions to `0.2.0-SNAPSHOT` across all modules and introduces several improvements to the build configuration, especially for cross-platform compatibility and dependency management. The most significant changes are outlined below.

Major Technology Upgrade

* Embabel Agent Framework 1.5.0-SNAPSHOT
* Embabel Build 2.0.0-SNAPSHOT
* Kotlin Compiler 2.2.21
* Spring Boot 4.1
* Spring AI 2.0.0
* Jackson 3.0

Version upgrades:

* Updated the parent POM version to `0.2.0-SNAPSHOT` in all module `pom.xml` files (`dice-ingestion`, `dice-integration-tests`, `dice-report`, `dice-storage-autoconfigure`, `dice-storage`, `dice`, and the root `pom.xml`). Also updated the build parent and `embabel-agent` dependency versions in the root `pom.xml`. [[1]](diffhunk://#diff-a0fb7e59ffcc46fefc5d7ff9fd4ee06e099c5c54c4c11cb5891918d139de3190L8-R8) [[2]](diffhunk://#diff-e51012ea9d8a1cae3b41266c344942f2616befd17e6d8af1c1106c7e8415671cL8-R8) [[3]](diffhunk://#diff-c58df7c75b6778bf17a3e081bdad3583d96b1aae4f7903f13f5efa3bfaa525faL8-R8) [[4]](diffhunk://#diff-ec8a5a198b25092f5314fa3a8cdc03dc45530ff82b396c2d417efdbfdb14d0e0L8-R8) [[5]](diffhunk://#diff-ecfa3a5bbc7c37c0def544d0996eb5bf11bba5c5f781c3986e078db5083beb41L8-R8) [[6]](diffhunk://#diff-ec3082cc55e29ca6befbf9103af66b4e180676c634d92ff18f565121b6706e00L8-R8) [[7]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R12) [[8]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L35-R35)

Build and cross-platform improvements:

* Added a `gradlew.executable` property in `dice-storage/pom.xml` and a Maven profile to use `gradlew.bat` on Windows, ensuring the KSP code generation step works on both Unix and Windows systems. Updated the Maven exec plugin configuration to use this property. [[1]](diffhunk://#diff-ecfa3a5bbc7c37c0def544d0996eb5bf11bba5c5f781c3986e078db5083beb41R23-R24) [[2]](diffhunk://#diff-ecfa3a5bbc7c37c0def544d0996eb5bf11bba5c5f781c3986e078db5083beb41L110-R112) [[3]](diffhunk://#diff-ecfa3a5bbc7c37c0def544d0996eb5bf11bba5c5f781c3986e078db5083beb41R190-R204)
* Removed redundant Kotlin Maven plugin configuration for the all-open (spring) plugin and its dependency in `dice-storage/pom.xml`, simplifying the build setup.

Dependency updates:

* Added the `jackson-module-kotlin` dependency to `dice/pom.xml` to improve Kotlin and Jackson integration.