### PR TITLE
Build against drivine 73

### DIFF
--- a/dice-storage/codegen-gradle/build.gradle.kts
+++ b/dice-storage/codegen-gradle/build.gradle.kts
@@ -27,7 +27,11 @@ plugins {
 group = "com.embabel.dice.storage"
 version = "0.1.1-SNAPSHOT"
 
-val drivineVersion = "0.0.57"
+// Comes from the Maven build via -PdrivineVersion (see the exec-maven-plugin in dice-storage/pom.xml),
+// so the pom is the single source of truth and the KSP DSL is generated against the *same* Drivine it
+// is later compiled against. This was previously hardcoded and had already drifted from the pom
+// (0.0.57 here vs 0.0.58 there). The fallback keeps a standalone `./gradlew kspKotlin` working.
+val drivineVersion = (findProperty("drivineVersion") as String?) ?: "0.0.73"
 
 repositories {
     mavenCentral()

--- a/dice-storage/pom.xml
+++ b/dice-storage/pom.xml
@@ -116,6 +116,9 @@
                                 <argument>--no-daemon</argument>
                                 <argument>--console=plain</argument>
                                 <argument>--quiet</argument>
+                                <!-- Pass the pom's Drivine version through so the KSP DSL is generated
+                                     against the same Drivine it is then compiled against. -->
+                                <argument>-PdrivineVersion=${drivine.version}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
             to Kotlin 2.2.21+.
         -->
         <tuprolog.version>1.0.4</tuprolog.version>
-        <drivine.version>0.0.58</drivine.version>
+        <drivine.version>0.0.73</drivine.version>
         <!--
             Docker Engine API version the Testcontainers docker-java client talks. The client's
             default is below the engine minimum, which disables container-backed tests; pin it here


### PR DESCRIPTION
# Rebuild dice-storage against Drivine 0.0.73 (ABI fix), and stop the codegen version drifting

## Why this is needed

Drivine 0.0.73 added a `nullPolicy` parameter to `GraphObjectManager.save` / `saveAll`. That changes the signature of the synthetic Kotlin default-args bridge, so the method a consumer compiled against no longer exists:

```
java.lang.NoSuchMethodError: 'java.lang.Object org.drivine.manager.GraphObjectManager.save$default(
    org.drivine.manager.GraphObjectManager, java.lang.Object, org.drivine.manager.CascadeType, int, java.lang.Object)'
```

Old bridge: `save$default(gom, obj, CascadeType, int, Object)`. New bridge: `save$default(gom, obj, CascadeType, NullPolicy, int, Object)`.

This is a **binary** break, not a source break. Any module compiled against Drivine ≤ 0.0.72 that calls `save(x)` or `save(x, cascade)` relying on defaults still compiles, and then throws at runtime the first time that line executes. `@JvmOverloads` does not preserve the old `$default` ABI.

`
embabel-chat-store has been updated as well. 

