### PR TITLE
Build against Drivine 0.0.79

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
             to Kotlin 2.2.21+.
         -->
         <tuprolog.version>1.0.4</tuprolog.version>
-        <drivine.version>0.0.73</drivine.version>
+        <drivine.version>0.0.79</drivine.version>
         <!--
             Docker Engine API version the Testcontainers docker-java client talks. The client's
             default is below the engine minimum, which disables container-backed tests; pin it here


### PR DESCRIPTION
Drivine 0.0.79 replaced `VectorIndexSpec`'s 5-arg constructor with an 8-arg one (`hnswM`, `hnswEfConstruction`, `engineOptions`).

`embabel-agent-rag-graph` and `embabel-chat-store` already publish against 0.0.79, while `dice-storage` was still on 0.0.73. A consumer that puts all three on one classpath gets a `NoSuchMethodError` at context load whichever Drivine wins — this is currently breaking `embabel/me`'s build on main.

`propositionVectorIndexSpec` passes named arguments and leaves the new parameters defaulted, so the bump is source-compatible. Full `mvn install` is green locally.

Merging this publishes a `dice` SNAPSHOT that lets `me` pin Drivine 0.0.79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bVjwe3rqRZ5wp9ov6q2Ki