### PR TITLE
Start when the host has no embedding model configured yet

### DIFF
--- a/dice-storage-autoconfigure/src/main/kotlin/com/embabel/dice/storage/autoconfigure/DiceStorageAutoConfiguration.kt
+++ b/dice-storage-autoconfigure/src/main/kotlin/com/embabel/dice/storage/autoconfigure/DiceStorageAutoConfiguration.kt
@@ -16,6 +16,7 @@
 package com.embabel.dice.storage.autoconfigure
 
 import com.embabel.agent.api.common.Ai
+import com.embabel.common.ai.model.EmbeddingService
 import com.embabel.dice.spi.DecayStatusPolicy
 import com.embabel.dice.incremental.ChunkHistoryStore
 import com.embabel.dice.incremental.InMemoryChunkHistoryStore
@@ -81,15 +82,31 @@ class DiceStorageAutoConfiguration {
         persistenceManager: PersistenceManager,
         ai: Ai,
         transactionManager: PlatformTransactionManager,
+        embeddingServices: ObjectProvider<EmbeddingService>,
     ): PropositionRepository {
         logger.info(
             "Wiring graph proposition store (Drivine/Neo4j), vector index '{}'",
             DrivinePropositionRepository.VECTOR_INDEX,
         )
         return DrivinePropositionRepository(
-            graphObjectManager, persistenceManager, ai.withDefaultEmbeddingService(), transactionManager,
+            graphObjectManager, persistenceManager, embeddingService(ai, embeddingServices), transactionManager,
         )
     }
+
+    /**
+     * The application's own [EmbeddingService] bean where there is an unambiguous one
+     * (a `@Primary` bean counts), otherwise the platform default.
+     *
+     * Preferring the bean matters for a host that can start with NO embedding model
+     * configured — one whose provider key arrives at first run rather than at boot.
+     * Such a host registers an embedding service that reports its own absence and can be
+     * switched on later, whereas `ai.withDefaultEmbeddingService()` resolves the default
+     * eagerly and throws when no model is registered, taking the context down with it.
+     * [DrivinePropositionRepository] only touches the service when it actually embeds, so
+     * an absent-tolerant one is safe to hold.
+     */
+    private fun embeddingService(ai: Ai, embeddingServices: ObjectProvider<EmbeddingService>): EmbeddingService =
+        embeddingServices.getIfUnique() ?: ai.withDefaultEmbeddingService()
 
     @Bean
     @ConditionalOnProperty(prefix = "embabel.dice.store", name = ["type"], havingValue = "graph")
@@ -163,9 +180,26 @@ class DiceStorageAutoConfiguration {
         havingValue = "true",
         matchIfMissing = true,
     )
-    fun propositionVectorIndexSchema(ai: Ai): SchemaCatalog {
-        val embeddingService = ai.withDefaultEmbeddingService()
-        val spec = propositionVectorIndexSpec(embeddingService.dimensions)
+    fun propositionVectorIndexSchema(
+        ai: Ai,
+        embeddingServices: ObjectProvider<EmbeddingService>,
+    ): SchemaCatalog {
+        // A vector index is created AT the embedding model's dimension, so with no model
+        // there is no dimension to create it at. Register nothing rather than guess: an
+        // index at the wrong dimension is worse than none, because writes to it succeed.
+        // The catalog is rebuilt on the next boot, by which time a model configured at
+        // first run is registered.
+        val embeddingService = runCatching { embeddingService(ai, embeddingServices) }
+            .getOrElse {
+                logger.warn("Skipping proposition vector index schema: no embedding model ({})", it.message)
+                return SchemaCatalog.of()
+            }
+        val dimensions = runCatching { embeddingService.dimensions }
+            .getOrElse {
+                logger.warn("Skipping proposition vector index schema: no embedding model ({})", it.message)
+                return SchemaCatalog.of()
+            }
+        val spec = propositionVectorIndexSpec(dimensions)
         logger.info("Registering proposition vector index schema: {} (model={})", spec, embeddingService.name)
         return SchemaCatalog.of(spec).withVersion(embeddingService.name)
     }


### PR DESCRIPTION
## Problem

Both graph-backend beans resolved the default embedding service **while being created**:

```kotlin
DrivinePropositionRepository(..., ai.withDefaultEmbeddingService(), ...)   // :90
val embeddingService = ai.withDefaultEmbeddingService()                    // :167
```

`withDefaultEmbeddingService()` throws when no embedding model is registered. A host whose provider key arrives at first run rather than at boot therefore could not start — and so could not reach the setup flow that would have supplied the key.

## Change

**`drivinePropositionRepository`** prefers the application's own `EmbeddingService` bean where there is an unambiguous one (a `@Primary` bean counts), falling back to `ai.withDefaultEmbeddingService()` as before.

This matters because a host that supports late configuration registers a service that reports its own absence and can be switched on later. `DrivinePropositionRepository` only touches the service when it actually embeds — never in its constructor — so holding an absent-tolerant one is safe.

`getIfUnique()` is deliberate: it returns the `@Primary` bean when there is one, `null` when the choice is ambiguous, and the fallback then preserves today's behaviour rather than failing on ambiguity.

**`propositionVectorIndexSchema`** registers nothing when there is no model, instead of guessing a dimension.

## Why skip rather than guess

An index built at the wrong dimension is worse than no index, because writes to it *succeed* — a real model configured later silently disagrees with everything already stored. Skipping is recoverable; a corrupted index is not obviously broken until someone notices bad results.

The catalog is rebuilt on the next boot, by which time a model configured at first run is registered. Deployments that restart after first-run setup get this for free.

## Compatibility

Unchanged for any deployment that has an embedding model — which is every existing one. The new path is only reachable when resolution would previously have thrown and taken the context down.

The in-memory backend (`inMemoryPropositionRepository`) still calls `withDefaultEmbeddingService()` directly. It is only active when the graph store is not, and was left alone to keep this change to the failing path.

## Testing

- `dice-storage` + `dice-storage-autoconfigure`: 100 tests pass, 0 failures
- Verified in situ by booting a consuming application with zero provider keys, which previously died here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
