### PR TITLE
feat(metamodel): dice-metamodel module — schema governance contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ DICE (Domain-Integrated Context Engineering) is a proposition-first knowledge su
 | `dice-report` | Output projectors over propositions: rationale (why a fact is believed, with evidence), structured report, and surprising-link discovery |
 | `dice-ingestion` | Ingestion SPI (artifacts → chunks) with a content-hash dedup ledger so the same source isn't extracted twice |
 | `dice-integration-tests` | Test-only: the cross-feature end-to-end canonical-flow harness |
+| `dice-metamodel` | Metamodel versioning, diffing between versions, and quarantining propositions whose types drift from the schema |
 
 ## Build & test
 
@@ -90,4 +91,4 @@ The `dice` module is organized by responsibility:
 - **Tuning what gets into the store** → admission gates in `com.embabel.dice.proposition.gate` (`ExtractionGatePipeline`, `StandardGates`); they run on pipeline output before the caller persists.
 - **Running maintenance / consolidation** → `DefaultDreamLoopOrchestrator` (threshold-gated consolidation passes) or `DefaultMemoryMaintenanceOrchestrator` (the legacy four-step pipeline), both in `com.embabel.dice.projection.memory`.
 - **Reclaiming stale or duplicate propositions** → `DefaultCollectorRunner` and its `CollectorStrategy` in `com.embabel.dice.projection.memory` (the `SweepPolicy` that decides each fate lives in `com.embabel.dice.spi`); runs are auditable via `CollectorRecordStore`.
-- **Understanding *why* the system behaves as it does** → [`docs/design/`](docs/design/INDEX.md) holds the design-decision notes — start with [`docs/design/architecture.md`](docs/design/architecture.md) for a system-level map and then follow to: the extraction pipeline, the proposition lifecycle (trust, authority, supersession, decay, pinning), knowledge hygiene (gates, reclamation, consolidation), graph projection, retrieval and discovery, durable storage (backends, dedup, the decay tick), and the event model.
+- **Understanding *why* the system behaves as it does** → [`docs/design/`](docs/design/INDEX.md) holds the design-decision notes — start with [`docs/design/architecture.md`](docs/design/architecture.md) for a system-level map and then follow to: the extraction pipeline, the proposition lifecycle (trust, authority, supersession, decay, pinning), knowledge hygiene (gates, reclamation, consolidation), graph projection, retrieval and discovery, durable storage (backends, dedup, the decay tick), metamodel governance (schema versioning, drift quarantine), and the event model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+Notable changes to DICE. Each entry states its compatibility impact on consumers
+(assistant/me and anything else tracking `0.2.0-SNAPSHOT`): **additive** (safe to
+pick up), **behavioral** (same API, different runtime behavior — read the note),
+or **breaking** (consumer change required; the entry links the migration notes
+and the consumer PRs that deliver it).
+
+## Unreleased
+
+### Added
+
+- `dice-metamodel` module: schema governance contracts — `MetamodelVersion`
+  content-hash stamping, declared-vs-observed schema diffing, drift reports, and
+  proposition quarantine policy. Pure JVM, no Spring or database dependencies.
+  See [docs/design/metamodel-governance.md](docs/design/metamodel-governance.md).
+  **Compatibility: additive.** New module; no existing API touched.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ recover by reading a single class — see the design notes in [`docs/design/`](d
   query-time authority filtering, the single retrieval router, and serendipitous link discovery.
 - [Durable storage](docs/design/durable-storage.md) — backend selection, defense-in-depth dedup,
   two-phase save, materialised effective confidence, schema-as-beans, and the decay tick.
+- [Metamodel governance](docs/design/metamodel-governance.md) — versioned schema stamps, diffing
+  additive vs. lossy changes, and quarantining propositions whose types drift from the schema.
 - [Events](docs/design/events.md) — the domain-event model the store and pipeline emit.
 
 ## Real-World Example: Impromptu

--- a/dice-metamodel/AGENTS.md
+++ b/dice-metamodel/AGENTS.md
@@ -1,0 +1,90 @@
+# dice-metamodel
+
+Tracks how a knowledge-graph schema changes over time and protects stored propositions when it
+does. Two comparisons live here: **declared vs. declared** (`MetamodelDiffer`) — two schema versions
+you chose — and **declared vs. observed** (`DeclaredObservedDiffer`, `DriftCheckRunner`) — what you
+declared against what a live graph actually holds. Both end at the same quarantine policy, which
+marks affected propositions `STALE` rather than deleting them.
+
+Read [metamodel-governance.md](../docs/design/metamodel-governance.md) first if you want the
+reasoning: why a version is a content hash, why drift is observed after the fact instead of blocked
+at write time, why quarantine never deletes.
+
+## Contracts and support
+
+Everything in `com.embabel.dice.metamodel` is contract — interfaces and immutable value types:
+
+- `MetamodelVersion` — an immutable stamp of a `DataDictionary`, fingerprinted by a length-prefixed
+  SHA-256 `contentHash` that excludes the schema name. Build one with `MetamodelVersion.from(dd)`.
+- `MetamodelChange` / `MetamodelDiff` — the five structural change kinds and the diff that carries
+  them. `DeclaredObservedDiff` is the asymmetric cousin: drift vs. unobserved.
+- `DeclaredSchemaSource` / `ObservedSchemaSource` — where the two sides of a drift check come from.
+  Neither has a default here; a consumer supplies the first, a storage module the second.
+- `MetamodelStore` — log of versions and drift reports. Nothing is ever deleted, and both writes
+  upsert on a natural key: re-saving under a key that already exists overwrites that record's
+  non-key content rather than adding a duplicate. Three reads for drift reports, because the scope
+  has to be visible at the call site: `driftReports` (everything), `globalDriftReports` (unscoped
+  checks only), `driftReportsInContext` (one context only).
+- `DriftCheckRunner` — sequences observe → declare → diff → report → optional quarantine. Dry-run by
+  default. No scheduler of its own.
+- `DriftQuarantinePolicy` — turns a diff plus some propositions into `QuarantineDecision`s. Returns
+  immutable copies; the caller persists them.
+
+`com.embabel.dice.metamodel.support` holds the shipped implementations: `StructuralMetamodelDiffer`
+(both differ interfaces, stateless), `MentionTypeDriftQuarantinePolicy` (lossy changes only,
+idempotent on already-quarantined propositions), and `DefaultDriftCheckRunner`. The top-level
+package holds contracts only.
+
+There is no Spring wiring in this module. The defaults are ordinary constructor calls; a ready-made
+set of beans arrives with the autoconfigure slice, where `@ConditionalOnMissingBean` actually behaves
+as advertised.
+
+## Dependencies, and the ones to keep out
+
+- **`dice` (core)** — required. `Proposition`, `PropositionStatus`, `PropositionRepository`,
+  `DiceMetadataKeys`.
+- **`embabel-agent-api`, `embabel-agent-rag-core`** — `provided`. `DataDictionary` and `ContextId`
+  come from here; the consuming app supplies them.
+- **slf4j** — logging only.
+
+No Spring dependency at all, not even `provided`. Nothing here is annotated, so keep it that way —
+bean wiring belongs in the autoconfigure module.
+
+Never add Drivine, the Neo4j driver, or Jackson. This module has to stay runnable with no database
+and no serialization framework — that is what lets tests drive the whole drift loop from a canned
+`ObservedSchema`. Graph-side work belongs one module out: `DrivineMetamodelStore` lives in
+`dice-storage`, and the Neo4j `ObservedSchemaSource` lands with the autoconfigure wiring that
+assembles the `DriftCheckRunner` bean.
+
+## Who depends on this
+
+`dice-storage` (for `MetamodelStore` and the value types it persists). Autoconfiguration will follow.
+Nothing here depends on either, so a change to the contracts ripples outward only.
+
+## Tests
+
+`src/test/kotlin/com/embabel/dice/metamodel/` — plain JUnit, no Spring context, no containers:
+`MetamodelVersionTest` (hashing and its escape safety), `MetamodelDifferTest`,
+`DriftQuarantinePolicyTest`, `DriftCheckRunnerTest` (fakes for the store, observer, and repository),
+`DriftReportTest`. Run them with `mvn test -pl dice-metamodel`.
+
+`MetamodelVersionTest.GoldenHash` pins the digest of a fixed schema to a literal string. That is on
+purpose: the hash is a persisted format — a MERGE key in the store and a stored `versionHash` on
+every drift report — so changing the encoding orphans reports already on disk. If the literal goes
+red, decide whether you meant to change the format, and migrate; don't paste in the new value.
+
+## Gotchas
+
+- **The content hash excludes the schema name.** Deliberate, for dev/prod parity. It also means
+  `contentHash` alone can't distinguish two identically-shaped schemas.
+- **`EntityTypeModified` only fires for types in both versions.** Removed-and-re-added under the same
+  name shows up as `EntityTypeRemoved` + `EntityTypeAdded`.
+- **Quarantine is idempotent.** A proposition already `STALE` with a `QUARANTINE_REASON` comes back
+  as `QuarantineDecision.AlreadyQuarantined`, unchanged — its own bucket, not the conforming one, so
+  `conforming.size` stays an honest count of clean propositions. Clear the metadata key to force
+  re-evaluation.
+- **`contentHash` is derived, never supplied.** It's computed in `MetamodelVersion`'s body from the
+  structural fields, so two versions that compare equal really do have the same shape.
+- **Relationship names travel un-rendered.** `MetamodelVersion.relationshipNames` holds
+  `From-[name]->To` descriptors; never parse a bare name back out of one. `DeclaredSchema` carries
+  the bare names for that reason.

--- a/dice-metamodel/pom.xml
+++ b/dice-metamodel/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.dice</groupId>
+        <artifactId>dice-parent</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>dice-metamodel</artifactId>
+    <packaging>jar</packaging>
+    <name>Dice Metamodel</name>
+    <description>Metamodel versioning, diffing, and drift quarantine for DICE knowledge graphs</description>
+
+    <dependencies>
+        <!-- Dice core: Proposition model and repository SPI -->
+        <dependency>
+            <groupId>com.embabel.dice</groupId>
+            <artifactId>dice</artifactId>
+        </dependency>
+
+        <!-- Embabel agent core types; provided, supplied by the consuming app -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Retrievable (supertype of Proposition) lives in rag-core; provided, non-transitive from dice -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-rag-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- Default interface methods available for Java consumers -->
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <configuration>
+                    <args>
+                        <arg>-Xjvm-default=all</arg>
+                    </args>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/dice-metamodel/pom.xml
+++ b/dice-metamodel/pom.xml
@@ -39,13 +39,8 @@
 
         <!-- Test -->
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/DeclaredSchemaSource.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/DeclaredSchemaSource.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+/**
+ * The schema as declared, ready to hand to [DeclaredObservedDiffer.diffAgainstObserved]: the
+ * stamped [version] plus the bare relationship type names it allows.
+ *
+ * The bare names travel alongside the stamp rather than being recovered from it because
+ * [MetamodelVersion.relationshipNames] holds rendered `From-[name]->To` descriptors, and
+ * reverse-parsing one back into a bare name is ambiguous for free-text / LLM-derived names (see
+ * [DeclaredObservedDiffer.diffAgainstObserved]'s KDoc). Whoever builds a [DeclaredSchema] holds the
+ * un-rendered relationship definitions before they were ever stamped, and should pass that set
+ * straight through.
+ *
+ * @property version The stamped declared schema.
+ * @property relationshipTypeNames The bare relationship type names [version] allows.
+ */
+data class DeclaredSchema(
+    val version: MetamodelVersion,
+    val relationshipTypeNames: Set<String>,
+)
+
+/**
+ * Supplies the schema an application has declared, for [DriftCheckRunner] to compare against a live
+ * graph's [ObservedSchema].
+ *
+ * This module has no opinion on where a declared schema comes from — a consuming Spring app is
+ * expected to implement this over whatever it already uses to define its [MetamodelVersion] (a
+ * `DataDictionary`, a config file, a registry, ...) and wire it as a bean. There is no default
+ * implementation because there is no default declared schema.
+ */
+fun interface DeclaredSchemaSource {
+
+    /**
+     * @return the current [DeclaredSchema].
+     */
+    fun declare(): DeclaredSchema
+}

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/DriftCheckRunner.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/DriftCheckRunner.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import com.embabel.agent.core.ContextId
+
+/**
+ * Summary of a single [DriftCheckRunner.run] call.
+ *
+ * @property dryRun Whether this was a preview run (no propositions were quarantined).
+ * @property schemaName The declared schema name the check was performed against.
+ * @property contextId The context this check was scoped to, or `null` if it checked the whole
+ *   graph.
+ * @property driftedEntityTypes Entity type names observed in the graph but never declared.
+ * @property driftedRelationshipTypes Relationship type names observed but never declared.
+ * @property quarantinedCount How many propositions were newly quarantined. Always 0 on a dry run
+ *   or when there was no entity-type drift.
+ * @property report The [DriftReport] this run persisted — every run persists one, even a clean one.
+ */
+data class DriftCheckResult(
+    val dryRun: Boolean,
+    val schemaName: String,
+    val driftedEntityTypes: Set<String>,
+    val driftedRelationshipTypes: Set<String>,
+    val quarantinedCount: Int,
+    val report: DriftReport,
+    val contextId: ContextId? = null,
+) {
+    /** `true` when the graph contained any type or relationship never declared. */
+    val hasDrift: Boolean get() = driftedEntityTypes.isNotEmpty() || driftedRelationshipTypes.isNotEmpty()
+}
+
+/**
+ * Runs a drift check: snapshots what a live graph actually contains, compares it against the
+ * declared schema, records the observation, and — opt-in — quarantines propositions whose
+ * mentions reference types the graph has but the schema doesn't.
+ *
+ * Mirrors [com.embabel.dice.projection.memory.CollectorRunner]'s shape: dry-run by default, no
+ * scheduling of its own (a consumer schedules calls to [run]), and every run leaves a durable
+ * record — "checked and found nothing" has to be as retrievable as "checked and found drift".
+ *
+ * The shorter [run] forms are real overloads with bodies rather than Kotlin default arguments,
+ * because Java can't see a default argument: `runner.run()` has to exist as a method for a Java
+ * caller to write it. Implementations override the two-argument form and get the other two free.
+ * For Java those two shorter forms are the whole surface — `ContextId` is a Kotlin value class, so
+ * the two-argument form compiles to a mangled JVM name Java can't call.
+ */
+interface DriftCheckRunner {
+
+    /**
+     * Snapshot, diff, persist, and — if [dryRun] is `false` and drift touched any entity type —
+     * quarantine.
+     *
+     * @param dryRun When `true`, the check runs and its [DriftReport] is persisted, but no
+     *   proposition is touched. When `false`, propositions whose mentions reference a drifted
+     *   entity type are handed to the configured [DriftQuarantinePolicy] and any it flags are
+     *   persisted as quarantined.
+     * @param contextId `null` means the check covers the whole graph. Non-null scopes everything
+     *   the check touches to that one context: the candidate propositions read for quarantine, the
+     *   observed schema snapshot, and the persisted [DriftReport]. A mis-declared schema in one
+     *   context can then only ever quarantine propositions in that same context — it has no way to
+     *   reach another one.
+     * @return A [DriftCheckResult] summarizing what was found and (if live) what was quarantined.
+     */
+    fun run(dryRun: Boolean, contextId: ContextId?): DriftCheckResult
+
+    /**
+     * Run a dry check over the whole graph — the safe default. Nothing is quarantined; the report
+     * is still persisted.
+     */
+    fun run(): DriftCheckResult = run(dryRun = true, contextId = null)
+
+    /**
+     * Run over the whole graph, dry or live.
+     *
+     * @param dryRun `true` to preview without touching any proposition.
+     */
+    fun run(dryRun: Boolean): DriftCheckResult = run(dryRun, null)
+}

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/DriftQuarantinePolicy.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/DriftQuarantinePolicy.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import com.embabel.dice.proposition.Proposition
+
+/**
+ * The outcome of evaluating a single [Proposition] against a [MetamodelDiff].
+ *
+ * There are three outcomes, not two, and the third is the one that's easy to miss: a proposition
+ * a *previous* sweep already quarantined. It isn't clean, so calling it conforming would overstate
+ * how healthy the set is, and it isn't newly quarantined either, since this sweep deliberately left
+ * it alone to preserve its original reason. It gets its own variant so `conforming.size` means what
+ * it says.
+ *
+ * Sealed so callers can exhaustively handle every outcome kind.
+ */
+sealed interface QuarantineDecision {
+
+    /** The proposition conforms to the updated schema and requires no action. */
+    data class Conforming(val proposition: Proposition) : QuarantineDecision
+
+    /**
+     * The proposition was already quarantined before this sweep ran — it is `STALE` and carries a
+     * `DiceMetadataKeys.QUARANTINE_REASON` from an earlier evaluation — so this sweep left it
+     * exactly as it found it. Nothing needs persisting for these.
+     *
+     * To force one back through evaluation, clear its `QUARANTINE_REASON` metadata and pass it in
+     * again.
+     *
+     * @property proposition The proposition, unchanged.
+     * @property originalReason The reason the earlier sweep recorded, when it is still readable as
+     *   text. `null` if the metadata value is present but isn't a string — the proposition is still
+     *   treated as already quarantined; only the explanation is unrecoverable.
+     */
+    data class AlreadyQuarantined(
+        val proposition: Proposition,
+        val originalReason: String?,
+    ) : QuarantineDecision
+
+    /**
+     * The proposition is affected by schema drift and has been flagged as quarantined.
+     *
+     * The returned [proposition] has already been transitioned to `STALE` and carries
+     * the quarantine reason in its metadata under `DiceMetadataKeys.QUARANTINE_REASON`.
+     * The original proposition is **not** mutated — this is an immutable copy.
+     *
+     * @property proposition The flagged, STALE copy of the original proposition.
+     * @property reason A human-readable explanation of why this proposition was quarantined.
+     * @property affectedMentionTypes The entity type names that triggered quarantine.
+     */
+    data class Quarantined(
+        val proposition: Proposition,
+        val reason: String,
+        val affectedMentionTypes: Set<String>,
+    ) : QuarantineDecision
+}
+
+/**
+ * The aggregate result of applying a [DriftQuarantinePolicy] to a collection of propositions.
+ *
+ * @property conforming Propositions that were unaffected by the diff and are genuinely clean.
+ * @property quarantined Quarantine decisions for propositions this sweep flagged.
+ * @property alreadyQuarantined Propositions an earlier sweep had already quarantined, left
+ *   untouched by this one. Empty unless the input contained some.
+ */
+data class QuarantineResult @JvmOverloads constructor(
+    val conforming: List<QuarantineDecision.Conforming>,
+    val quarantined: List<QuarantineDecision.Quarantined>,
+    val alreadyQuarantined: List<QuarantineDecision.AlreadyQuarantined> = emptyList(),
+) {
+
+    /** Total number of propositions evaluated. */
+    val total: Int get() = conforming.size + quarantined.size + alreadyQuarantined.size
+
+    /** Every proposition copy the sweep saw, in a single flat list. */
+    val allPropositions: List<Proposition>
+        get() = conforming.map { it.proposition } +
+            quarantined.map { it.proposition } +
+            alreadyQuarantined.map { it.proposition }
+}
+
+/**
+ * Decides which propositions are affected by a [MetamodelDiff] and produces quarantine decisions.
+ *
+ * Quarantining is **non-destructive**: affected propositions are returned as immutable copies
+ * transitioned to [com.embabel.dice.proposition.PropositionStatus.STALE] with a metadata
+ * annotation explaining the reason. The caller is responsible for persisting the updated copies.
+ *
+ * Example usage:
+ * ```kotlin
+ * val diff = differ.diff(oldSchema, newSchema)
+ * val result = policy.evaluate(diff, repository.findAll())
+ * result.quarantined.forEach { decision ->
+ *     repository.save(decision.proposition)
+ * }
+ * ```
+ */
+interface DriftQuarantinePolicy {
+
+    /**
+     * Evaluate every proposition in [propositions] against [diff] and return a [QuarantineResult]
+     * partitioning them into conforming, newly quarantined, and already-quarantined groups.
+     *
+     * Implementations should be **idempotent**: a proposition that is already quarantined (status
+     * `STALE` with a `QUARANTINE_REASON` metadata entry) from a prior sweep must not have its
+     * original reason overwritten. Such propositions come back unchanged, as
+     * [QuarantineDecision.AlreadyQuarantined] — not as conforming, which would misreport them as
+     * clean. To force re-evaluation of a previously quarantined proposition, clear its
+     * `QUARANTINE_REASON` metadata before passing it here.
+     *
+     * @param diff The metamodel diff describing what changed between the old and new schema.
+     * @param propositions The propositions to evaluate. May be any [Iterable] (list, repository
+     *   page, lazy sequence, etc.).
+     * @return An immutable [QuarantineResult] with one decision per input proposition.
+     */
+    fun evaluate(diff: MetamodelDiff, propositions: Iterable<Proposition>): QuarantineResult
+}

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/MetamodelDiff.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/MetamodelDiff.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+/**
+ * A single structural change between two metamodel versions.
+ *
+ * Sealed so that callers can exhaustively handle every change kind with a `when` expression.
+ */
+sealed interface MetamodelChange {
+
+    /**
+     * An entity type that is present in the newer schema but absent from the older one.
+     *
+     * @property typeName The name of the added entity type.
+     */
+    data class EntityTypeAdded(val typeName: String) : MetamodelChange
+
+    /**
+     * An entity type that was present in the older schema but has been removed from the newer one.
+     * Propositions whose entity mentions reference this type are candidates for quarantine.
+     *
+     * @property typeName The name of the removed entity type.
+     */
+    data class EntityTypeRemoved(val typeName: String) : MetamodelChange
+
+    /**
+     * An entity type whose labels and/or properties changed between versions but whose name is
+     * preserved. The name is still resolvable; consumers may wish to re-extract mentions that relied
+     * on the old shape. A single change captures both the label delta and the property delta for the
+     * type; at least one of the four delta sets is non-empty.
+     *
+     * @property typeName The entity type name (unchanged).
+     * @property addedLabels Labels present in the new version but not the old.
+     * @property removedLabels Labels present in the old version but not the new.
+     * @property addedProperties Property names present in the new version but not the old.
+     * @property removedProperties Property names present in the old version but not the new.
+     */
+    data class EntityTypeModified @JvmOverloads constructor(
+        val typeName: String,
+        val addedLabels: Set<String> = emptySet(),
+        val removedLabels: Set<String> = emptySet(),
+        val addedProperties: Set<String> = emptySet(),
+        val removedProperties: Set<String> = emptySet(),
+    ) : MetamodelChange
+
+    /**
+     * An allowed relationship that is present in the newer schema but absent from the older one.
+     *
+     * @property descriptor A human-readable descriptor of the form `From-[name]->To`.
+     */
+    data class RelationshipAdded(val descriptor: String) : MetamodelChange
+
+    /**
+     * An allowed relationship that was present in the older schema but has been removed.
+     *
+     * @property descriptor A human-readable descriptor of the form `From-[name]->To`.
+     */
+    data class RelationshipRemoved(val descriptor: String) : MetamodelChange
+}
+
+/**
+ * The result of comparing two [MetamodelVersion]s (or two `DataDictionary` instances directly).
+ *
+ * A diff is **empty** when no structural changes were detected (the schemas are equivalent).
+ * Use [isEmpty] to guard against unnecessary quarantine sweeps.
+ *
+ * @property fromVersion The baseline (older) version.
+ * @property toVersion The target (newer) version.
+ * @property changes The ordered list of structural changes, grouped by kind.
+ */
+data class MetamodelDiff(
+    val fromVersion: MetamodelVersion,
+    val toVersion: MetamodelVersion,
+    val changes: List<MetamodelChange>,
+) {
+
+    /** `true` when no structural changes were detected. */
+    val isEmpty: Boolean get() = changes.isEmpty()
+
+    /** All [MetamodelChange.EntityTypeRemoved] entries, for quick quarantine candidate lookup. */
+    val removedEntityTypes: Set<String>
+        get() = changes
+            .filterIsInstance<MetamodelChange.EntityTypeRemoved>()
+            .map { it.typeName }
+            .toSet()
+
+    /** All [MetamodelChange.EntityTypeAdded] entries. */
+    val addedEntityTypes: Set<String>
+        get() = changes
+            .filterIsInstance<MetamodelChange.EntityTypeAdded>()
+            .map { it.typeName }
+            .toSet()
+
+    /** All [MetamodelChange.EntityTypeModified] entries. */
+    val modifiedEntityTypes: List<MetamodelChange.EntityTypeModified>
+        get() = changes.filterIsInstance<MetamodelChange.EntityTypeModified>()
+}
+
+/**
+ * The result of comparing a declared [MetamodelVersion] against what a live graph actually
+ * contains ([ObservedSchema]).
+ *
+ * This is a different question from [MetamodelDiff], which compares two declared versions
+ * against each other. Here, one side is the schema as declared and the other is a snapshot
+ * of reality, and the two can legitimately disagree in either direction:
+ *
+ * - **Drift** ([driftedEntityTypes] / [driftedRelationshipTypes]): a type observed in the graph
+ *   that was never declared. This is the actionable case — concretely, it means data is sitting
+ *   in the graph whose declaring integration has since been removed (or never registered one),
+ *   so nothing here can tell that data apart as valid or explain its shape.
+ * - **Unobserved** ([unobservedEntityTypes] / [unobservedRelationshipTypes]): a type that's
+ *   declared but currently has zero instances in the graph. This is purely informational —
+ *   a declared type with no data yet (or right now) is a completely normal state, not drift.
+ *
+ * @property declaredVersion The schema as declared at snapshot time.
+ * @property observedSchema What the live graph actually contained at snapshot time.
+ * @property driftedEntityTypes Entity type names observed in the graph with no matching declaration.
+ * @property driftedRelationshipTypes Relationship type names observed with no matching declaration.
+ * @property unobservedEntityTypes Declared entity type names with no observed instances.
+ * @property unobservedRelationshipTypes Declared relationship type names with no observed instances.
+ */
+data class DeclaredObservedDiff(
+    val declaredVersion: MetamodelVersion,
+    val observedSchema: ObservedSchema,
+    val driftedEntityTypes: Set<String>,
+    val driftedRelationshipTypes: Set<String>,
+    val unobservedEntityTypes: Set<String>,
+    val unobservedRelationshipTypes: Set<String>,
+) {
+
+    /** `true` when the graph contains any type or relationship that was never declared. */
+    val hasDrift: Boolean
+        get() = driftedEntityTypes.isNotEmpty() || driftedRelationshipTypes.isNotEmpty()
+}

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/MetamodelDiffer.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/MetamodelDiffer.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import com.embabel.agent.core.DataDictionary
+
+/**
+ * Compares two metamodel versions and reports what changed.
+ *
+ * The canonical entry points accept either raw [DataDictionary] instances (for
+ * convenience) or pre-computed [MetamodelVersion] stamps (when the caller has
+ * already stamped a schema at ingestion time and stored the stamp).
+ */
+interface MetamodelDiffer {
+
+    /**
+     * Compare two [MetamodelVersion] stamps and return a [MetamodelDiff] describing
+     * every structural change from [from] to [to].
+     *
+     * @param from The baseline (older) version.
+     * @param to The target (newer) version.
+     * @return An immutable diff. [MetamodelDiff.isEmpty] is `true` when the schemas are equivalent.
+     */
+    fun diff(from: MetamodelVersion, to: MetamodelVersion): MetamodelDiff
+
+    /**
+     * Convenience overload: stamps both dictionaries and then diffs the resulting versions.
+     *
+     * @param from The baseline (older) [DataDictionary].
+     * @param to The target (newer) [DataDictionary].
+     * @return An immutable diff.
+     */
+    fun diff(from: DataDictionary, to: DataDictionary): MetamodelDiff =
+        diff(MetamodelVersion.from(from), MetamodelVersion.from(to))
+}
+
+/**
+ * Compares a declared [MetamodelVersion] against an [ObservedSchema] — what a live graph
+ * actually contains — and reports where the two disagree.
+ *
+ * This is kept as its own interface rather than another overload on [MetamodelDiffer]
+ * because it answers a different question. [MetamodelDiffer] compares two declared schemas
+ * to each other (both sides are "what was decided"); this compares a declared schema to a
+ * runtime observation (one side is "what was decided", the other is "what's actually there").
+ * The result shape is different too — [MetamodelDiff] is a symmetric list of changes,
+ * while [DeclaredObservedDiff] is asymmetric (drift vs. merely-unobserved), and conflating
+ * the two would force callers to sift a generic change list to tell them apart.
+ */
+interface DeclaredObservedDiffer {
+
+    /**
+     * Compare [declared] against [observed] and return a [DeclaredObservedDiff].
+     *
+     * @param declared The schema as declared.
+     * @param declaredRelationshipTypeNames The bare relationship type names [declared] allows
+     *   (e.g. `WORKS_AT`, not the rendered `Person-[WORKS_AT]->Company` descriptor stored in
+     *   [MetamodelVersion.relationshipNames]). This has to come from the caller rather than be
+     *   recovered here: relationship (and entity) names are free-text / LLM-derived and can
+     *   themselves contain a `-[...]->`-shaped substring, so reverse-parsing a rendered
+     *   descriptor to recover the bare name is ambiguous and can silently extract the wrong
+     *   segment. Callers hold the un-rendered relationship definitions before they're stamped
+     *   into a [MetamodelVersion] (e.g. `DataDictionary.allowedRelationships().map { it.name
+     *   }.toSet()`) and must pass that set directly instead of round-tripping through the
+     *   descriptor string.
+     * @param observed A snapshot of what the live graph actually contains.
+     * @return An immutable diff distinguishing drift (observed-but-undeclared) from
+     *   unobserved-but-declared types.
+     */
+    fun diffAgainstObserved(
+        declared: MetamodelVersion,
+        declaredRelationshipTypeNames: Set<String>,
+        observed: ObservedSchema,
+    ): DeclaredObservedDiff
+}

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/MetamodelStore.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/MetamodelStore.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import com.embabel.agent.core.ContextId
+import java.time.Instant
+
+/**
+ * A drift report captures a single observation of undeclared types in a live graph at a specific
+ * point in time. The types are compared against a declared [MetamodelVersion], so the report
+ * records which declared version was expected when the drift was detected. Later checks can
+ * correlate repeated observations against the same baseline to judge whether the drift is stale
+ * or growing.
+ *
+ * @property schemaName The schema name at check time (for lookup and reporting).
+ * @property versionHash The SHA-256 hash of the declared [MetamodelVersion] this check was
+ *   performed against. Consumers can match this against saved versions to understand the
+ *   schema structure that was expected at the time.
+ * @property driftedEntityTypes Entity type names observed in the graph but not declared in the
+ *   baseline version.
+ * @property driftedRelationshipTypes Relationship type names observed in the graph but not
+ *   declared in the baseline version.
+ * @property capturedAt The instant the observation was taken.
+ * @property contextId The context this check was scoped to, or `null` if it covered the whole
+ *   graph.
+ */
+data class DriftReport(
+    val schemaName: String,
+    val versionHash: String,
+    val driftedEntityTypes: Set<String>,
+    val driftedRelationshipTypes: Set<String>,
+    val capturedAt: Instant,
+    val contextId: ContextId? = null,
+)
+
+/**
+ * Durable store for metamodel versions and drift reports, enabling a later drift-check runner to
+ * read the history of prior observations and make decisions about quarantine or schema updates.
+ * Implementations must preserve all saved data exactly as recorded (including sets, timestamps,
+ * and any serialization of collections).
+ *
+ * **What "save" means here.** Both writes are upserts on a natural key, not blind appends. Saving a
+ * version whose key already exists does not create a second record: the existing one is matched and
+ * its non-key content — the type names, label sets, property sets, and relationship names — is
+ * overwritten with what you just passed. Saving a drift report behaves the same way on its own key.
+ * So a re-save is idempotent when the content is identical (the common case, since a version's key
+ * includes its content hash) and is a genuine overwrite when it isn't. Nothing is ever deleted, and
+ * records with different keys always coexist, so history accumulates — but "nothing is ever updated"
+ * would be too strong a promise, and implementations are not expected to reject a re-save.
+ *
+ * Multiple versions of the same schema can coexist; later queries for the latest return the most
+ * recent by logical write order.
+ */
+interface MetamodelStore {
+
+    /**
+     * Save a metamodel version stamp, keyed on `(schemaName, contentHash)`. Saving the same version
+     * twice leaves one stored version, not two. Because the content hash is derived from the
+     * structural fields, two versions that share a key necessarily share their content too, so this
+     * write is idempotent in practice.
+     *
+     * @param version The version to save.
+     */
+    fun saveVersion(version: MetamodelVersion)
+
+    /**
+     * Return the most recently saved version for the given schema name, or null if no versions
+     * have been recorded.
+     *
+     * @param schemaName The schema to look up.
+     * @return The latest [MetamodelVersion], or null if unknown.
+     */
+    fun latestVersion(schemaName: String): MetamodelVersion?
+
+    /**
+     * Return all saved versions for the given schema, newest first.
+     *
+     * @param schemaName The schema to look up.
+     * @return A list of all [MetamodelVersion]s, ordered newest first. Empty if no versions
+     *   exist for this schema.
+     */
+    fun versionHistory(schemaName: String): List<MetamodelVersion>
+
+    /**
+     * Save a single drift observation, keyed on the schema, the version hash it checked against,
+     * the capture instant, and the context. Two observations that differ in any of those are
+     * separate records; re-saving one with the same key overwrites its drifted type sets rather
+     * than adding a duplicate.
+     *
+     * @param report The observation to save.
+     */
+    fun saveDriftReport(report: DriftReport)
+
+    /**
+     * Return every saved drift report for the given schema, newest first — global ones and every
+     * context's, mixed together.
+     *
+     * There are deliberately three separate reads here rather than one method with a nullable
+     * context argument. `driftReports(schema)`, `globalDriftReports(schema)` and
+     * `driftReportsInContext(schema, id)` each say at the call site which set you meant. A single
+     * `driftReports(schema, null)` would have quietly meant "the global ones only" while
+     * `driftReports(schema)` meant "all of them" — the same-looking call with a different answer,
+     * and nothing but the doc to tell them apart.
+     *
+     * Splitting them also gives Java callers a way to ask for the global reports at all: `ContextId`
+     * is a Kotlin value class, so any method taking one gets a mangled JVM name that Java can't
+     * call. [driftReportsInContext] is in that boat along with the rest of this module's
+     * context-scoped API; [driftReports] and [globalDriftReports] are not.
+     *
+     * @param schemaName The schema to look up.
+     * @return A list of all [DriftReport]s, ordered newest first. Empty if no reports exist
+     *   for this schema.
+     */
+    fun driftReports(schemaName: String): List<DriftReport>
+
+    /**
+     * Return only the reports from unscoped, whole-graph checks — the ones whose
+     * [DriftReport.contextId] is `null`. A check scoped to a context is excluded no matter which
+     * context it was.
+     *
+     * The default filters the full [driftReports] list in memory, which is correct for every
+     * implementation but not necessarily efficient; a backend that can push the filter down (a
+     * database `WHERE`, not an in-memory `filter`) should override this directly rather than rely
+     * on the default.
+     *
+     * @param schemaName The schema to look up.
+     * @return A list of matching [DriftReport]s, ordered newest first.
+     */
+    fun globalDriftReports(schemaName: String): List<DriftReport> =
+        driftReports(schemaName).filter { it.contextId == null }
+
+    /**
+     * Return only the reports from checks scoped to [contextId]. Global reports are excluded, as
+     * are other contexts'.
+     *
+     * The default filters in memory, with the same caveat as [globalDriftReports]: override it if
+     * the backend can push the filter down.
+     *
+     * @param schemaName The schema to look up.
+     * @param contextId The context to restrict to.
+     * @return A list of matching [DriftReport]s, ordered newest first.
+     */
+    fun driftReportsInContext(schemaName: String, contextId: ContextId): List<DriftReport> =
+        driftReports(schemaName).filter { it.contextId == contextId }
+}

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/MetamodelVersion.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/MetamodelVersion.kt
@@ -17,6 +17,7 @@ package com.embabel.dice.metamodel
 
 import com.embabel.agent.core.DataDictionary
 import java.security.MessageDigest
+import java.util.Collections
 
 /**
  * An immutable stamp that captures the identity and structural content of a
@@ -45,16 +46,36 @@ import java.security.MessageDigest
  *   are equal regardless of how they are named. Stable across JVM restarts; any change — even
  *   labels or properties on a type whose name is preserved — produces a different hash.
  */
-data class MetamodelVersion(
-    val schemaName: String,
-    val entityTypeNames: List<String>,
-    val entityTypeLabels: Map<String, Set<String>>,
-    val entityTypeProperties: Map<String, Set<String>>,
-    val relationshipNames: List<String>,
+class MetamodelVersion(
+    schemaName: String,
+    entityTypeNames: List<String>,
+    entityTypeLabels: Map<String, Set<String>>,
+    entityTypeProperties: Map<String, Set<String>>,
+    relationshipNames: List<String>,
 ) {
 
+    val schemaName: String = schemaName
+
+    val entityTypeNames: List<String> = immutableList(entityTypeNames.sorted())
+
+    val entityTypeLabels: Map<String, Set<String>> = immutableNestedSetMap(entityTypeLabels)
+
+    val entityTypeProperties: Map<String, Set<String>> = immutableNestedSetMap(entityTypeProperties)
+
+    val relationshipNames: List<String> = immutableList(relationshipNames.sorted())
+
     val contentHash: String =
-        fingerprint(entityTypeNames, entityTypeLabels, entityTypeProperties, relationshipNames)
+        fingerprint(this.entityTypeNames, this.entityTypeLabels, this.entityTypeProperties, this.relationshipNames)
+
+    init {
+        val entityTypeNameSet = this.entityTypeNames.toHashSet()
+        require(this.entityTypeLabels.keys.all { it in entityTypeNameSet }) {
+            "entityTypeLabels contains a type absent from entityTypeNames"
+        }
+        require(this.entityTypeProperties.keys.all { it in entityTypeNameSet }) {
+            "entityTypeProperties contains a type absent from entityTypeNames"
+        }
+    }
 
     /**
      * Returns `true` when this version and [other] have the same structural content —
@@ -63,7 +84,68 @@ data class MetamodelVersion(
      */
     fun hasSameContentAs(other: MetamodelVersion): Boolean = contentHash == other.contentHash
 
+    /**
+     * Return another immutable stamp, recomputing [contentHash] from the supplied structure.
+     *
+     * @throws IllegalArgumentException if a label or property map contains a key absent from
+     *   [entityTypeNames].
+     */
+    fun copy(
+        schemaName: String = this.schemaName,
+        entityTypeNames: List<String> = this.entityTypeNames,
+        entityTypeLabels: Map<String, Set<String>> = this.entityTypeLabels,
+        entityTypeProperties: Map<String, Set<String>> = this.entityTypeProperties,
+        relationshipNames: List<String> = this.relationshipNames,
+    ): MetamodelVersion = MetamodelVersion(
+        schemaName = schemaName,
+        entityTypeNames = entityTypeNames,
+        entityTypeLabels = entityTypeLabels,
+        entityTypeProperties = entityTypeProperties,
+        relationshipNames = relationshipNames,
+    )
+
+    operator fun component1(): String = schemaName
+
+    operator fun component2(): List<String> = entityTypeNames
+
+    operator fun component3(): Map<String, Set<String>> = entityTypeLabels
+
+    operator fun component4(): Map<String, Set<String>> = entityTypeProperties
+
+    operator fun component5(): List<String> = relationshipNames
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is MetamodelVersion &&
+            schemaName == other.schemaName &&
+            entityTypeNames == other.entityTypeNames &&
+            entityTypeLabels == other.entityTypeLabels &&
+            entityTypeProperties == other.entityTypeProperties &&
+            relationshipNames == other.relationshipNames
+
+    override fun hashCode(): Int {
+        var result = schemaName.hashCode()
+        result = 31 * result + entityTypeNames.hashCode()
+        result = 31 * result + entityTypeLabels.hashCode()
+        result = 31 * result + entityTypeProperties.hashCode()
+        result = 31 * result + relationshipNames.hashCode()
+        return result
+    }
+
+    override fun toString(): String =
+        "MetamodelVersion(schemaName=$schemaName, entityTypeNames=$entityTypeNames, " +
+            "entityTypeLabels=$entityTypeLabels, entityTypeProperties=$entityTypeProperties, " +
+            "relationshipNames=$relationshipNames)"
+
     companion object {
+
+        private fun <T> immutableList(values: Collection<T>): List<T> =
+            Collections.unmodifiableList(values.toList())
+
+        private fun immutableNestedSetMap(values: Map<String, Set<String>>): Map<String, Set<String>> =
+            Collections.unmodifiableMap(
+                values.mapValues { (_, entries) -> Collections.unmodifiableSet(entries.toSet()) }
+            )
 
         /** Append [token] length-prefixed (`<len>:<token>`) so concatenation can't be ambiguous. */
         private fun StringBuilder.appendSized(token: String) {
@@ -95,9 +177,8 @@ data class MetamodelVersion(
             // Schema name is deliberately excluded: two structurally identical schemas must produce
             // the same hash even when named differently (e.g. dev vs prod environments).
             val hashInput = buildString {
-                val sortedTypeNames = entityTypeNames.sorted()
-                append("types:").append(sortedTypeNames.size).append('|')
-                sortedTypeNames.forEach { name ->
+                append("types:").append(entityTypeNames.size).append('|')
+                entityTypeNames.forEach { name ->
                     appendSized(name)
                     val labels = entityTypeLabels[name].orEmpty().sorted()
                     append("labels:").append(labels.size).append('|')
@@ -106,9 +187,8 @@ data class MetamodelVersion(
                     append("props:").append(props.size).append('|')
                     props.forEach { appendSized(it) }
                 }
-                val sortedRelationshipNames = relationshipNames.sorted()
-                append("rels:").append(sortedRelationshipNames.size).append('|')
-                sortedRelationshipNames.forEach { appendSized(it) }
+                append("rels:").append(relationshipNames.size).append('|')
+                relationshipNames.forEach { appendSized(it) }
             }
 
             val digest = MessageDigest.getInstance("SHA-256")

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/MetamodelVersion.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/MetamodelVersion.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import com.embabel.agent.core.DataDictionary
+import java.security.MessageDigest
+
+/**
+ * An immutable stamp that captures the identity and structural content of a
+ * [DataDictionary] at a point in time.
+ *
+ * Two [MetamodelVersion] instances with the same [contentHash] represent semantically
+ * equivalent schemas. A proposition can record the version it was created under via
+ * the `DiceMetadataKeys.METAMODEL_VERSION` metadata key.
+ *
+ * The hash is computed here, from the structural fields, and is not something a caller can
+ * supply. That matters because the hash is load-bearing: it is the store's natural key, it is
+ * what [hasSameContentAs] compares, and it is what a `DriftReport` records as the baseline it
+ * checked against. If it were an ordinary constructor argument, two structurally different
+ * schemas could claim the same hash, compare as equal, and overwrite each other in storage.
+ *
+ * @property schemaName The [DataDictionary.name] at the time the stamp was taken.
+ * @property entityTypeNames Sorted list of entity type names at stamp time.
+ * @property entityTypeLabels Full label set per type (including inherited labels), keyed by type
+ *   name. Captured so label-only drift is detectable and reflected in [contentHash].
+ * @property entityTypeProperties Full property-name set per type (including inherited properties),
+ *   keyed by type name. Captured so property-only drift is detectable and reflected in [contentHash].
+ * @property relationshipNames Sorted list of allowed relationship names at stamp time.
+ * @property contentHash SHA-256 hex digest of the schema's entity types, label sets, property
+ *   names, and allowed relationships — structural content only, derived from the four fields
+ *   above. The schema name is intentionally excluded so that two structurally identical schemas
+ *   are equal regardless of how they are named. Stable across JVM restarts; any change — even
+ *   labels or properties on a type whose name is preserved — produces a different hash.
+ */
+data class MetamodelVersion(
+    val schemaName: String,
+    val entityTypeNames: List<String>,
+    val entityTypeLabels: Map<String, Set<String>>,
+    val entityTypeProperties: Map<String, Set<String>>,
+    val relationshipNames: List<String>,
+) {
+
+    val contentHash: String =
+        fingerprint(entityTypeNames, entityTypeLabels, entityTypeProperties, relationshipNames)
+
+    /**
+     * Returns `true` when this version and [other] have the same structural content —
+     * identical entity types, label sets, property names, and relationships — regardless
+     * of schema name. Uses [contentHash] for the comparison.
+     */
+    fun hasSameContentAs(other: MetamodelVersion): Boolean = contentHash == other.contentHash
+
+    companion object {
+
+        /** Append [token] length-prefixed (`<len>:<token>`) so concatenation can't be ambiguous. */
+        private fun StringBuilder.appendSized(token: String) {
+            append(token.length).append(':').append(token)
+        }
+
+        /**
+         * The content hash itself: a deterministic encoding of the structural fields, hashed with
+         * SHA-256 and rendered as lowercase hex.
+         *
+         * This is a **persisted** format. The digest is a MERGE key in the store and a stored
+         * foreign key on every drift report, so changing the encoding orphans every report already
+         * on disk. `MetamodelVersionTest` pins the digest of a fixed schema with a literal
+         * assertion for exactly that reason — if you change the encoding, change that literal
+         * deliberately and plan a migration.
+         */
+        private fun fingerprint(
+            entityTypeNames: List<String>,
+            entityTypeLabels: Map<String, Set<String>>,
+            entityTypeProperties: Map<String, Set<String>>,
+            relationshipNames: List<String>,
+        ): String {
+            // Build a collision-free fingerprint by length-prefixing every name, label, and property
+            // (and counting each set) before hashing. A plain delimiter-joined encoding isn't safe
+            // here: these names come from free-text / LLM extraction and routinely contain ';', '[',
+            // '=' and spaces, so joining with those characters could make ["a;b"] and ["a", "b"] hash
+            // identically and hide a real, lossy schema change. Length-prefixing makes the encoding
+            // unambiguous, so distinct content always yields a distinct hash.
+            // Schema name is deliberately excluded: two structurally identical schemas must produce
+            // the same hash even when named differently (e.g. dev vs prod environments).
+            val hashInput = buildString {
+                val sortedTypeNames = entityTypeNames.sorted()
+                append("types:").append(sortedTypeNames.size).append('|')
+                sortedTypeNames.forEach { name ->
+                    appendSized(name)
+                    val labels = entityTypeLabels[name].orEmpty().sorted()
+                    append("labels:").append(labels.size).append('|')
+                    labels.forEach { appendSized(it) }
+                    val props = entityTypeProperties[name].orEmpty().sorted()
+                    append("props:").append(props.size).append('|')
+                    props.forEach { appendSized(it) }
+                }
+                val sortedRelationshipNames = relationshipNames.sorted()
+                append("rels:").append(sortedRelationshipNames.size).append('|')
+                sortedRelationshipNames.forEach { appendSized(it) }
+            }
+
+            val digest = MessageDigest.getInstance("SHA-256")
+            val hashBytes = digest.digest(hashInput.toByteArray(Charsets.UTF_8))
+            return hashBytes.joinToString("") { "%02x".format(it) }
+        }
+
+        /**
+         * Create a [MetamodelVersion] stamp from the given [DataDictionary].
+         *
+         * @param dataDictionary The schema to stamp.
+         * @return An immutable version stamp.
+         */
+        @JvmStatic
+        fun from(dataDictionary: DataDictionary): MetamodelVersion {
+            // A DataDictionary can legally hold two domain types that share a name but differ in
+            // shape (DynamicType is a data class, so same-named instances with different labels are
+            // not equal and both survive a set). Merge their labels and properties by union per name
+            // rather than letting associate() keep only the last — otherwise a label or property
+            // present under that name would vanish from the fingerprint, and later removing it
+            // wouldn't change the hash, hiding a real drift.
+            val entityTypeLabels = dataDictionary.domainTypes
+                .groupBy { it.name }
+                .mapValues { (_, types) -> types.flatMap { it.labels }.toSet() }
+
+            val entityTypeProperties = dataDictionary.domainTypes
+                .groupBy { it.name }
+                .mapValues { (_, types) -> types.flatMap { type -> type.properties.map { it.name } }.toSet() }
+
+            val entityTypeNames = entityTypeLabels.keys.sorted()
+
+            val relationshipNames = dataDictionary.allowedRelationships()
+                .map { rel -> "${rel.from.name}-[${rel.name}]->${rel.to.name}" }
+                .sorted()
+
+            return MetamodelVersion(
+                schemaName = dataDictionary.name,
+                entityTypeNames = entityTypeNames,
+                entityTypeLabels = entityTypeLabels,
+                entityTypeProperties = entityTypeProperties,
+                relationshipNames = relationshipNames,
+            )
+        }
+    }
+}

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/ObservedSchema.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/ObservedSchema.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import java.time.Instant
+
+/**
+ * A snapshot of what a live graph actually contains, as opposed to what the declared
+ * [MetamodelVersion] says it should contain.
+ *
+ * This is a plain value type — nothing in this module knows how to go and read a graph.
+ * A storage layer (Neo4j or otherwise) is expected to build one of these by querying the
+ * live database for its distinct entity and relationship type labels, then hand it here
+ * to be compared against the declared schema. That's deliberate: schemas in the wild are
+ * often partly dynamic (integrations contribute types that come and go), so what's actually
+ * in the graph can drift from what was ever declared, and this module needs a way to talk
+ * about that without depending on any particular graph driver.
+ *
+ * @property entityTypeNames Entity type (label) names actually observed in the graph.
+ * @property relationshipTypeNames Relationship type names actually observed in the graph.
+ * @property capturedAt When this snapshot was taken.
+ */
+data class ObservedSchema(
+    val entityTypeNames: Set<String>,
+    val relationshipTypeNames: Set<String>,
+    val capturedAt: Instant,
+)

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/ObservedSchemaSource.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/ObservedSchemaSource.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import com.embabel.agent.core.ContextId
+
+/**
+ * Takes a fresh snapshot of what a live graph actually contains, for [DriftCheckRunner] to compare
+ * against the declared schema.
+ *
+ * This module has no graph driver dependency, so it can't implement this itself — a storage layer
+ * (Neo4j via Drivine, or anything else) provides the real implementation by querying its live
+ * database for distinct entity and relationship type labels. Tests can supply a canned
+ * [ObservedSchema] instead of touching a database at all.
+ *
+ * An ordinary interface, not a `fun interface`: it carries two entry points — the scoped
+ * [observe] an implementation provides, and the no-argument [observe] convenience it gets for
+ * free — and a SAM lambda can only ever supply the first. The no-argument form is a real method
+ * with a body rather than a Kotlin default argument so that Java callers can write `observe()`
+ * too; Java cannot see a Kotlin default argument. It is also all Java gets: `ContextId` is a
+ * Kotlin value class, so the scoped form compiles to a mangled JVM name Java can't call.
+ */
+interface ObservedSchemaSource {
+
+    /**
+     * @param contextId `null` snapshots the whole graph. Non-null scopes the snapshot to that one
+     *   context: only that context's own data is consulted. What "scoped" means concretely is up
+     *   to the implementation — a graph-backed one typically walks the context's own nodes, and
+     *   may return an empty relationship-type set when it can only reach node labels that way.
+     * @return a fresh [ObservedSchema] snapshot, captured at call time.
+     */
+    fun observe(contextId: ContextId?): ObservedSchema
+
+    /**
+     * Snapshot the whole graph, unscoped.
+     *
+     * @return a fresh [ObservedSchema] snapshot, captured at call time.
+     */
+    fun observe(): ObservedSchema = observe(null)
+}

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/support/DefaultDriftCheckRunner.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/support/DefaultDriftCheckRunner.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel.support
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.metamodel.DeclaredObservedDiffer
+import com.embabel.dice.metamodel.DeclaredSchemaSource
+import com.embabel.dice.metamodel.DriftCheckResult
+import com.embabel.dice.metamodel.DriftCheckRunner
+import com.embabel.dice.metamodel.DriftQuarantinePolicy
+import com.embabel.dice.metamodel.DriftReport
+import com.embabel.dice.metamodel.MetamodelChange
+import com.embabel.dice.metamodel.MetamodelDiff
+import com.embabel.dice.metamodel.MetamodelStore
+import com.embabel.dice.metamodel.MetamodelVersion
+import com.embabel.dice.metamodel.ObservedSchemaSource
+import com.embabel.dice.proposition.PropositionRepository
+import org.slf4j.LoggerFactory
+
+/**
+ * Default [DriftCheckRunner]. Stateless and safe to call repeatedly or concurrently for different
+ * schemas; concurrent checks of the *same* schema aren't corrupting (each is a distinct, fully
+ * captured snapshot) but are wasteful — serialize at the scheduling layer if that matters.
+ *
+ * @param observedSchemaSource Snapshots what the live graph actually contains.
+ * @param declaredSchemaSource Supplies the schema as declared.
+ * @param differ Compares the declared schema against the observed one.
+ * @param store Durable store for the persisted [DriftReport] (and, separately, schema version
+ *   history — this runner only writes reports, not versions).
+ * @param quarantinePolicy Decides which drift-affected propositions to quarantine. Only consulted
+ *   on a live (non-dry) run with entity-type drift; this runner never reimplements its decision,
+ *   only feeds it a diff and persists what it decides.
+ * @param propositionRepository Read the candidate propositions from, and save quarantine decisions to.
+ */
+class DefaultDriftCheckRunner(
+    private val observedSchemaSource: ObservedSchemaSource,
+    private val declaredSchemaSource: DeclaredSchemaSource,
+    private val differ: DeclaredObservedDiffer,
+    private val store: MetamodelStore,
+    private val quarantinePolicy: DriftQuarantinePolicy,
+    private val propositionRepository: PropositionRepository,
+) : DriftCheckRunner {
+
+    private val logger = LoggerFactory.getLogger(DefaultDriftCheckRunner::class.java)
+
+    override fun run(dryRun: Boolean, contextId: ContextId?): DriftCheckResult {
+        val observed = observedSchemaSource.observe(contextId)
+        val declared = declaredSchemaSource.declare()
+
+        val diff = differ.diffAgainstObserved(
+            declared = declared.version,
+            declaredRelationshipTypeNames = declared.relationshipTypeNames,
+            observed = observed,
+        )
+
+        val report = DriftReport(
+            schemaName = declared.version.schemaName,
+            versionHash = declared.version.contentHash,
+            driftedEntityTypes = diff.driftedEntityTypes,
+            driftedRelationshipTypes = diff.driftedRelationshipTypes,
+            capturedAt = observed.capturedAt,
+            contextId = contextId,
+        )
+        // Persisted unconditionally: a zero-drift check is itself a fact worth having on record,
+        // not just a no-op.
+        store.saveDriftReport(report)
+
+        val quarantinedCount = if (!dryRun && diff.driftedEntityTypes.isNotEmpty()) {
+            quarantineDriftedEntityTypes(declared.version, diff.driftedEntityTypes, contextId)
+        } else {
+            0
+        }
+
+        logger.info(
+            "Drift check for '{}' complete (dryRun={}, contextId={}): {} drifted entity type(s), {} drifted " +
+                "relationship type(s), {} quarantined",
+            declared.version.schemaName,
+            dryRun,
+            contextId?.value,
+            diff.driftedEntityTypes.size,
+            diff.driftedRelationshipTypes.size,
+            quarantinedCount,
+        )
+
+        return DriftCheckResult(
+            dryRun = dryRun,
+            schemaName = declared.version.schemaName,
+            driftedEntityTypes = diff.driftedEntityTypes,
+            driftedRelationshipTypes = diff.driftedRelationshipTypes,
+            quarantinedCount = quarantinedCount,
+            report = report,
+            contextId = contextId,
+        )
+    }
+
+    /**
+     * Delegates to [quarantinePolicy] and persists whatever it decides to quarantine.
+     *
+     * [DriftQuarantinePolicy.evaluate] takes a [MetamodelDiff] (a comparison between two *declared*
+     * versions) keyed off [MetamodelDiff.removedEntityTypes], but what we have here is a
+     * [DeclaredObservedDiff] (declared vs. a live observation) — a different comparison entirely.
+     * The two agree on the part that matters to the policy, though: a mention whose type is no
+     * longer recognized by the declared schema is orphaned either way, whether that's because the
+     * type was removed from a newer declared version or because the graph holds a type that was
+     * never declared at all. So we synthesize a [MetamodelDiff] whose only content is
+     * [MetamodelChange.EntityTypeRemoved] for each drifted entity type, and hand that to the real
+     * policy rather than re-deciding quarantine here. Both `fromVersion` and `toVersion` point at
+     * the same declared version — there was no "old declared vs. new declared" transition, so
+     * they're only there to give the policy's human-readable reason string something to name.
+     */
+    private fun quarantineDriftedEntityTypes(
+        declaredVersion: MetamodelVersion,
+        driftedEntityTypes: Set<String>,
+        contextId: ContextId?,
+    ): Int {
+        val syntheticDiff = MetamodelDiff(
+            fromVersion = declaredVersion,
+            toVersion = declaredVersion,
+            changes = driftedEntityTypes.sorted().map { MetamodelChange.EntityTypeRemoved(it) },
+        )
+        // Scoped to one context, this is the whole blast radius: a proposition in another context
+        // is never a candidate, so it can never be quarantined by this run no matter what its
+        // mentions reference.
+        val propositions = if (contextId != null) {
+            propositionRepository.findByContextId(contextId)
+        } else {
+            propositionRepository.findAll()
+        }
+        val result = quarantinePolicy.evaluate(syntheticDiff, propositions)
+        result.quarantined.forEach { decision -> propositionRepository.save(decision.proposition) }
+        return result.quarantined.size
+    }
+}

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/support/MentionTypeDriftQuarantinePolicy.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/support/MentionTypeDriftQuarantinePolicy.kt
@@ -62,8 +62,24 @@ class MentionTypeDriftQuarantinePolicy : DriftQuarantinePolicy {
 
         if (removedTypes.isEmpty() && lossyModified.isEmpty()) {
             // Fast path: no lossy change means no proposition can be affected.
-            val conforming = propositions.map { QuarantineDecision.Conforming(it) }
-            return QuarantineResult(conforming = conforming, quarantined = emptyList())
+            // Preserve the third outcome even here: a proposition quarantined by an earlier sweep
+            // is still stale, so reporting it as conforming would corrupt health counts.
+            val conforming = mutableListOf<QuarantineDecision.Conforming>()
+            val alreadyQuarantined = mutableListOf<QuarantineDecision.AlreadyQuarantined>()
+            propositions.forEach { proposition ->
+                val priorDecision = alreadyQuarantinedDecision(proposition)
+                if (priorDecision != null) {
+                    alreadyQuarantined += priorDecision
+                } else {
+                    conforming += QuarantineDecision.Conforming(proposition)
+                }
+            }
+            logSummary(conforming.size, alreadyQuarantined.size, 0, removedTypes, lossyModified.keys)
+            return QuarantineResult(
+                conforming = conforming,
+                quarantined = emptyList(),
+                alreadyQuarantined = alreadyQuarantined,
+            )
         }
 
         val conforming = mutableListOf<QuarantineDecision.Conforming>()
@@ -77,17 +93,13 @@ class MentionTypeDriftQuarantinePolicy : DriftQuarantinePolicy {
             // Skip propositions that were already quarantined by a previous drift sweep so we
             // don't overwrite their original quarantine reason. The caller can force a re-sweep
             // by clearing the QUARANTINE_REASON metadata before passing propositions here.
-            if (proposition.status == PropositionStatus.STALE
-                && proposition.metadata.containsKey(DiceMetadataKeys.QUARANTINE_REASON)
-            ) {
+            val priorDecision = alreadyQuarantinedDecision(proposition)
+            if (priorDecision != null) {
                 logger.debug(
                     "Leaving already-quarantined proposition (id={}) untouched; original reason preserved",
                     proposition.id,
                 )
-                alreadyQuarantined += QuarantineDecision.AlreadyQuarantined(
-                    proposition = proposition,
-                    originalReason = proposition.metadata[DiceMetadataKeys.QUARANTINE_REASON] as? String,
-                )
+                alreadyQuarantined += priorDecision
                 continue
             }
 
@@ -124,9 +136,7 @@ class MentionTypeDriftQuarantinePolicy : DriftQuarantinePolicy {
             }
         }
 
-        logger.info(
-            "Drift quarantine sweep complete: {} conforming, {} already quarantined from a prior sweep, " +
-                "{} newly quarantined (removed types: {}, lossy-modified types: {})",
+        logSummary(
             conforming.size,
             alreadyQuarantined.size,
             quarantined.size,
@@ -138,6 +148,38 @@ class MentionTypeDriftQuarantinePolicy : DriftQuarantinePolicy {
             conforming = conforming,
             quarantined = quarantined,
             alreadyQuarantined = alreadyQuarantined,
+        )
+    }
+
+    private fun alreadyQuarantinedDecision(
+        proposition: Proposition,
+    ): QuarantineDecision.AlreadyQuarantined? =
+        if (proposition.status == PropositionStatus.STALE &&
+            proposition.metadata.containsKey(DiceMetadataKeys.QUARANTINE_REASON)
+        ) {
+            QuarantineDecision.AlreadyQuarantined(
+                proposition = proposition,
+                originalReason = proposition.metadata[DiceMetadataKeys.QUARANTINE_REASON] as? String,
+            )
+        } else {
+            null
+        }
+
+    private fun logSummary(
+        conformingCount: Int,
+        alreadyQuarantinedCount: Int,
+        quarantinedCount: Int,
+        removedTypes: Set<String>,
+        lossyModifiedTypes: Set<String>,
+    ) {
+        logger.info(
+            "Drift quarantine sweep complete: {} conforming, {} already quarantined from a prior sweep, " +
+                "{} newly quarantined (removed types: {}, lossy-modified types: {})",
+            conformingCount,
+            alreadyQuarantinedCount,
+            quarantinedCount,
+            removedTypes,
+            lossyModifiedTypes,
         )
     }
 

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/support/MentionTypeDriftQuarantinePolicy.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/support/MentionTypeDriftQuarantinePolicy.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel.support
+
+import com.embabel.dice.common.DiceMetadataKeys
+import com.embabel.dice.metamodel.DriftQuarantinePolicy
+import com.embabel.dice.metamodel.MetamodelChange
+import com.embabel.dice.metamodel.MetamodelDiff
+import com.embabel.dice.metamodel.QuarantineDecision
+import com.embabel.dice.metamodel.QuarantineResult
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionStatus
+import org.slf4j.LoggerFactory
+
+/**
+ * Default [DriftQuarantinePolicy] that quarantines propositions whose entity mentions reference
+ * entity types affected by a **lossy** schema change. A change is lossy when it can orphan
+ * existing mentions:
+ *
+ * - the entity type was **removed** ([MetamodelDiff.removedEntityTypes]); or
+ * - the entity type's name is preserved but it **lost** labels or properties
+ *   ([MetamodelChange.EntityTypeModified] with non-empty `removedLabels`/`removedProperties`).
+ *
+ * Additive changes (new types, added labels, added properties) are non-lossy and never trigger
+ * quarantine. A proposition is quarantined when at least one of its mentions has a type matching
+ * a lossy change. Quarantining:
+ *
+ * 1. Transitions the proposition to [PropositionStatus.STALE] via [Proposition.withStatus].
+ * 2. Annotates it with a human-readable reason under [DiceMetadataKeys.QUARANTINE_REASON].
+ *
+ * Both operations produce an immutable copy — the original proposition is never mutated.
+ * The caller is responsible for persisting the returned copies.
+ *
+ * A proposition an earlier sweep already quarantined comes back as
+ * [QuarantineDecision.AlreadyQuarantined], untouched: never re-flagged, its original reason
+ * preserved, and never counted as conforming.
+ */
+class MentionTypeDriftQuarantinePolicy : DriftQuarantinePolicy {
+
+    private val logger = LoggerFactory.getLogger(MentionTypeDriftQuarantinePolicy::class.java)
+
+    override fun evaluate(diff: MetamodelDiff, propositions: Iterable<Proposition>): QuarantineResult {
+        val removedTypes = diff.removedEntityTypes
+        // Types whose name is preserved but which lost labels or properties — also lossy, since a
+        // mention may have relied on a label/property that no longer exists. Keyed by type name.
+        val lossyModified = diff.modifiedEntityTypes
+            .filter { it.removedLabels.isNotEmpty() || it.removedProperties.isNotEmpty() }
+            .associateBy { it.typeName }
+
+        if (removedTypes.isEmpty() && lossyModified.isEmpty()) {
+            // Fast path: no lossy change means no proposition can be affected.
+            val conforming = propositions.map { QuarantineDecision.Conforming(it) }
+            return QuarantineResult(conforming = conforming, quarantined = emptyList())
+        }
+
+        val conforming = mutableListOf<QuarantineDecision.Conforming>()
+        val quarantined = mutableListOf<QuarantineDecision.Quarantined>()
+        // Propositions left untouched because a previous sweep already quarantined them. They get
+        // their own bucket rather than being folded into conforming: they aren't clean, and a
+        // caller reading conforming.size as a health number would be wrong about them.
+        val alreadyQuarantined = mutableListOf<QuarantineDecision.AlreadyQuarantined>()
+
+        for (proposition in propositions) {
+            // Skip propositions that were already quarantined by a previous drift sweep so we
+            // don't overwrite their original quarantine reason. The caller can force a re-sweep
+            // by clearing the QUARANTINE_REASON metadata before passing propositions here.
+            if (proposition.status == PropositionStatus.STALE
+                && proposition.metadata.containsKey(DiceMetadataKeys.QUARANTINE_REASON)
+            ) {
+                logger.debug(
+                    "Leaving already-quarantined proposition (id={}) untouched; original reason preserved",
+                    proposition.id,
+                )
+                alreadyQuarantined += QuarantineDecision.AlreadyQuarantined(
+                    proposition = proposition,
+                    originalReason = proposition.metadata[DiceMetadataKeys.QUARANTINE_REASON] as? String,
+                )
+                continue
+            }
+
+            val mentionTypes = proposition.mentions.map { it.type }.toSet()
+            val removedHit = mentionTypes intersect removedTypes
+            val lossyHit = mentionTypes intersect lossyModified.keys
+            val affectedTypes = removedHit + lossyHit
+
+            if (affectedTypes.isEmpty()) {
+                conforming += QuarantineDecision.Conforming(proposition)
+            } else {
+                val reason = buildReason(
+                    removedTypes = removedHit,
+                    lossyChanges = lossyHit.map { lossyModified.getValue(it) },
+                    fromSchema = diff.fromVersion.schemaName,
+                    toSchema = diff.toVersion.schemaName,
+                )
+                val flagged = proposition
+                    .withStatus(PropositionStatus.STALE)
+                    .withMetadataValue(DiceMetadataKeys.QUARANTINE_REASON, reason)
+
+                logger.debug(
+                    "Quarantining proposition '{}' (id={}): {}",
+                    proposition.text,
+                    proposition.id,
+                    reason,
+                )
+
+                quarantined += QuarantineDecision.Quarantined(
+                    proposition = flagged,
+                    reason = reason,
+                    affectedMentionTypes = affectedTypes,
+                )
+            }
+        }
+
+        logger.info(
+            "Drift quarantine sweep complete: {} conforming, {} already quarantined from a prior sweep, " +
+                "{} newly quarantined (removed types: {}, lossy-modified types: {})",
+            conforming.size,
+            alreadyQuarantined.size,
+            quarantined.size,
+            removedTypes,
+            lossyModified.keys,
+        )
+
+        return QuarantineResult(
+            conforming = conforming,
+            quarantined = quarantined,
+            alreadyQuarantined = alreadyQuarantined,
+        )
+    }
+
+    private fun buildReason(
+        removedTypes: Set<String>,
+        lossyChanges: List<MetamodelChange.EntityTypeModified>,
+        fromSchema: String,
+        toSchema: String,
+    ): String {
+        val clauses = mutableListOf<String>()
+        if (removedTypes.isNotEmpty()) {
+            clauses += "type(s) [${removedTypes.sorted().joinToString(", ")}] removed"
+        }
+        lossyChanges.sortedBy { it.typeName }.forEach { change ->
+            val losses = mutableListOf<String>()
+            if (change.removedLabels.isNotEmpty()) {
+                losses += "label(s) [${change.removedLabels.sorted().joinToString(", ")}]"
+            }
+            if (change.removedProperties.isNotEmpty()) {
+                losses += "propert${if (change.removedProperties.size == 1) "y" else "ies"} " +
+                    "[${change.removedProperties.sorted().joinToString(", ")}]"
+            }
+            clauses += "type '${change.typeName}' lost ${losses.joinToString(" and ")}"
+        }
+        return "Schema drift '$fromSchema' → '$toSchema': ${clauses.joinToString("; ")}"
+    }
+}

--- a/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/support/StructuralMetamodelDiffer.kt
+++ b/dice-metamodel/src/main/kotlin/com/embabel/dice/metamodel/support/StructuralMetamodelDiffer.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel.support
+
+import com.embabel.dice.metamodel.DeclaredObservedDiff
+import com.embabel.dice.metamodel.DeclaredObservedDiffer
+import com.embabel.dice.metamodel.MetamodelChange
+import com.embabel.dice.metamodel.MetamodelDiff
+import com.embabel.dice.metamodel.MetamodelDiffer
+import com.embabel.dice.metamodel.MetamodelVersion
+import com.embabel.dice.metamodel.ObservedSchema
+import org.slf4j.LoggerFactory
+
+/**
+ * The default [MetamodelDiffer]: a deterministic, structural comparison of two [MetamodelVersion]s.
+ *
+ * It works on the snapshot data each version already carries — entity-type names, per-type label and
+ * property sets, and relationship descriptors — and reports what was added, removed, or modified.
+ * Sets are compared directly (never via a delimiter-joined projection), so a label or property whose
+ * name contains a delimiter can't collapse two genuinely different sets into a false "unchanged".
+ *
+ * Stateless and thread-safe — a single shared instance is fine.
+ */
+class StructuralMetamodelDiffer : MetamodelDiffer, DeclaredObservedDiffer {
+
+    private val logger = LoggerFactory.getLogger(StructuralMetamodelDiffer::class.java)
+
+    override fun diff(from: MetamodelVersion, to: MetamodelVersion): MetamodelDiff {
+        val changes = mutableListOf<MetamodelChange>()
+
+        // --- Entity type changes ---
+        val fromTypes = from.entityTypeNames.toSet()
+        val toTypes = to.entityTypeNames.toSet()
+
+        val removedTypes = fromTypes - toTypes
+        val addedTypes = toTypes - fromTypes
+
+        removedTypes.sorted().mapTo(changes) { MetamodelChange.EntityTypeRemoved(it) }
+        addedTypes.sorted().mapTo(changes) { MetamodelChange.EntityTypeAdded(it) }
+
+        // Detect modified entity types: a type whose name is preserved but whose label or property
+        // set changed. Compare the sets directly — never a delimiter-joined projection — so a label
+        // or property whose name contains the delimiter (spaces are common in free-text / LLM-extracted
+        // names) can't collapse two genuinely different sets into a false "unchanged".
+        val commonTypes = fromTypes intersect toTypes
+        for (typeName in commonTypes.sorted()) {
+            val fromLabels = from.entityTypeLabels[typeName].orEmpty()
+            val toLabels = to.entityTypeLabels[typeName].orEmpty()
+            val fromProperties = from.entityTypeProperties[typeName].orEmpty()
+            val toProperties = to.entityTypeProperties[typeName].orEmpty()
+
+            val addedLabels = toLabels - fromLabels
+            val removedLabels = fromLabels - toLabels
+            val addedProperties = toProperties - fromProperties
+            val removedProperties = fromProperties - toProperties
+
+            if (addedLabels.isNotEmpty() || removedLabels.isNotEmpty() ||
+                addedProperties.isNotEmpty() || removedProperties.isNotEmpty()
+            ) {
+                changes += MetamodelChange.EntityTypeModified(
+                    typeName = typeName,
+                    addedLabels = addedLabels,
+                    removedLabels = removedLabels,
+                    addedProperties = addedProperties,
+                    removedProperties = removedProperties,
+                )
+            }
+        }
+
+        // --- Relationship changes ---
+        val fromRels = from.relationshipNames.toSet()
+        val toRels = to.relationshipNames.toSet()
+
+        val removedRels = fromRels - toRels
+        val addedRels = toRels - fromRels
+
+        removedRels.sorted().mapTo(changes) { MetamodelChange.RelationshipRemoved(it) }
+        addedRels.sorted().mapTo(changes) { MetamodelChange.RelationshipAdded(it) }
+
+        logger.debug(
+            "Metamodel diff '{}' → '{}': {} added types, {} removed types, {} modified types, " +
+                "{} added rels, {} removed rels",
+            from.schemaName,
+            to.schemaName,
+            addedTypes.size,
+            removedTypes.size,
+            changes.count { it is MetamodelChange.EntityTypeModified },
+            addedRels.size,
+            removedRels.size,
+        )
+
+        return MetamodelDiff(fromVersion = from, toVersion = to, changes = changes)
+    }
+
+    override fun diffAgainstObserved(
+        declared: MetamodelVersion,
+        declaredRelationshipTypeNames: Set<String>,
+        observed: ObservedSchema,
+    ): DeclaredObservedDiff {
+        val declaredTypes = declared.entityTypeNames.toSet()
+        val observedTypes = observed.entityTypeNames
+
+        // Drift: observed but never declared — the concrete case is orphaned data whose
+        // declaring integration is gone (or was never registered). Missing-but-declared is
+        // the opposite situation and is not drift: a declared type with zero instances is fine.
+        val driftedEntityTypes = observedTypes - declaredTypes
+        val unobservedEntityTypes = declaredTypes - observedTypes
+
+        // MetamodelVersion.relationshipNames holds full "From-[name]->To" descriptors, but an
+        // observed graph only knows bare relationship type names (e.g. via Neo4j's
+        // db.relationshipTypes()) — it can't tell you which node types a relationship actually
+        // connected without walking the data. We compare on the bare name, but we never try to
+        // recover it by parsing the descriptor: these names are free-text / LLM-derived and can
+        // themselves contain a "-[...]->"-shaped substring, so a string-split extraction is
+        // ambiguous and can silently pick the wrong segment. The caller supplies the bare names
+        // directly (see DeclaredObservedDiffer.diffAgainstObserved) from the structured
+        // declaration, before it was ever rendered into a descriptor.
+        val observedRels = observed.relationshipTypeNames
+
+        val driftedRelationshipTypes = observedRels - declaredRelationshipTypeNames
+        val unobservedRelationshipTypes = declaredRelationshipTypeNames - observedRels
+
+        logger.debug(
+            "Declared/observed diff for '{}': {} drifted entity types, {} drifted relationship " +
+                "types, {} unobserved entity types, {} unobserved relationship types",
+            declared.schemaName,
+            driftedEntityTypes.size,
+            driftedRelationshipTypes.size,
+            unobservedEntityTypes.size,
+            unobservedRelationshipTypes.size,
+        )
+
+        return DeclaredObservedDiff(
+            declaredVersion = declared,
+            observedSchema = observed,
+            driftedEntityTypes = driftedEntityTypes,
+            driftedRelationshipTypes = driftedRelationshipTypes,
+            unobservedEntityTypes = unobservedEntityTypes,
+            unobservedRelationshipTypes = unobservedRelationshipTypes,
+        )
+    }
+}

--- a/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/DriftCheckRunnerTest.kt
+++ b/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/DriftCheckRunnerTest.kt
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.common.DiceMetadataKeys
+import com.embabel.dice.metamodel.support.DefaultDriftCheckRunner
+import com.embabel.dice.metamodel.support.MentionTypeDriftQuarantinePolicy
+import com.embabel.dice.metamodel.support.StructuralMetamodelDiffer
+import com.embabel.dice.proposition.EntityMention
+import com.embabel.dice.proposition.MentionRole
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionRepository
+import com.embabel.dice.proposition.PropositionStatus
+import com.embabel.dice.proposition.store.InMemoryPropositionRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Unit tests for [DefaultDriftCheckRunner] against fake [ObservedSchemaSource]/[DeclaredSchemaSource]/
+ * [MetamodelStore] doubles, the real [StructuralMetamodelDiffer] (already covered on its own), and
+ * the real [MentionTypeDriftQuarantinePolicy] (also covered on its own) so these tests exercise the
+ * actual delegation, not a stand-in for it.
+ */
+class DriftCheckRunnerTest {
+
+    private val contextId = ContextId("test-context")
+    private val otherContextId = ContextId("other-context")
+    private val schemaName = "test-schema"
+
+    private lateinit var store: FakeMetamodelStore
+    private lateinit var propositionRepository: InMemoryPropositionRepository
+    private lateinit var runner: DriftCheckRunner
+
+    /** Declared schema: two entity types, one relationship. Overridable per test. */
+    private var declaredEntityTypes = listOf("Person", "Company")
+    private var declaredRelationshipTypeNames = setOf("WORKS_AT")
+
+    /** Observed schema: overridable per test. Defaults to matching the declared schema exactly. */
+    private var observedEntityTypes = setOf("Person", "Company")
+    private var observedRelationshipTypeNames = setOf("WORKS_AT")
+
+    @BeforeEach
+    fun setUp() {
+        store = FakeMetamodelStore()
+        propositionRepository = InMemoryPropositionRepository()
+    }
+
+    private fun buildRunner(repo: PropositionRepository = propositionRepository): DriftCheckRunner {
+        val declaredVersion = MetamodelVersion(
+            schemaName = schemaName,
+            entityTypeNames = declaredEntityTypes,
+            entityTypeLabels = declaredEntityTypes.associateWith { emptySet() },
+            entityTypeProperties = declaredEntityTypes.associateWith { emptySet() },
+            relationshipNames = declaredRelationshipTypeNames.map { "Person-[$it]->Company" },
+        )
+        val declaredSchema = DeclaredSchema(
+            version = declaredVersion,
+            relationshipTypeNames = declaredRelationshipTypeNames,
+        )
+        val observedSchema = ObservedSchema(
+            entityTypeNames = observedEntityTypes,
+            relationshipTypeNames = observedRelationshipTypeNames,
+            capturedAt = Instant.parse("2026-01-01T00:00:00Z"),
+        )
+        return DefaultDriftCheckRunner(
+            observedSchemaSource = object : ObservedSchemaSource {
+                override fun observe(contextId: ContextId?): ObservedSchema = observedSchema
+            },
+            declaredSchemaSource = DeclaredSchemaSource { declaredSchema },
+            differ = StructuralMetamodelDiffer(),
+            store = store,
+            quarantinePolicy = MentionTypeDriftQuarantinePolicy(),
+            propositionRepository = repo,
+        )
+    }
+
+    private fun proposition(
+        text: String,
+        vararg mentionTypes: String,
+        inContext: ContextId = contextId,
+    ): Proposition = Proposition(
+        contextId = inContext,
+        text = text,
+        mentions = mentionTypes.map { type -> EntityMention(span = type.lowercase(), type = type, role = MentionRole.SUBJECT) },
+        confidence = 0.9,
+    )
+
+    @Test
+    fun `zero drift still persists a retrievable report`() {
+        runner = buildRunner()
+
+        val result = runner.run(dryRun = true)
+
+        assertTrue(result.driftedEntityTypes.isEmpty())
+        assertTrue(result.driftedRelationshipTypes.isEmpty())
+        assertEquals(0, result.quarantinedCount)
+        assertTrue(result.dryRun)
+
+        val reports = store.driftReports(schemaName)
+        assertEquals(1, reports.size, "even a clean check must leave a record behind")
+        assertEquals(emptySet<String>(), reports.single().driftedEntityTypes)
+        assertEquals(emptySet<String>(), reports.single().driftedRelationshipTypes)
+        assertEquals(result.report, reports.single())
+    }
+
+    @Test
+    fun `drift with dryRun persists the report but quarantines nothing`() {
+        observedEntityTypes = setOf("Person", "Company", "GhostType")
+        propositionRepository.save(proposition("a ghost was mentioned", "GhostType"))
+        runner = buildRunner()
+
+        val result = runner.run(dryRun = true)
+
+        assertEquals(setOf("GhostType"), result.driftedEntityTypes)
+        assertEquals(0, result.quarantinedCount)
+        assertTrue(result.dryRun)
+
+        // The report is on record even though nothing was quarantined.
+        val report = store.driftReports(schemaName).single()
+        assertEquals(setOf("GhostType"), report.driftedEntityTypes)
+
+        // No proposition was touched: the dry run applied no transition.
+        val stillActive = propositionRepository.findAll().single()
+        assertEquals(PropositionStatus.ACTIVE, stillActive.status)
+        assertNull(stillActive.metadata[DiceMetadataKeys.QUARANTINE_REASON])
+    }
+
+    @Test
+    fun `drift with a live run delegates quarantine to the configured policy`() {
+        observedEntityTypes = setOf("Person", "Company", "GhostType")
+        val affected = propositionRepository.save(proposition("a ghost was mentioned", "GhostType"))
+        val safe = propositionRepository.save(proposition("Alice works at Acme", "Person", "Company"))
+        runner = buildRunner()
+
+        val result = runner.run(dryRun = false)
+
+        assertEquals(setOf("GhostType"), result.driftedEntityTypes)
+        assertEquals(1, result.quarantinedCount)
+        assertTrue(!result.dryRun)
+
+        val quarantined = propositionRepository.findById(affected.id)!!
+        assertEquals(PropositionStatus.STALE, quarantined.status)
+        assertNotNull(quarantined.metadata[DiceMetadataKeys.QUARANTINE_REASON])
+
+        val untouched = propositionRepository.findById(safe.id)!!
+        assertEquals(PropositionStatus.ACTIVE, untouched.status)
+
+        // The report is still persisted, same as the dry-run case.
+        assertEquals(1, store.driftReports(schemaName).size)
+    }
+
+    @Test
+    fun `a live run with no entity-type drift never consults the quarantine policy`() {
+        // Relationship-only drift: nothing a mention's type could ever match, so nothing should be
+        // quarantined even on a live run.
+        observedRelationshipTypeNames = setOf("WORKS_AT", "UNDECLARED_LINK")
+        propositionRepository.save(proposition("Alice works at Acme", "Person", "Company"))
+        runner = buildRunner()
+
+        val result = runner.run(dryRun = false)
+
+        assertTrue(result.driftedEntityTypes.isEmpty())
+        assertEquals(setOf("UNDECLARED_LINK"), result.driftedRelationshipTypes)
+        assertEquals(0, result.quarantinedCount)
+
+        val untouched = propositionRepository.findAll().single()
+        assertEquals(PropositionStatus.ACTIVE, untouched.status)
+    }
+
+    @Test
+    fun `declared relationship type names with pipes, tabs, and newlines flow through untouched`() {
+        val delimiterLaden = setOf("REL|WITH|PIPE", "REL\tWITH\tTAB", "REL\nWITH\nNEWLINE")
+        declaredRelationshipTypeNames = delimiterLaden
+        observedRelationshipTypeNames = delimiterLaden + "UNDECLARED|ALSO\tDELIMITED"
+        runner = buildRunner()
+
+        val result = runner.run(dryRun = true)
+
+        // The declared names must reach the differ exactly as supplied -- no splitting, trimming,
+        // or delimiter-based parsing -- so only the genuinely undeclared name shows up as drift.
+        assertEquals(setOf("UNDECLARED|ALSO\tDELIMITED"), result.driftedRelationshipTypes)
+        val report = store.driftReports(schemaName).single()
+        assertEquals(setOf("UNDECLARED|ALSO\tDELIMITED"), report.driftedRelationshipTypes)
+    }
+
+    // ---- Context scoping ----
+
+    @Test
+    fun `a scoped run reads candidates via findByContextId, not findAll`() {
+        observedEntityTypes = setOf("Person", "Company", "GhostType")
+        propositionRepository.save(proposition("a ghost was mentioned", "GhostType"))
+        val recording = RecordingPropositionRepository(propositionRepository)
+        runner = buildRunner(recording)
+
+        val result = runner.run(dryRun = false, contextId = contextId)
+
+        assertEquals(contextId, recording.findByContextIdCall)
+        assertNull(recording.findAllCall)
+        assertEquals(contextId, result.contextId)
+        assertEquals(contextId, result.report.contextId)
+    }
+
+    @Test
+    fun `a global run (no contextId) reads candidates via findAll, not findByContextId`() {
+        observedEntityTypes = setOf("Person", "Company", "GhostType")
+        propositionRepository.save(proposition("a ghost was mentioned", "GhostType"))
+        val recording = RecordingPropositionRepository(propositionRepository)
+        runner = buildRunner(recording)
+
+        val result = runner.run(dryRun = false)
+
+        assertTrue(recording.findAllCall == true)
+        assertNull(recording.findByContextIdCall)
+        assertNull(result.contextId)
+        assertNull(result.report.contextId)
+    }
+
+    @Test
+    fun `a scoped live run leaves another context's propositions completely alone`() {
+        // The containment claim in DriftCheckRunner.run's KDoc, fired rather than merely wired:
+        // both propositions mention the drifted type, and both would be quarantined by a global
+        // run. Scoping to context A must reach exactly one of them.
+        observedEntityTypes = setOf("Person", "Company", "GhostType")
+        val inScope = propositionRepository.save(proposition("a ghost in context A", "GhostType"))
+        val outOfScope = propositionRepository.save(
+            proposition("a ghost in context B", "GhostType", inContext = otherContextId),
+        )
+        runner = buildRunner()
+
+        val result = runner.run(dryRun = false, contextId = contextId)
+
+        assertEquals(setOf("GhostType"), result.driftedEntityTypes)
+        assertEquals(1, result.quarantinedCount, "only context A's proposition is a candidate")
+
+        val quarantined = propositionRepository.findById(inScope.id)!!
+        assertEquals(PropositionStatus.STALE, quarantined.status)
+
+        val untouched = propositionRepository.findById(outOfScope.id)!!
+        assertEquals(
+            PropositionStatus.ACTIVE,
+            untouched.status,
+            "a check scoped to one context must not be able to reach another's propositions",
+        )
+        assertNull(untouched.metadata[DiceMetadataKeys.QUARANTINE_REASON])
+    }
+
+    @Test
+    fun `a dry-run scoped check still stamps the report with the context, even with nothing to quarantine`() {
+        runner = buildRunner()
+
+        val result = runner.run(dryRun = true, contextId = contextId)
+
+        assertEquals(contextId, result.contextId)
+        assertEquals(contextId, result.report.contextId)
+        assertEquals(contextId, store.driftReports(schemaName).single().contextId)
+    }
+
+    /**
+     * Records which candidate-read method [DefaultDriftCheckRunner] actually called, so the tests
+     * above can assert the scoped/global read path directly rather than inferring it from a side
+     * effect. Delegates everything else to the wrapped [InMemoryPropositionRepository] unchanged.
+     */
+    private class RecordingPropositionRepository(
+        private val delegate: PropositionRepository,
+    ) : PropositionRepository by delegate {
+
+        var findAllCall: Boolean? = null
+            private set
+        var findByContextIdCall: ContextId? = null
+            private set
+
+        override fun findAll(): List<Proposition> {
+            findAllCall = true
+            return delegate.findAll()
+        }
+
+        override fun findByContextId(contextId: ContextId): List<Proposition> {
+            findByContextIdCall = contextId
+            return delegate.findByContextId(contextId)
+        }
+    }
+
+    /** Minimal in-memory [MetamodelStore] fake: append-only, newest first, no deletion. */
+    private class FakeMetamodelStore : MetamodelStore {
+        private val versions = mutableListOf<MetamodelVersion>()
+        private val reports = mutableListOf<DriftReport>()
+
+        override fun saveVersion(version: MetamodelVersion) {
+            if (versions.none { it.schemaName == version.schemaName && it.contentHash == version.contentHash }) {
+                versions.add(0, version)
+            }
+        }
+
+        override fun latestVersion(schemaName: String): MetamodelVersion? =
+            versions.firstOrNull { it.schemaName == schemaName }
+
+        override fun versionHistory(schemaName: String): List<MetamodelVersion> =
+            versions.filter { it.schemaName == schemaName }
+
+        override fun saveDriftReport(report: DriftReport) {
+            reports.add(0, report)
+        }
+
+        override fun driftReports(schemaName: String): List<DriftReport> =
+            reports.filter { it.schemaName == schemaName }
+    }
+}

--- a/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/DriftQuarantinePolicyTest.kt
+++ b/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/DriftQuarantinePolicyTest.kt
@@ -312,6 +312,23 @@ class DriftQuarantinePolicyTest {
             assertEquals(0, result.quarantined.size)
             assertEquals(2, result.total)
         }
+
+        @Test
+        fun `already-quarantined proposition stays out of conforming bucket when diff is non-lossy`() {
+            val lossyDiff = differ.diff(schemaWith("Person", "RemovedType"), schemaWith("Person"))
+            val stale = policy.evaluate(
+                lossyDiff,
+                listOf(proposition("entity with removed type", "RemovedType")),
+            ).quarantined.single().proposition
+
+            val additiveDiff = differ.diff(schemaWith("Person"), schemaWith("Person", "Company"))
+            val result = policy.evaluate(additiveDiff, listOf(stale))
+
+            assertEquals(0, result.conforming.size)
+            assertEquals(0, result.quarantined.size)
+            assertEquals(1, result.alreadyQuarantined.size)
+            assertEquals(stale, result.alreadyQuarantined.single().proposition)
+        }
     }
 
     @Nested

--- a/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/DriftQuarantinePolicyTest.kt
+++ b/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/DriftQuarantinePolicyTest.kt
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import com.embabel.agent.core.ContextId
+import com.embabel.agent.core.DataDictionary
+import com.embabel.agent.core.DynamicType
+import com.embabel.agent.core.ValuePropertyDefinition
+import com.embabel.dice.common.DiceMetadataKeys
+import com.embabel.dice.metamodel.support.MentionTypeDriftQuarantinePolicy
+import com.embabel.dice.metamodel.support.StructuralMetamodelDiffer
+import com.embabel.dice.proposition.EntityMention
+import com.embabel.dice.proposition.MentionRole
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionStatus
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class DriftQuarantinePolicyTest {
+
+    private val contextId = ContextId("test-context")
+    private lateinit var policy: MentionTypeDriftQuarantinePolicy
+    private lateinit var differ: MetamodelDiffer
+
+    @BeforeEach
+    fun setUp() {
+        policy = MentionTypeDriftQuarantinePolicy()
+        differ = StructuralMetamodelDiffer()
+    }
+
+    private fun schemaWith(vararg typeNames: String): DataDictionary =
+        DataDictionary.fromDomainTypes("test", typeNames.map { DynamicType(name = it) })
+
+    private fun proposition(
+        text: String,
+        vararg mentionTypes: String,
+        status: PropositionStatus = PropositionStatus.ACTIVE,
+    ): Proposition = Proposition(
+        contextId = contextId,
+        text = text,
+        mentions = mentionTypes.map { type ->
+            EntityMention(span = type.lowercase(), type = type, role = MentionRole.SUBJECT)
+        },
+        confidence = 0.9,
+    ).withStatus(status)
+
+    @Nested
+    inner class NoRemovedTypes {
+
+        @Test
+        fun `empty diff leaves all propositions conforming`() {
+            val old = schemaWith("Person", "Company")
+            val new = schemaWith("Person", "Company")
+            val diff = differ.diff(old, new)
+
+            val props = listOf(
+                proposition("Alice works at Acme", "Person", "Company"),
+                proposition("Bob likes coffee", "Person"),
+            )
+            val result = policy.evaluate(diff, props)
+
+            assertEquals(2, result.conforming.size)
+            assertEquals(0, result.quarantined.size)
+            result.conforming.forEach { assertEquals(PropositionStatus.ACTIVE, it.proposition.status) }
+        }
+    }
+
+    @Nested
+    inner class WithRemovedTypes {
+
+        @Test
+        fun `proposition mentioning removed type is quarantined`() {
+            val old = schemaWith("Person", "LegacyType")
+            val new = schemaWith("Person")
+            val diff = differ.diff(old, new)
+
+            val affected = proposition("legacy entity stuff", "LegacyType")
+            val safe = proposition("Alice is a person", "Person")
+
+            val result = policy.evaluate(diff, listOf(affected, safe))
+
+            assertEquals(1, result.conforming.size)
+            assertEquals(1, result.quarantined.size)
+
+            val decision = result.quarantined.single()
+            assertEquals(PropositionStatus.STALE, decision.proposition.status)
+            assertTrue(decision.affectedMentionTypes.contains("LegacyType"))
+            assertNotNull(decision.proposition.metadata[DiceMetadataKeys.QUARANTINE_REASON])
+        }
+
+        @Test
+        fun `conforming propositions remain ACTIVE and unmodified`() {
+            val old = schemaWith("Person", "Removed")
+            val new = schemaWith("Person")
+            val diff = differ.diff(old, new)
+
+            val safe = proposition("Alice is active", "Person")
+            val result = policy.evaluate(diff, listOf(safe))
+
+            assertEquals(1, result.conforming.size)
+            assertEquals(PropositionStatus.ACTIVE, result.conforming.single().proposition.status)
+            assertNull(result.conforming.single().proposition.metadata[DiceMetadataKeys.QUARANTINE_REASON])
+        }
+
+        @Test
+        fun `proposition with multiple mentions is quarantined when any mention type is removed`() {
+            val old = schemaWith("Person", "Company", "OldType")
+            val new = schemaWith("Person", "Company")
+            val diff = differ.diff(old, new)
+
+            val mixed = proposition("Alice at Acme via OldType", "Person", "OldType")
+            val result = policy.evaluate(diff, listOf(mixed))
+
+            assertEquals(1, result.quarantined.size)
+            assertTrue(result.quarantined.single().affectedMentionTypes.contains("OldType"))
+        }
+
+        @Test
+        fun `quarantine reason references the removed type`() {
+            val old = schemaWith("Person", "DeprecatedEntity")
+            val new = schemaWith("Person")
+            val diff = differ.diff(old, new)
+
+            val prop = proposition("something with deprecated", "DeprecatedEntity")
+            val result = policy.evaluate(diff, listOf(prop))
+
+            val reason = result.quarantined.single().proposition.metadata[DiceMetadataKeys.QUARANTINE_REASON] as String
+            assertTrue(reason.contains("DeprecatedEntity"), "Reason should mention the type: $reason")
+        }
+
+        @Test
+        fun `quarantine is non-destructive — original proposition is unchanged`() {
+            val old = schemaWith("Person", "Removed")
+            val new = schemaWith("Person")
+            val diff = differ.diff(old, new)
+
+            val original = proposition("entity with removed type", "Removed")
+            val result = policy.evaluate(diff, listOf(original))
+
+            val quarantined = result.quarantined.single().proposition
+            // Returned copy is STALE
+            assertEquals(PropositionStatus.STALE, quarantined.status)
+            // Original is unchanged
+            assertEquals(PropositionStatus.ACTIVE, original.status)
+            assertNull(original.metadata[DiceMetadataKeys.QUARANTINE_REASON])
+        }
+
+        @Test
+        fun `all propositions are returned via allPropositions`() {
+            val old = schemaWith("Person", "Removed")
+            val new = schemaWith("Person")
+            val diff = differ.diff(old, new)
+
+            val props = listOf(
+                proposition("safe", "Person"),
+                proposition("affected", "Removed"),
+            )
+            val result = policy.evaluate(diff, props)
+
+            assertEquals(2, result.allPropositions.size)
+            assertEquals(2, result.total)
+        }
+    }
+
+    @Nested
+    inner class WithLossyShapeChanges {
+
+        private fun personWith(parents: List<String> = emptyList(), props: List<String> = emptyList()): DynamicType =
+            DynamicType(
+                name = "Person",
+                parents = parents.map { DynamicType(name = it) },
+                ownProperties = props.map { ValuePropertyDefinition(it) },
+            )
+
+        private fun schema(person: DynamicType): DataDictionary =
+            DataDictionary.fromDomainTypes("test", listOf(person))
+
+        @Test
+        fun `proposition mentioning a type that lost a label is quarantined`() {
+            val old = schema(personWith(parents = listOf("Agent")))   // labels {Person, Agent}
+            val new = schema(personWith())                            // labels {Person}
+            val diff = differ.diff(old, new)
+
+            val result = policy.evaluate(diff, listOf(proposition("Alice is a person", "Person")))
+
+            assertEquals(1, result.quarantined.size)
+            val decision = result.quarantined.single()
+            assertEquals(PropositionStatus.STALE, decision.proposition.status)
+            assertTrue(decision.affectedMentionTypes.contains("Person"))
+            val reason = decision.proposition.metadata[DiceMetadataKeys.QUARANTINE_REASON] as String
+            assertTrue(reason.contains("Agent"), "reason should name the lost label: $reason")
+        }
+
+        @Test
+        fun `proposition mentioning a type that lost a property is quarantined`() {
+            val old = schema(personWith(props = listOf("age", "email")))
+            val new = schema(personWith(props = listOf("age")))
+            val diff = differ.diff(old, new)
+
+            val result = policy.evaluate(diff, listOf(proposition("Alice is a person", "Person")))
+
+            assertEquals(1, result.quarantined.size)
+            val reason = result.quarantined.single().proposition.metadata[DiceMetadataKeys.QUARANTINE_REASON] as String
+            assertTrue(reason.contains("email"), "reason should name the lost property: $reason")
+        }
+
+        @Test
+        fun `additive-only change does not quarantine`() {
+            // A type that GAINS a label and a property — non-lossy, so nothing is quarantined.
+            val old = schema(personWith())
+            val new = schema(personWith(parents = listOf("Agent"), props = listOf("age")))
+            val diff = differ.diff(old, new)
+            assertTrue(diff.modifiedEntityTypes.isNotEmpty(), "sanity: a modified type was detected")
+
+            val result = policy.evaluate(diff, listOf(proposition("Alice is a person", "Person")))
+
+            assertEquals(1, result.conforming.size)
+            assertEquals(0, result.quarantined.size)
+            assertEquals(PropositionStatus.ACTIVE, result.conforming.single().proposition.status)
+        }
+    }
+
+    @Nested
+    inner class EmptyInput {
+
+        @Test
+        fun `empty proposition list produces empty result`() {
+            val old = schemaWith("Person")
+            val new = schemaWith()
+            val diff = differ.diff(old, new)
+
+            val result = policy.evaluate(diff, emptyList())
+            assertEquals(0, result.total)
+        }
+    }
+
+    @Nested
+    inner class Idempotency {
+
+        @Test
+        fun `already-quarantined proposition is not re-quarantined on a second sweep`() {
+            val old = schemaWith("Person", "RemovedType")
+            val new = schemaWith("Person")
+            val diff = differ.diff(old, new)
+
+            // First sweep quarantines the proposition.
+            val original = proposition("entity with removed type", "RemovedType")
+            val firstResult = policy.evaluate(diff, listOf(original))
+            assertEquals(1, firstResult.quarantined.size)
+            val alreadyQuarantined = firstResult.quarantined.single().proposition
+
+            // Second sweep with the already-quarantined proposition: it comes back in its own
+            // bucket, untouched, with the original quarantine reason intact.
+            val secondResult = policy.evaluate(diff, listOf(alreadyQuarantined))
+            assertEquals(
+                0,
+                secondResult.conforming.size,
+                "an already-quarantined proposition is not clean and must not be reported as conforming",
+            )
+            assertEquals(0, secondResult.quarantined.size)
+            assertEquals(1, secondResult.alreadyQuarantined.size)
+            assertEquals(1, secondResult.total)
+
+            // The QUARANTINE_REASON from the first sweep is preserved, and surfaced on the decision.
+            val decision = secondResult.alreadyQuarantined.single()
+            assertEquals(
+                alreadyQuarantined.metadata[DiceMetadataKeys.QUARANTINE_REASON],
+                decision.proposition.metadata[DiceMetadataKeys.QUARANTINE_REASON],
+            )
+            assertEquals(
+                alreadyQuarantined.metadata[DiceMetadataKeys.QUARANTINE_REASON],
+                decision.originalReason,
+            )
+            assertEquals(PropositionStatus.STALE, decision.proposition.status)
+            assertTrue(
+                secondResult.allPropositions.contains(decision.proposition),
+                "already-quarantined propositions still belong to the full evaluated set",
+            )
+        }
+
+        @Test
+        fun `a clean proposition and an already-quarantined one land in different buckets`() {
+            val old = schemaWith("Person", "RemovedType")
+            val new = schemaWith("Person")
+            val diff = differ.diff(old, new)
+
+            val firstSweep = policy.evaluate(diff, listOf(proposition("entity with removed type", "RemovedType")))
+            val stale = firstSweep.quarantined.single().proposition
+            val clean = proposition("Alice is a person", "Person")
+
+            val result = policy.evaluate(diff, listOf(clean, stale))
+
+            assertEquals(1, result.conforming.size)
+            assertEquals(clean.id, result.conforming.single().proposition.id)
+            assertEquals(1, result.alreadyQuarantined.size)
+            assertEquals(stale.id, result.alreadyQuarantined.single().proposition.id)
+            assertEquals(0, result.quarantined.size)
+            assertEquals(2, result.total)
+        }
+    }
+
+    @Nested
+    inner class PropositionsWithNoMentions {
+
+        @Test
+        fun `proposition with no mentions is conforming even when entity types are removed`() {
+            // The removed type cannot match an empty mention set, so no quarantine.
+            val old = schemaWith("Person", "RemovedType")
+            val new = schemaWith("Person")
+            val diff = differ.diff(old, new)
+
+            val noMentionProp = proposition("A fact with no entity mentions")
+            val result = policy.evaluate(diff, listOf(noMentionProp))
+
+            assertEquals(1, result.conforming.size)
+            assertEquals(0, result.quarantined.size)
+            assertEquals(PropositionStatus.ACTIVE, result.conforming.single().proposition.status)
+        }
+
+        @Test
+        fun `proposition with no mentions is conforming when diff is empty`() {
+            val old = schemaWith("Person", "Company")
+            val new = schemaWith("Person", "Company")
+            val diff = differ.diff(old, new)
+
+            val noMentionProp = proposition("A fact with no entity mentions")
+            val result = policy.evaluate(diff, listOf(noMentionProp))
+
+            assertEquals(1, result.total)
+            assertEquals(1, result.conforming.size)
+            assertEquals(0, result.quarantined.size)
+        }
+    }
+}

--- a/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/DriftReportTest.kt
+++ b/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/DriftReportTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class DriftReportTest {
+
+    @Test
+    fun `drift report preserves entity and relationship type sets`() {
+        val entities = setOf("UnknownPerson", "UnknownOrg")
+        val relationships = setOf("UNDECLARED_LINKS")
+        val now = Instant.now()
+
+        val report = DriftReport(
+            schemaName = "test-schema",
+            versionHash = "abc123",
+            driftedEntityTypes = entities,
+            driftedRelationshipTypes = relationships,
+            capturedAt = now,
+        )
+
+        assertEquals("test-schema", report.schemaName)
+        assertEquals("abc123", report.versionHash)
+        assertEquals(entities, report.driftedEntityTypes)
+        assertEquals(relationships, report.driftedRelationshipTypes)
+        assertEquals(now, report.capturedAt)
+    }
+
+    @Test
+    fun `drift report with empty type sets constructs successfully`() {
+        val report = DriftReport(
+            schemaName = "clean-schema",
+            versionHash = "def456",
+            driftedEntityTypes = emptySet(),
+            driftedRelationshipTypes = emptySet(),
+            capturedAt = Instant.parse("2026-01-01T00:00:00Z"),
+        )
+
+        assertEquals(0, report.driftedEntityTypes.size)
+        assertEquals(0, report.driftedRelationshipTypes.size)
+    }
+}

--- a/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/MetamodelDifferTest.kt
+++ b/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/MetamodelDifferTest.kt
@@ -1,0 +1,483 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import com.embabel.agent.core.DataDictionary
+import com.embabel.agent.core.DynamicType
+import com.embabel.agent.core.ValuePropertyDefinition
+import com.embabel.dice.metamodel.support.StructuralMetamodelDiffer
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class MetamodelDifferTest {
+
+    private lateinit var differ: MetamodelDiffer
+    private lateinit var declaredObservedDiffer: DeclaredObservedDiffer
+
+    @BeforeEach
+    fun setUp() {
+        val structural = StructuralMetamodelDiffer()
+        differ = structural
+        declaredObservedDiffer = structural
+    }
+
+    private fun schemaWith(name: String = "test", vararg typeNames: String): DataDictionary =
+        DataDictionary.fromDomainTypes(name, typeNames.map { DynamicType(name = it) })
+
+    @Nested
+    inner class NoChanges {
+
+        @Test
+        fun `identical schemas produce an empty diff`() {
+            val old = schemaWith(typeNames = arrayOf("Person", "Company"))
+            val new = schemaWith(typeNames = arrayOf("Person", "Company"))
+            val diff = differ.diff(old, new)
+            assertTrue(diff.isEmpty)
+            assertTrue(diff.changes.isEmpty())
+        }
+
+        @Test
+        fun `empty schemas produce an empty diff`() {
+            val diff = differ.diff(schemaWith(), schemaWith())
+            assertTrue(diff.isEmpty)
+        }
+    }
+
+    @Nested
+    inner class AddedTypes {
+
+        @Test
+        fun `added entity type is reported`() {
+            val old = schemaWith(typeNames = arrayOf("Person"))
+            val new = schemaWith(typeNames = arrayOf("Person", "Company"))
+            val diff = differ.diff(old, new)
+            assertFalse(diff.isEmpty)
+            val added = diff.addedEntityTypes
+            assertTrue(added.contains("Company"), "Expected Company in added: $added")
+            assertFalse(diff.removedEntityTypes.contains("Company"))
+        }
+
+        @Test
+        fun `multiple added types are all reported`() {
+            val old = schemaWith(typeNames = arrayOf("Person"))
+            val new = schemaWith(typeNames = arrayOf("Person", "Company", "Technology"))
+            val diff = differ.diff(old, new)
+            assertEquals(setOf("Company", "Technology"), diff.addedEntityTypes)
+        }
+    }
+
+    @Nested
+    inner class RemovedTypes {
+
+        @Test
+        fun `removed entity type is reported`() {
+            val old = schemaWith(typeNames = arrayOf("Person", "LegacyType"))
+            val new = schemaWith(typeNames = arrayOf("Person"))
+            val diff = differ.diff(old, new)
+            assertFalse(diff.isEmpty)
+            assertTrue(diff.removedEntityTypes.contains("LegacyType"),
+                "Expected LegacyType in removed: ${diff.removedEntityTypes}")
+        }
+
+        @Test
+        fun `multiple removed types are all reported`() {
+            val old = schemaWith(typeNames = arrayOf("Person", "Foo", "Bar"))
+            val new = schemaWith(typeNames = arrayOf("Person"))
+            val diff = differ.diff(old, new)
+            assertEquals(setOf("Foo", "Bar"), diff.removedEntityTypes)
+        }
+
+        @Test
+        fun `removed type does not appear in added set`() {
+            val old = schemaWith(typeNames = arrayOf("Person", "OldType"))
+            val new = schemaWith(typeNames = arrayOf("Person"))
+            val diff = differ.diff(old, new)
+            assertFalse(diff.addedEntityTypes.contains("OldType"))
+        }
+    }
+
+    @Nested
+    inner class MixedChanges {
+
+        @Test
+        fun `simultaneous add and remove are both captured`() {
+            val old = schemaWith(typeNames = arrayOf("Person", "LegacyType"))
+            val new = schemaWith(typeNames = arrayOf("Person", "NewType"))
+            val diff = differ.diff(old, new)
+            assertTrue(diff.removedEntityTypes.contains("LegacyType"))
+            assertTrue(diff.addedEntityTypes.contains("NewType"))
+        }
+    }
+
+    @Nested
+    inner class ModifiedTypes {
+
+        /** A schema with a single `Person` type whose labels include the given parent's label. */
+        private fun personWithParent(parent: String): DataDictionary =
+            DataDictionary.fromDomainTypes(
+                "test",
+                listOf(DynamicType(name = "Person", parents = listOf(DynamicType(name = parent)))),
+            )
+
+        @Test
+        fun `a label change on a same-named type is reported as modified, not add or remove`() {
+            val old = personWithParent("Agent")   // labels: {Person, Agent}
+            val new = personWithParent("Actor")   // labels: {Person, Actor}
+            val diff = differ.diff(old, new)
+
+            assertFalse(diff.isEmpty)
+            assertTrue(diff.addedEntityTypes.isEmpty(), "no type was added: ${diff.addedEntityTypes}")
+            assertTrue(diff.removedEntityTypes.isEmpty(), "no type was removed: ${diff.removedEntityTypes}")
+
+            val modified = diff.modifiedEntityTypes
+            assertEquals(1, modified.size, "expected exactly one modified type: $modified")
+            val change = modified.single()
+            assertEquals("Person", change.typeName)
+            assertEquals(setOf("Actor"), change.addedLabels)
+            assertEquals(setOf("Agent"), change.removedLabels)
+        }
+
+        @Test
+        fun `unchanged labels yield no modified entry`() {
+            val diff = differ.diff(personWithParent("Agent"), personWithParent("Agent"))
+            assertTrue(diff.isEmpty)
+            assertTrue(diff.modifiedEntityTypes.isEmpty())
+        }
+
+        /** A schema with a single `Person` type carrying the given property names. */
+        private fun personWithProperties(vararg props: String): DataDictionary =
+            DataDictionary.fromDomainTypes(
+                "test",
+                listOf(DynamicType(name = "Person", ownProperties = props.map { ValuePropertyDefinition(it) })),
+            )
+
+        @Test
+        fun `a property change on a same-named type is reported as modified`() {
+            val old = personWithProperties("age")
+            val new = personWithProperties("age", "email")
+            val diff = differ.diff(old, new)
+
+            assertFalse(diff.isEmpty)
+            assertTrue(diff.addedEntityTypes.isEmpty())
+            assertTrue(diff.removedEntityTypes.isEmpty())
+
+            val change = diff.modifiedEntityTypes.single()
+            assertEquals("Person", change.typeName)
+            assertEquals(setOf("email"), change.addedProperties)
+            assertTrue(change.removedProperties.isEmpty())
+            // labels are unchanged, so their deltas stay empty
+            assertTrue(change.addedLabels.isEmpty())
+            assertTrue(change.removedLabels.isEmpty())
+        }
+
+        @Test
+        fun `simultaneous label and property change are captured in one modified entry`() {
+            val old = DataDictionary.fromDomainTypes(
+                "test",
+                listOf(
+                    DynamicType(
+                        name = "Person",
+                        ownProperties = listOf(ValuePropertyDefinition("age")),
+                        parents = listOf(DynamicType(name = "Agent")),
+                    ),
+                ),
+            )
+            val new = DataDictionary.fromDomainTypes(
+                "test",
+                listOf(
+                    DynamicType(
+                        name = "Person",
+                        ownProperties = listOf(ValuePropertyDefinition("email")),
+                        parents = listOf(DynamicType(name = "Actor")),
+                    ),
+                ),
+            )
+            val change = differ.diff(old, new).modifiedEntityTypes.single()
+            assertEquals("Person", change.typeName)
+            assertEquals(setOf("Actor"), change.addedLabels)
+            assertEquals(setOf("Agent"), change.removedLabels)
+            assertEquals(setOf("email"), change.addedProperties)
+            assertEquals(setOf("age"), change.removedProperties)
+        }
+    }
+
+    @Nested
+    inner class VersionOverload {
+
+        @Test
+        fun `MetamodelVersion overload produces same result as DataDictionary overload`() {
+            val old = schemaWith(typeNames = arrayOf("Person", "Removed"))
+            val new = schemaWith(typeNames = arrayOf("Person", "Added"))
+            val fromVersions = differ.diff(MetamodelVersion.from(old), MetamodelVersion.from(new))
+            val fromDicts = differ.diff(old, new)
+            assertEquals(fromVersions.removedEntityTypes, fromDicts.removedEntityTypes)
+            assertEquals(fromVersions.addedEntityTypes, fromDicts.addedEntityTypes)
+        }
+    }
+
+    @Nested
+    inner class DelimiterSafetyInNames {
+
+        /**
+         * A label name that contains a comma — possible when names come from LLM extraction.
+         * The diff compares label sets directly, so punctuation in a name is just a character;
+         * the change is still detected and the label comes back as one entry, not split.
+         */
+        @Test
+        fun `label containing a comma is treated as a single label`() {
+            // A parent whose name happens to contain a comma (e.g. from free-text extraction).
+            val commaParent = DynamicType(name = "foo,bar")
+            val old = DataDictionary.fromDomainTypes(
+                "test",
+                listOf(DynamicType(name = "Person", parents = listOf(commaParent))),
+            )
+            val new = DataDictionary.fromDomainTypes(
+                "test",
+                listOf(DynamicType(name = "Person")),
+            )
+            val diff = differ.diff(old, new)
+
+            // The comma-bearing label was removed; it must come back as one entry, not split in two.
+            val change = diff.modifiedEntityTypes.single()
+            assertEquals(1, change.removedLabels.size)
+            assertTrue(change.removedLabels.single().contains(","))
+            assertTrue(change.addedLabels.isEmpty())
+        }
+
+        /**
+         * Property names can contain spaces when they come from free-text / LLM extraction.
+         * The two sets `{"a", "b c"}` and `{"a b", "c"}` are genuinely different, yet both
+         * collapse to the string "a b c" if you compare a space-joined projection instead of
+         * the sets themselves. A real property change must never be hidden by that collision.
+         */
+        @Test
+        fun `property sets that collide under a space delimiter are still reported as modified`() {
+            val old = DataDictionary.fromDomainTypes(
+                "test",
+                listOf(
+                    DynamicType(
+                        name = "Person",
+                        ownProperties = listOf(ValuePropertyDefinition("a"), ValuePropertyDefinition("b c")),
+                    ),
+                ),
+            )
+            val new = DataDictionary.fromDomainTypes(
+                "test",
+                listOf(
+                    DynamicType(
+                        name = "Person",
+                        ownProperties = listOf(ValuePropertyDefinition("a b"), ValuePropertyDefinition("c")),
+                    ),
+                ),
+            )
+            val diff = differ.diff(old, new)
+
+            assertFalse(diff.isEmpty, "a real property change must not be hidden by a delimiter collision")
+            val change = diff.modifiedEntityTypes.single()
+            assertEquals("Person", change.typeName)
+            assertEquals(setOf("a b", "c"), change.addedProperties)
+            assertEquals(setOf("a", "b c"), change.removedProperties)
+        }
+    }
+
+    @Nested
+    inner class DeclaredVsObserved {
+
+        private fun declared(vararg typeNames: String, relationshipNames: List<String> = emptyList()): MetamodelVersion =
+            MetamodelVersion(
+                schemaName = "test",
+                entityTypeNames = typeNames.toList(),
+                entityTypeLabels = typeNames.associateWith { setOf(it) },
+                entityTypeProperties = typeNames.associateWith { emptySet() },
+                relationshipNames = relationshipNames,
+            )
+
+        private fun observed(
+            entityTypeNames: Set<String>,
+            relationshipTypeNames: Set<String> = emptySet(),
+        ): ObservedSchema =
+            ObservedSchema(
+                entityTypeNames = entityTypeNames,
+                relationshipTypeNames = relationshipTypeNames,
+                capturedAt = Instant.parse("2026-01-01T00:00:00Z"),
+            )
+
+        /**
+         * Thin wrapper so most tests don't have to spell out an empty relationship-name set:
+         * [DeclaredObservedDiffer.diffAgainstObserved] takes the declared bare relationship type
+         * names as an explicit parameter (never parsed out of a rendered descriptor — see the
+         * interface doc and the `RelationshipNameParsing` tests below for why).
+         */
+        private fun diffAgainstObserved(
+            declaredVersion: MetamodelVersion,
+            observedSchema: ObservedSchema,
+            declaredRelationshipTypeNames: Set<String> = emptySet(),
+        ) = declaredObservedDiffer.diffAgainstObserved(declaredVersion, declaredRelationshipTypeNames, observedSchema)
+
+        @Test
+        fun `an observed type with no declaration is reported as drift`() {
+            val diff = diffAgainstObserved(
+                declared("Person"),
+                observed(entityTypeNames = setOf("Person", "GhostIntegrationType")),
+            )
+            assertTrue(diff.hasDrift)
+            assertEquals(setOf("GhostIntegrationType"), diff.driftedEntityTypes)
+        }
+
+        @Test
+        fun `a declared type with zero observed instances is not drift`() {
+            val diff = diffAgainstObserved(
+                declared("Person", "NeverSeenYet"),
+                observed(entityTypeNames = setOf("Person")),
+            )
+            assertFalse(diff.hasDrift, "absence of a declared type must not count as drift")
+            assertTrue(diff.driftedEntityTypes.isEmpty())
+            assertEquals(setOf("NeverSeenYet"), diff.unobservedEntityTypes)
+        }
+
+        @Test
+        fun `matching declared and observed types produce no drift and nothing unobserved`() {
+            val diff = diffAgainstObserved(
+                declared("Person", "Company"),
+                observed(entityTypeNames = setOf("Person", "Company")),
+            )
+            assertFalse(diff.hasDrift)
+            assertTrue(diff.driftedEntityTypes.isEmpty())
+            assertTrue(diff.unobservedEntityTypes.isEmpty())
+        }
+
+        @Test
+        fun `drift and unobserved can both be present at once and don't overlap`() {
+            val diff = diffAgainstObserved(
+                declared("Person", "NeverSeenYet"),
+                observed(entityTypeNames = setOf("Person", "GhostIntegrationType")),
+            )
+            assertEquals(setOf("GhostIntegrationType"), diff.driftedEntityTypes)
+            assertEquals(setOf("NeverSeenYet"), diff.unobservedEntityTypes)
+        }
+
+        @Test
+        fun `relationship drift is compared on the bare relationship type name, not the full descriptor`() {
+            // Declared descriptors carry from/to node types; an observed graph only reports
+            // bare relationship type names (e.g. via a `db.relationshipTypes()`-style query).
+            val diff = diffAgainstObserved(
+                declared("Person", "Company", relationshipNames = listOf("Person-[WORKS_AT]->Company")),
+                observed(
+                    entityTypeNames = setOf("Person", "Company"),
+                    relationshipTypeNames = setOf("WORKS_AT"),
+                ),
+                declaredRelationshipTypeNames = setOf("WORKS_AT"),
+            )
+            assertFalse(diff.hasDrift, "a declared relationship must not be reported as drift just because " +
+                "its bare name matches")
+            assertTrue(diff.driftedRelationshipTypes.isEmpty())
+            assertTrue(diff.unobservedRelationshipTypes.isEmpty())
+        }
+
+        @Test
+        fun `an observed relationship type with no declaration is reported as drift`() {
+            val diff = diffAgainstObserved(
+                declared("Person", relationshipNames = emptyList()),
+                observed(entityTypeNames = setOf("Person"), relationshipTypeNames = setOf("GHOST_REL")),
+            )
+            assertTrue(diff.hasDrift)
+            assertEquals(setOf("GHOST_REL"), diff.driftedRelationshipTypes)
+        }
+
+        @Test
+        fun `diff carries the declared version and observed schema unchanged`() {
+            val declaredVersion = declared("Person")
+            val observedSchema = observed(entityTypeNames = setOf("Person"))
+            val diff = diffAgainstObserved(declaredVersion, observedSchema)
+            assertEquals(declaredVersion, diff.declaredVersion)
+            assertEquals(observedSchema, diff.observedSchema)
+        }
+    }
+
+    @Nested
+    inner class RelationshipNameParsing {
+
+        private fun declared(vararg typeNames: String, relationshipNames: List<String>): MetamodelVersion =
+            MetamodelVersion(
+                schemaName = "test",
+                entityTypeNames = typeNames.toList(),
+                entityTypeLabels = typeNames.associateWith { setOf(it) },
+                entityTypeProperties = typeNames.associateWith { emptySet() },
+                relationshipNames = relationshipNames,
+            )
+
+        private fun observed(entityTypeNames: Set<String>, relationshipTypeNames: Set<String>): ObservedSchema =
+            ObservedSchema(
+                entityTypeNames = entityTypeNames,
+                relationshipTypeNames = relationshipTypeNames,
+                capturedAt = Instant.parse("2026-01-01T00:00:00Z"),
+            )
+
+        /**
+         * A relationship name embedding a `-[...]->`-shaped substring — the exact case a
+         * previous implementation got wrong: it recovered the bare name by regex-matching the
+         * rendered `From-[name]->To` descriptor, and a greedy `.*-\[(.+)]->.*` pattern backtracks
+         * to the *last* such substring. Concretely, `"A-[X]->B-[Y]->C"` parsed to `"Y"`, not `"X"`.
+         * Since relationship (and entity) names are free-text / LLM-derived, a name shaped like
+         * `"A-[X]->B"` is realistic, not contrived. The fix passes the bare name in directly
+         * instead of ever parsing a descriptor, so this must classify correctly regardless of
+         * what the name looks like.
+         */
+        @Test
+        fun `a relationship name shaped like a full descriptor is matched by its bare name, not reverse-parsed`() {
+            val trickyRelName = "A-[X]->B"
+            val diff = declaredObservedDiffer.diffAgainstObserved(
+                declared("Foo", "Bar", relationshipNames = listOf("Foo-[$trickyRelName]->Bar")),
+                declaredRelationshipTypeNames = setOf(trickyRelName),
+                observed(
+                    entityTypeNames = setOf("Foo", "Bar"),
+                    relationshipTypeNames = setOf(trickyRelName),
+                ),
+            )
+            assertFalse(diff.hasDrift, "the declared relationship must match the observed one by its full, " +
+                "unambiguous bare name, despite the tricky shape")
+            assertTrue(diff.driftedRelationshipTypes.isEmpty())
+            assertTrue(diff.unobservedRelationshipTypes.isEmpty())
+        }
+
+        /**
+         * The inverse check: if a naive regex-based extraction were reintroduced, it would parse
+         * `"Foo-[A-[X]->B]->Bar"` down to just `"B"` (or some other wrong substring), which would
+         * spuriously "match" a differently-named observed relationship. Observing the substring a
+         * greedy parse would have wrongly extracted must NOT be treated as a match — it must show
+         * up as both an unmatched observed relationship (drift) and an unmatched declared one
+         * (unobserved).
+         */
+        @Test
+        fun `an observed relationship type equal to a substring of the declared tricky name is not treated as a match`() {
+            val trickyRelName = "A-[X]->B"
+            val diff = declaredObservedDiffer.diffAgainstObserved(
+                declared("Foo", "Bar", relationshipNames = listOf("Foo-[$trickyRelName]->Bar")),
+                declaredRelationshipTypeNames = setOf(trickyRelName),
+                observed(
+                    entityTypeNames = setOf("Foo", "Bar"),
+                    relationshipTypeNames = setOf("X"),
+                ),
+            )
+            assertTrue(diff.hasDrift, "observed 'X' must not be confused with the declared '$trickyRelName'")
+            assertEquals(setOf("X"), diff.driftedRelationshipTypes)
+            assertEquals(setOf(trickyRelName), diff.unobservedRelationshipTypes)
+        }
+    }
+}

--- a/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/MetamodelVersionTest.kt
+++ b/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/MetamodelVersionTest.kt
@@ -92,6 +92,123 @@ class MetamodelVersionTest {
         }
 
         @Test
+        fun `constructor takes an immutable snapshot of caller-owned collections`() {
+            val typeNames = mutableListOf("A")
+            val labels = mutableMapOf<String, Set<String>>("A" to mutableSetOf("A"))
+            val properties = mutableMapOf<String, Set<String>>("A" to mutableSetOf("name"))
+            val relationships = mutableListOf("A-[KNOWS]->A")
+            val version = MetamodelVersion(
+                schemaName = "s",
+                entityTypeNames = typeNames,
+                entityTypeLabels = labels,
+                entityTypeProperties = properties,
+                relationshipNames = relationships,
+            )
+            val originalHash = version.contentHash
+
+            typeNames += "B"
+            (labels.getValue("A") as MutableSet<String>) += "Agent"
+            labels["B"] = mutableSetOf("B")
+            (properties.getValue("A") as MutableSet<String>) += "email"
+            relationships += "A-[LIKES]->B"
+
+            assertEquals(listOf("A"), version.entityTypeNames)
+            assertEquals(mapOf("A" to setOf("A")), version.entityTypeLabels)
+            assertEquals(mapOf("A" to setOf("name")), version.entityTypeProperties)
+            assertEquals(listOf("A-[KNOWS]->A"), version.relationshipNames)
+            assertEquals(originalHash, version.contentHash)
+            assertThrows(UnsupportedOperationException::class.java) {
+                (version.entityTypeNames as MutableList<String>) += "B"
+            }
+            assertThrows(UnsupportedOperationException::class.java) {
+                (version.entityTypeLabels.getValue("A") as MutableSet<String>) += "Agent"
+            }
+        }
+
+        @Test
+        fun `constructor rejects shape maps for absent entity types`() {
+            val error = assertThrows(IllegalArgumentException::class.java) {
+                MetamodelVersion(
+                    schemaName = "s",
+                    entityTypeNames = listOf("A"),
+                    entityTypeLabels = mapOf("A" to setOf("A"), "B" to setOf("B")),
+                    entityTypeProperties = mapOf("A" to emptySet()),
+                    relationshipNames = emptyList(),
+                )
+            }
+
+            assertTrue(error.message.orEmpty().contains("entityTypeLabels"))
+        }
+
+        @Test
+        fun `copy requires labels and properties to remain aligned with entity type names`() {
+            val version = MetamodelVersion(
+                schemaName = "s",
+                entityTypeNames = listOf("A", "B"),
+                entityTypeLabels = mapOf("A" to setOf("A"), "B" to setOf("B")),
+                entityTypeProperties = mapOf("A" to emptySet(), "B" to emptySet()),
+                relationshipNames = emptyList(),
+            )
+
+            assertThrows(IllegalArgumentException::class.java) {
+                version.copy(entityTypeNames = listOf("A"))
+            }
+            val aligned = version.copy(
+                entityTypeNames = listOf("A"),
+                entityTypeLabels = mapOf("A" to setOf("A")),
+                entityTypeProperties = mapOf("A" to emptySet()),
+            )
+            assertEquals(listOf("A"), aligned.entityTypeNames)
+        }
+
+        @Test
+        fun `value semantics match the former data class contract`() {
+            val one = MetamodelVersion(
+                schemaName = "s",
+                entityTypeNames = listOf("B", "A"),
+                entityTypeLabels = mapOf("A" to setOf("A"), "B" to setOf("B")),
+                entityTypeProperties = mapOf("A" to emptySet(), "B" to setOf("name")),
+                relationshipNames = listOf("B-[KNOWS]->A"),
+            )
+            val two = MetamodelVersion(
+                schemaName = "s",
+                entityTypeNames = listOf("A", "B"),
+                entityTypeLabels = mapOf("B" to setOf("B"), "A" to setOf("A")),
+                entityTypeProperties = mapOf("B" to setOf("name"), "A" to emptySet()),
+                relationshipNames = listOf("B-[KNOWS]->A"),
+            )
+
+            assertEquals(one, two)
+            assertEquals(one.hashCode(), two.hashCode())
+            assertEquals(one, one.copy())
+            assertEquals("s", one.component1())
+            assertEquals(listOf("A", "B"), one.component2())
+            assertTrue(one.toString().startsWith("MetamodelVersion(schemaName=s"))
+        }
+
+        @Test
+        fun `constructor sorting does not deduplicate persisted hash input`() {
+            val duplicated = MetamodelVersion(
+                schemaName = "s",
+                entityTypeNames = listOf("A", "A"),
+                entityTypeLabels = mapOf("A" to setOf("A")),
+                entityTypeProperties = mapOf("A" to emptySet()),
+                relationshipNames = listOf("A-[KNOWS]->A", "A-[KNOWS]->A"),
+            )
+            val single = MetamodelVersion(
+                schemaName = "s",
+                entityTypeNames = listOf("A"),
+                entityTypeLabels = mapOf("A" to setOf("A")),
+                entityTypeProperties = mapOf("A" to emptySet()),
+                relationshipNames = listOf("A-[KNOWS]->A"),
+            )
+
+            assertEquals(listOf("A", "A"), duplicated.entityTypeNames)
+            assertEquals(2, duplicated.relationshipNames.size)
+            assertNotEquals(single.contentHash, duplicated.contentHash)
+        }
+
+        @Test
         fun `same types under different schema names produce the same hash`() {
             // contentHash covers structural content only; the schema name is excluded so that
             // dev/prod variants of the same schema compare as equal.

--- a/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/MetamodelVersionTest.kt
+++ b/dice-metamodel/src/test/kotlin/com/embabel/dice/metamodel/MetamodelVersionTest.kt
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.metamodel
+
+import com.embabel.agent.core.DataDictionary
+import com.embabel.agent.core.DomainTypePropertyDefinition
+import com.embabel.agent.core.DynamicType
+import com.embabel.agent.core.ValuePropertyDefinition
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class MetamodelVersionTest {
+
+    private fun schemaWith(vararg typeNames: String): DataDictionary =
+        DataDictionary.fromDomainTypes(
+            "test",
+            typeNames.map { DynamicType(name = it) },
+        )
+
+    @Nested
+    inner class ContentHash {
+
+        @Test
+        fun `identical schemas produce the same hash`() {
+            val a = MetamodelVersion.from(schemaWith("Person", "Company"))
+            val b = MetamodelVersion.from(schemaWith("Person", "Company"))
+            assertEquals(a.contentHash, b.contentHash)
+            assertTrue(a.hasSameContentAs(b))
+        }
+
+        @Test
+        fun `different type sets produce different hashes`() {
+            val a = MetamodelVersion.from(schemaWith("Person", "Company"))
+            val b = MetamodelVersion.from(schemaWith("Person", "Technology"))
+            assertNotEquals(a.contentHash, b.contentHash)
+            assertFalse(a.hasSameContentAs(b))
+        }
+
+        @Test
+        fun `type order does not affect hash`() {
+            val a = MetamodelVersion.from(schemaWith("Company", "Person"))
+            val b = MetamodelVersion.from(schemaWith("Person", "Company"))
+            assertEquals(a.contentHash, b.contentHash)
+        }
+
+        @Test
+        fun `adding a type changes the hash`() {
+            val base = MetamodelVersion.from(schemaWith("Person"))
+            val extended = MetamodelVersion.from(schemaWith("Person", "Company"))
+            assertNotEquals(base.contentHash, extended.contentHash)
+        }
+
+        @Test
+        fun `empty schema has a stable hash`() {
+            val a = MetamodelVersion.from(schemaWith())
+            val b = MetamodelVersion.from(schemaWith())
+            assertEquals(a.contentHash, b.contentHash)
+        }
+
+        @Test
+        fun `a caller cannot supply the hash — it is always derived from the content`() {
+            // The whole point of deriving it: two versions that differ structurally can never claim
+            // the same hash, because there is no way to hand one in.
+            val one = MetamodelVersion(
+                schemaName = "s",
+                entityTypeNames = listOf("A"),
+                entityTypeLabels = mapOf("A" to setOf("A")),
+                entityTypeProperties = mapOf("A" to emptySet()),
+                relationshipNames = emptyList(),
+            )
+            val two = one.copy(
+                entityTypeNames = listOf("A", "B"),
+                entityTypeLabels = mapOf("A" to setOf("A"), "B" to setOf("B")),
+                entityTypeProperties = mapOf("A" to emptySet(), "B" to emptySet()),
+            )
+            assertNotEquals(one.contentHash, two.contentHash)
+            assertFalse(one.hasSameContentAs(two))
+        }
+
+        @Test
+        fun `same types under different schema names produce the same hash`() {
+            // contentHash covers structural content only; the schema name is excluded so that
+            // dev/prod variants of the same schema compare as equal.
+            val a = MetamodelVersion.from(
+                DataDictionary.fromDomainTypes("schema-dev", listOf(DynamicType("Person")))
+            )
+            val b = MetamodelVersion.from(
+                DataDictionary.fromDomainTypes("schema-prod", listOf(DynamicType("Person")))
+            )
+            assertEquals(a.contentHash, b.contentHash)
+            assertTrue(a.hasSameContentAs(b))
+        }
+    }
+
+    @Nested
+    inner class GoldenHash {
+
+        /**
+         * A fixed schema whose every hashed ingredient is spelled out: two type names, one label
+         * apiece, three properties on one of them, and one relationship.
+         */
+        private fun goldenSchema(): DataDictionary {
+            val company = DynamicType(name = "Company")
+            val person = DynamicType(
+                name = "Person",
+                ownProperties = listOf(
+                    ValuePropertyDefinition("age"),
+                    ValuePropertyDefinition("email"),
+                    DomainTypePropertyDefinition("worksAt", company),
+                ),
+            )
+            return DataDictionary.fromDomainTypes("golden-schema", listOf(person, company))
+        }
+
+        @Test
+        fun `the fixture hashes exactly these ingredients`() {
+            // Guards the golden vector below: if this fails, the fixture changed, not the format.
+            val version = MetamodelVersion.from(goldenSchema())
+            assertEquals(listOf("Company", "Person"), version.entityTypeNames)
+            assertEquals(setOf("Company"), version.entityTypeLabels["Company"])
+            assertEquals(setOf("Person"), version.entityTypeLabels["Person"])
+            assertEquals(emptySet<String>(), version.entityTypeProperties["Company"])
+            assertEquals(setOf("age", "email", "worksAt"), version.entityTypeProperties["Person"])
+            assertEquals(listOf("Person-[worksAt]->Company"), version.relationshipNames)
+        }
+
+        @Test
+        fun `golden vector — the digest of a fixed schema is pinned to a literal`() {
+            // This literal is the persisted hash format, deliberately frozen. contentHash is the
+            // store's MERGE key and every DriftReport records it as versionHash, so changing how
+            // the fingerprint is encoded orphans every report already on disk. If you mean to
+            // change the format, change this literal in the same commit and plan the migration —
+            // do not "fix" the test by pasting in whatever the new code produces.
+            assertEquals(
+                "17e3a63380fe1871ec4944918521022c381dea0e314ee7518515391ecfb73ab9",
+                MetamodelVersion.from(goldenSchema()).contentHash,
+            )
+        }
+
+        @Test
+        fun `the golden digest does not depend on the schema name`() {
+            val renamed = DataDictionary.fromDomainTypes("some-other-name", goldenSchema().domainTypes)
+            assertEquals(
+                "17e3a63380fe1871ec4944918521022c381dea0e314ee7518515391ecfb73ab9",
+                MetamodelVersion.from(renamed).contentHash,
+            )
+        }
+    }
+
+    @Nested
+    inner class RelationshipDrift {
+
+        /** Same types and properties throughout; only the relationship list varies. */
+        private fun versionWithRelationships(vararg relationshipNames: String): MetamodelVersion =
+            MetamodelVersion(
+                schemaName = "test",
+                entityTypeNames = listOf("Company", "Person"),
+                entityTypeLabels = mapOf("Company" to setOf("Company"), "Person" to setOf("Person")),
+                entityTypeProperties = mapOf("Company" to emptySet(), "Person" to emptySet()),
+                relationshipNames = relationshipNames.toList(),
+            )
+
+        @Test
+        fun `adding a relationship changes the hash`() {
+            val before = versionWithRelationships()
+            val after = versionWithRelationships("Person-[WORKS_AT]->Company")
+            assertNotEquals(before.contentHash, after.contentHash)
+            assertFalse(before.hasSameContentAs(after))
+        }
+
+        @Test
+        fun `removing one relationship of two changes the hash`() {
+            val both = versionWithRelationships("Person-[WORKS_AT]->Company", "Person-[FOUNDED]->Company")
+            val one = versionWithRelationships("Person-[WORKS_AT]->Company")
+            assertNotEquals(both.contentHash, one.contentHash)
+        }
+
+        @Test
+        fun `relationship order does not affect the hash`() {
+            val a = versionWithRelationships("Person-[WORKS_AT]->Company", "Person-[FOUNDED]->Company")
+            val b = versionWithRelationships("Person-[FOUNDED]->Company", "Person-[WORKS_AT]->Company")
+            assertEquals(a.contentHash, b.contentHash)
+            assertTrue(a.hasSameContentAs(b))
+        }
+
+        @Test
+        fun `dropping a relationship property from a dictionary changes the hash end to end`() {
+            val company = DynamicType(name = "Company")
+            val withRelationship = DataDictionary.fromDomainTypes(
+                "test",
+                listOf(
+                    DynamicType(
+                        name = "Person",
+                        ownProperties = listOf(DomainTypePropertyDefinition("worksAt", company)),
+                    ),
+                    company,
+                ),
+            )
+            val withoutRelationship = DataDictionary.fromDomainTypes(
+                "test",
+                listOf(DynamicType(name = "Person"), company),
+            )
+
+            val before = MetamodelVersion.from(withRelationship)
+            val after = MetamodelVersion.from(withoutRelationship)
+
+            assertEquals(listOf("Person-[worksAt]->Company"), before.relationshipNames)
+            assertEquals(emptyList<String>(), after.relationshipNames)
+            assertNotEquals(before.contentHash, after.contentHash)
+        }
+    }
+
+    @Nested
+    inner class VersionMetadata {
+
+        @Test
+        fun `entity type names are sorted`() {
+            val version = MetamodelVersion.from(schemaWith("Zebra", "Apple", "Mango"))
+            assertEquals(listOf("Apple", "Mango", "Zebra"), version.entityTypeNames)
+        }
+
+        @Test
+        fun `schema name is captured`() {
+            val dict = DataDictionary.fromDomainTypes("my-schema", listOf(DynamicType("Person")))
+            val version = MetamodelVersion.from(dict)
+            assertEquals("my-schema", version.schemaName)
+        }
+
+        @Test
+        fun `per-type label sets are captured including inherited labels`() {
+            val dict = DataDictionary.fromDomainTypes(
+                "test",
+                listOf(DynamicType(name = "Person", parents = listOf(DynamicType(name = "Agent")))),
+            )
+            val version = MetamodelVersion.from(dict)
+            assertEquals(setOf("Person", "Agent"), version.entityTypeLabels["Person"])
+        }
+
+        @Test
+        fun `per-type property sets are captured`() {
+            val dict = DataDictionary.fromDomainTypes(
+                "test",
+                listOf(
+                    DynamicType(
+                        name = "Person",
+                        ownProperties = listOf(ValuePropertyDefinition("age"), ValuePropertyDefinition("email")),
+                    ),
+                ),
+            )
+            val version = MetamodelVersion.from(dict)
+            assertEquals(setOf("age", "email"), version.entityTypeProperties["Person"])
+        }
+
+        @Test
+        fun `same-named types with different shapes are merged, not dropped`() {
+            // A DataDictionary can hold two "Person" types with different shapes. The fingerprint
+            // must union both, never silently keep only the last — otherwise a label or property
+            // would disappear from the hash and its later removal would go undetected.
+            val dict = DataDictionary.fromDomainTypes(
+                "test",
+                listOf(
+                    DynamicType(
+                        name = "Person",
+                        parents = listOf(DynamicType(name = "Agent")),
+                        ownProperties = listOf(ValuePropertyDefinition("age")),
+                    ),
+                    DynamicType(
+                        name = "Person",
+                        parents = listOf(DynamicType(name = "Robot")),
+                        ownProperties = listOf(ValuePropertyDefinition("email")),
+                    ),
+                ),
+            )
+            val version = MetamodelVersion.from(dict)
+            assertEquals(setOf("Person", "Agent", "Robot"), version.entityTypeLabels["Person"])
+            assertEquals(setOf("age", "email"), version.entityTypeProperties["Person"])
+            // The name is deduped in the sorted name list, not repeated.
+            assertEquals(listOf("Person"), version.entityTypeNames)
+        }
+    }
+
+    @Nested
+    inner class LabelDrift {
+
+        /** Same type name, but a different parent — so the label set differs while the name does not. */
+        private fun personWithParent(parent: String): DataDictionary =
+            DataDictionary.fromDomainTypes(
+                "test",
+                listOf(DynamicType(name = "Person", parents = listOf(DynamicType(name = parent)))),
+            )
+
+        @Test
+        fun `a label-only change produces a different hash`() {
+            val a = MetamodelVersion.from(personWithParent("Agent"))
+            val b = MetamodelVersion.from(personWithParent("Actor"))
+            // The type name set is identical; only the label sets differ.
+            assertEquals(a.entityTypeNames, b.entityTypeNames)
+            assertNotEquals(a.contentHash, b.contentHash)
+            assertFalse(a.hasSameContentAs(b))
+        }
+
+        @Test
+        fun `identical label sets produce the same hash`() {
+            val a = MetamodelVersion.from(personWithParent("Agent"))
+            val b = MetamodelVersion.from(personWithParent("Agent"))
+            assertEquals(a.contentHash, b.contentHash)
+        }
+    }
+
+    @Nested
+    inner class PropertyDrift {
+
+        /** Same type name, but a different property set. */
+        private fun personWithProperties(vararg props: String): DataDictionary =
+            DataDictionary.fromDomainTypes(
+                "test",
+                listOf(DynamicType(name = "Person", ownProperties = props.map { ValuePropertyDefinition(it) })),
+            )
+
+        @Test
+        fun `a property-only change produces a different hash`() {
+            val a = MetamodelVersion.from(personWithProperties("age"))
+            val b = MetamodelVersion.from(personWithProperties("age", "email"))
+            assertEquals(a.entityTypeNames, b.entityTypeNames)
+            assertEquals(a.entityTypeLabels, b.entityTypeLabels)
+            assertNotEquals(a.contentHash, b.contentHash)
+            assertFalse(a.hasSameContentAs(b))
+        }
+
+        @Test
+        fun `identical property sets produce the same hash`() {
+            val a = MetamodelVersion.from(personWithProperties("age", "email"))
+            val b = MetamodelVersion.from(personWithProperties("email", "age"))
+            assertEquals(a.contentHash, b.contentHash)
+        }
+
+        @Test
+        fun `a property name containing the set delimiter does not collide with a split set`() {
+            // ["a;b"] and ["a", "b"] are genuinely different property sets. A delimiter-joined
+            // encoding would serialise both as "a;b;" and hash them identically, hiding a real
+            // (lossy) schema change. Length-prefixed encoding keeps them distinct.
+            val joined = MetamodelVersion.from(personWithProperties("a;b"))
+            val split = MetamodelVersion.from(personWithProperties("a", "b"))
+            assertNotEquals(joined.contentHash, split.contentHash)
+            assertFalse(joined.hasSameContentAs(split))
+        }
+    }
+}

--- a/docs/design/INDEX.md
+++ b/docs/design/INDEX.md
@@ -70,10 +70,13 @@ you need.
   layers, gated by an API-key filter.
 - [report.md](report.md) — `dice-report`'s pure projectors that turn queried propositions into
   human-facing artifacts: structured breakdowns, discovered links, LLM-generated rationale.
+- [metamodel-governance.md](metamodel-governance.md) — versioning the declared schema, detecting
+  drift between what a `DataDictionary` declares and what the live graph contains, and
+  quarantining propositions that reference undeclared types.
 
 ## Modules
 
-DICE ships as six Maven modules; [architecture.md](architecture.md#module-map) has the full
+DICE ships as seven Maven modules; [architecture.md](architecture.md#module-map) has the full
 dependency map. Quick pointer to where each is documented:
 
 | Module | Documented in |
@@ -81,6 +84,7 @@ dependency map. Quick pointer to where each is documented:
 | `dice` (core) | most notes above — propositions, pipeline, projections, hygiene, retrieval |
 | `dice-storage` | [durable-storage.md](durable-storage.md), [graph-projection.md](graph-projection.md), [prolog-projection.md](prolog-projection.md) |
 | `dice-storage-autoconfigure` | [durable-storage.md](durable-storage.md) |
+| `dice-metamodel` | [metamodel-governance.md](metamodel-governance.md) |
 | `dice-ingestion` | [ingestion.md](ingestion.md) |
 | `dice-report` | [report.md](report.md) |
 | `dice-integration-tests` | not separately documented — exercises the above end-to-end |

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -16,6 +16,7 @@ DICE is a multi-module Maven build. Each module's intent, and what it's allowed 
 | `dice-storage-autoconfigure` | Spring Boot autoconfiguration that wires `dice-storage`'s beans (repository, projectors, trust scorer) into a host application. Depends on `dice-storage`. |
 | `dice-ingestion` | Content-hash dedup ledger and source adapters that sit in front of `PropositionPipeline`, so the same artifact is never extracted twice concurrently. Depends on `dice`. |
 | `dice-report` | Rationale and structured report generation over propositions and their lineage. Depends on `dice`. |
+| `dice-metamodel` | Schema governance contracts: `MetamodelVersion` stamping, declared-vs-observed diffing, drift reports, quarantine policy. Pure JVM — no database driver, no Spring wiring. Depends on `dice`. |
 | `dice-integration-tests` | End-to-end tests exercising the real Neo4j backend and full pipeline across module boundaries. Depends on `dice`, `dice-ingestion`, `dice-report` (and transitively `dice-storage`). Not shipped. |
 
 ```mermaid
@@ -25,9 +26,11 @@ flowchart TB
     autoconf["dice-storage-autoconfigure<br/>(Spring Boot wiring)"]
     ingestion["dice-ingestion<br/>(dedup ledger)"]
     report["dice-report<br/>(rationale/reports)"]
+    metamodel["dice-metamodel<br/>(schema governance)"]
     itest["dice-integration-tests"]
 
     storage --> dice
+    metamodel --> dice
     autoconf --> storage
     ingestion --> dice
     report --> dice

--- a/docs/design/metamodel-governance.md
+++ b/docs/design/metamodel-governance.md
@@ -1,0 +1,380 @@
+# Metamodel governance: stamping a schema, watching it drift, quarantining the fallout
+
+DICE extracts entities and relationships against a metamodel — the entity types, their labels and
+properties, and the relationships allowed between them. That schema moves. It's edited as a domain
+is understood better, and it can quietly diverge from what a live graph actually holds, because an
+integration that used to declare a type can be switched off while its data stays behind. This note
+is about the decisions that let the schema move without poisoning stored knowledge. The types
+themselves are documented in `dice-metamodel`'s own guide; this note is the *why*.
+
+Two different comparisons live in this module, and keeping them apart is the first design decision:
+
+- **Declared vs. declared** (`MetamodelDiffer`) — two schema versions you chose, before and after a
+  migration. Symmetric: a list of changes.
+- **Declared vs. observed** (`DeclaredObservedDiffer`, `DriftCheckRunner`) — what you declared
+  against what the graph contains right now. Asymmetric: drift on one side, unobserved on the other.
+
+They answer different questions and have different result shapes, so they're different interfaces —
+folding the second into an overload of the first would leave every caller sifting a generic change
+list to work out which kind of disagreement it had. Both feed the same quarantine machinery, which is
+where they meet.
+
+## The contract family
+
+```mermaid
+classDiagram
+    class DeclaredSchemaSource {
+        <<interface>>
+        +declare() DeclaredSchema
+    }
+    class ObservedSchemaSource {
+        <<interface>>
+        +observe(contextId) ObservedSchema
+    }
+    class MetamodelDiffer {
+        <<interface>>
+        +diff(from, to) MetamodelDiff
+    }
+    class DeclaredObservedDiffer {
+        <<interface>>
+        +diffAgainstObserved(declared, declaredRelationshipTypeNames, observed) DeclaredObservedDiff
+    }
+    class DriftQuarantinePolicy {
+        <<interface>>
+        +evaluate(diff, propositions) QuarantineResult
+    }
+    class MetamodelStore {
+        <<interface>>
+        +saveVersion(version)
+        +latestVersion(schemaName) MetamodelVersion
+        +saveDriftReport(report)
+        +driftReports(schemaName) List
+        +globalDriftReports(schemaName) List
+        +driftReportsInContext(schemaName, contextId) List
+    }
+    class DriftCheckRunner {
+        <<interface>>
+        +run(dryRun, contextId) DriftCheckResult
+    }
+    class MetamodelVersion {
+        +schemaName String
+        +contentHash String
+        +entityTypeNames List
+        +entityTypeLabels Map
+        +entityTypeProperties Map
+        +relationshipNames List
+    }
+    class DeclaredSchema {
+        +version MetamodelVersion
+        +relationshipTypeNames Set
+    }
+    class ObservedSchema {
+        +entityTypeNames Set
+        +relationshipTypeNames Set
+        +capturedAt Instant
+    }
+    class MetamodelDiff {
+        +changes List
+        +removedEntityTypes Set
+        +modifiedEntityTypes List
+    }
+    class DeclaredObservedDiff {
+        +driftedEntityTypes Set
+        +driftedRelationshipTypes Set
+        +unobservedEntityTypes Set
+        +unobservedRelationshipTypes Set
+    }
+    class DriftReport {
+        +schemaName String
+        +versionHash String
+        +driftedEntityTypes Set
+        +driftedRelationshipTypes Set
+        +capturedAt Instant
+        +contextId ContextId
+    }
+    class StructuralMetamodelDiffer
+    class MentionTypeDriftQuarantinePolicy
+    DeclaredSchemaSource --> DeclaredSchema : produces
+    DeclaredSchema --> MetamodelVersion
+    ObservedSchemaSource --> ObservedSchema : produces
+    MetamodelDiffer --> MetamodelDiff
+    DeclaredObservedDiffer --> DeclaredObservedDiff
+    DriftQuarantinePolicy --> MetamodelDiff : reads
+    MetamodelStore --> MetamodelVersion
+    MetamodelStore --> DriftReport
+    DriftCheckRunner --> DeclaredSchemaSource
+    DriftCheckRunner --> ObservedSchemaSource
+    DriftCheckRunner --> DeclaredObservedDiffer
+    DriftCheckRunner --> MetamodelStore
+    DriftCheckRunner --> DriftQuarantinePolicy
+    MetamodelDiffer <|.. StructuralMetamodelDiffer
+    DeclaredObservedDiffer <|.. StructuralMetamodelDiffer
+    DriftQuarantinePolicy <|.. MentionTypeDriftQuarantinePolicy
+```
+
+Nothing on that diagram knows how to read a graph. `ObservedSchemaSource` and `MetamodelStore` are
+ports; the module holds value types, comparison logic, and the runner that sequences them. That's
+what lets a test hand the runner a canned `ObservedSchema` and exercise the whole loop with no
+database in sight.
+
+## Why a version is a content hash
+
+The live schema is mutable. What you store, compare, and stamp onto extracted data has to not be.
+`MetamodelVersion.from(dataDictionary)` takes an immutable snapshot — sorted entity type names, the
+full label and property set per type, sorted relationship descriptors — and fingerprints it as a
+SHA-256 `contentHash`. That stamp is the fixed point. A proposition can record which one it was
+extracted under via `DiceMetadataKeys.METAMODEL_VERSION` (`"dice.metamodel.version"`), which is how
+you later tell which stored knowledge a schema change actually touches.
+
+Two choices in the fingerprint carry weight.
+
+**The schema name is excluded.** Two structurally identical schemas hash identically no matter what
+they're called, so a dev environment and a prod environment compare cleanly. The cost is that
+`contentHash` alone can't tell two same-shaped schemas apart by name, which is why `MetamodelStore`
+keys on `(schemaName, contentHash)` together.
+
+**The hash is derived, not passed in.** `MetamodelVersion` computes it from its own structural
+fields; there is no constructor parameter for it. That's not tidiness — the hash is the store's
+MERGE key, what `hasSameContentAs` compares, and what every drift report records as its baseline. If
+a caller could supply it, two schemas with different types could claim the same hash, compare equal,
+and overwrite each other in storage.
+
+**Every name, label, and property is length-prefixed** (`<len>:<token>`) before hashing, and each set
+is preceded by its size. These names come from free-text and LLM extraction; they routinely contain
+`;`, `[`, `=`, and spaces. A delimiter-joined encoding would let `["a;b"]` and `["a", "b"]` produce
+the same digest — and a schema change that collapsed one into the other would be invisible. Losing a
+property silently is exactly the failure this whole module exists to catch, so the encoding is made
+unambiguous rather than merely tidy.
+
+One subtlety: a `DataDictionary` can legally hold two domain types sharing a name but differing in
+shape, so `from` unions their labels and properties per name rather than letting the last one win.
+Otherwise a label under that name never reaches the fingerprint, and removing it later wouldn't
+change the hash.
+
+## Additive is safe, lossy is not
+
+`StructuralMetamodelDiffer.diff` compares two stamps and enumerates what changed: `EntityTypeAdded`,
+`EntityTypeRemoved`, `EntityTypeModified` (the label and property deltas on a type whose name
+survived), `RelationshipAdded`, `RelationshipRemoved`. The diff isn't a summary or a boolean; it's
+the concrete input the quarantine step reads.
+
+The distinction that drives everything downstream is additive vs. lossy. Adding a type, label, or
+property invalidates nothing. Removing a type — or stripping labels or properties off a type that
+mentions relied on — can orphan references already in the graph. Only lossy changes reach quarantine.
+Sets are compared directly, never through a joined string projection, for the same escape-safety
+reason the hash is length-prefixed.
+
+## Observe and diff, don't gate the write
+
+The declared-vs-declared diff only fires when *you* change the schema. It says nothing about a graph
+that has accumulated data under a type nobody currently declares. `DriftCheckRunner` answers that
+second question, and it does it after the fact: snapshot what's really there, diff it against the
+declaration, record the result.
+
+The obvious alternative is rejecting undeclared types at write time, and it isn't the right first
+move. Extraction is LLM-driven, and a type nobody declared is often a real finding — refusing the
+write throws information away at the one moment it's cheap to keep and expensive to recover.
+Integrations come and go, so a graph holding types outside the current declaration is a normal state
+to *observe*, not an error to *prevent*. And an observer is safe to point at production: a dry run
+tells you what enforcement would have done before anything enforces it.
+
+Write-time gating is the known next step, not an oversight. The stamp and the diff are the pieces it
+needs; what's missing is a decision about what a rejected extraction should become.
+
+## One drift-check run
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Caller
+    participant Runner as DefaultDriftCheckRunner
+    participant OSS as ObservedSchemaSource
+    participant DSS as DeclaredSchemaSource
+    participant Differ as DeclaredObservedDiffer
+    participant Store as MetamodelStore
+    participant Policy as DriftQuarantinePolicy
+    participant Repo as PropositionRepository
+
+    Caller->>Runner: run(dryRun, contextId)
+    Runner->>OSS: observe(contextId)
+    OSS-->>Runner: ObservedSchema
+    Runner->>DSS: declare()
+    DSS-->>Runner: DeclaredSchema (stamped version + bare relationship names)
+    Runner->>Differ: diffAgainstObserved(declared, declaredRelNames, observed)
+    Differ-->>Runner: DeclaredObservedDiff
+    Runner->>Store: saveDriftReport(report)
+    Note over Store: written every run —<br/>"checked and found nothing" is also a fact
+    alt live run and entity-type drift found
+        Runner->>Repo: findByContextId(contextId) or findAll()
+        Runner->>Policy: evaluate(syntheticDiff, propositions)
+        Policy-->>Runner: QuarantineResult
+        Runner->>Repo: save(each quarantined copy)
+    else dry run, or relationship-only drift
+        Note over Runner: no proposition touched
+    end
+    Runner-->>Caller: DriftCheckResult
+```
+
+`run()` is the default shape: preview, whole graph. It and `run(dryRun)` are real overloads rather
+than Kotlin default arguments, because Java can't see a default argument and these two are the only
+`run` forms it can call at all — `ContextId` is a value class, so the scoped form gets a mangled JVM
+name. `ObservedSchemaSource.observe()` is split the same way for the same reason. The report is
+persisted either way, because a clean check needs to be as retrievable as a dirty one — that's what
+lets you tell "drift appeared last Tuesday" from "nobody has looked since Tuesday". Quarantine, by
+contrast, runs only on a live call *and* only when some entity type drifted. Relationship-only drift
+never reaches the policy: a mention carries an entity type, so no relationship name could ever match
+one, and sweeping anyway would be a full repository scan that decides nothing.
+
+When quarantine does run, the runner re-decides nothing. It synthesizes a `MetamodelDiff` whose only
+content is `EntityTypeRemoved` for each drifted type and hands that to the same
+`DriftQuarantinePolicy` the declared-vs-declared path uses. A mention whose type the declared schema
+doesn't recognize is orphaned identically whether the type was deleted from a newer declaration or
+never declared at all — one policy, not two that drift apart. Both ends of the synthetic diff point
+at the same declared version; they exist only to give the reason string something to name.
+
+## Drift semantics: drift vs. unobserved
+
+`DeclaredObservedDiff` is deliberately asymmetric, and it's computed as plain set difference.
+
+- **Drift** — observed, never declared (`observed - declared`). Actionable: data exists that nothing
+  can vouch for or explain the shape of.
+- **Unobserved** — declared, zero instances (`declared - observed`). Informational: a declared type
+  with no data yet is normal, not a problem.
+
+Relationships are compared on the bare type name, supplied by the caller alongside the stamp.
+`MetamodelVersion.relationshipNames` holds rendered `From-[name]->To` descriptors, and those are built
+from free-text names that can themselves contain a `-[...]->`-shaped substring. Reverse-parsing one is
+ambiguous and can silently pick the wrong segment, so `DeclaredSchema` carries the un-rendered names
+through instead of recovering them.
+
+An observer also has to exclude dice's own bookkeeping labels — `Proposition`, `Mention`, the
+collector and projection records, and the metamodel nodes themselves — from the entity side of what
+it reports. None of them was ever part of a declared *domain* schema, so an implementation that
+reports them makes every single run look like drift. There's no relationship-side equivalent: dice's
+bookkeeping is all node labels.
+
+## Quarantine marks stale; it never deletes
+
+Whether the lossy change came from a declared-vs-declared diff or a drift check, a proposition whose
+entity mentions reference an affected type has drifted. `MentionTypeDriftQuarantinePolicy` moves each
+one to `STALE` and annotates it with a human-readable reason under
+`DiceMetadataKeys.QUARANTINE_REASON` (`"dice.metamodel.quarantine.reason"`).
+
+This is the same instinct as the rest of the lifecycle (see
+[proposition-lifecycle](proposition-lifecycle.md)): leaving drifted propositions in normal retrieval
+corrupts query results, but deleting them destroys something a human might want to rescue. Cold
+beats gone. Two properties make the sweep safe to run as routine maintenance:
+
+- **Non-destructive.** The original is never mutated. The policy returns an immutable copy and the
+  caller persists it, so a sweep that's evaluated but not saved has changed nothing.
+- **Idempotent.** A proposition already `STALE` *with* a quarantine reason is passed through
+  untouched, original reason intact — re-running a sweep can't overwrite the record of why something
+  was pulled out. Forcing a re-evaluation means deliberately clearing that annotation first. Those
+  come back as `QuarantineDecision.AlreadyQuarantined`, a third outcome alongside conforming and
+  newly quarantined, so a caller counting conforming propositions isn't counting stale ones too.
+
+A diff with no lossy change short-circuits — every proposition comes back conforming.
+
+## Scoping a check to one context
+
+Every step that touches data takes an optional `ContextId`: the observation, the candidate
+propositions, and the persisted report. `null` means the whole graph.
+
+| | `contextId = null` | `contextId = X` |
+|---|---|---|
+| Candidate propositions | `findAll()` | `findByContextId(X)` |
+| Observed entity types | every label in the graph, minus dice's bookkeeping labels | the types reachable from context `X`'s own data |
+| Observed relationship types | every relationship type in the graph | always empty — see below |
+| `DriftReport.contextId` | `null` | `X` |
+| Quarantine blast radius | any proposition | only propositions in `X` |
+
+Scoping earns its keep three ways. Multi-tenant deployments enable different integrations per tenant,
+so a type that's valid for one is drift for another; a global check hides that behind the union of
+everyone's declarations, and when one context drops an integration others still use, only a scoped
+check can see that its data is now orphaned. A scoped dry run is a canary — what a full rollout would
+find, at a fraction of the blast radius. And because quarantine mutates data, a mis-declared schema
+scoped to one context has no way to reach another.
+
+The scoped relationship-type set is empty by design, not best-effort. Dice doesn't persist
+relationship edges tagged by context, so there's no honest way to attribute an observed relationship
+type to one. Reporting something anyway would be a guess dressed up as an observation. Empty means a
+scoped check finds no relationship drift — it can under-report, but it can never manufacture a false
+positive that quarantines something it shouldn't.
+
+A declared schema, by contrast, is never scoped. `DeclaredSchemaSource.declare()` takes no context:
+what a deployment declares valid is one thing, whatever the check happens to be looking at.
+
+## Persistence accumulates, and upserts on a natural key
+
+`MetamodelStore` has no delete. Versions accumulate, reports accumulate, and history is the point —
+correlating today's observation against the same baseline as last month's is how you tell growing
+drift from a stale finding.
+
+What it does have is an upsert. Both writes MERGE on a natural key, and a MERGE that *matches* sets
+the non-key properties from what you just passed. `DrivineMetamodelStore` (in `dice-storage`) MERGEs
+a version on `(schemaName, contentHash)` and sets `savedAt` only `ON CREATE`, so re-saving preserves
+the original timestamp but rewrites the stored type, label, property and relationship sets. A drift
+report MERGEs on `(schemaName, versionHash, capturedAt, contextKey)` and rewrites its drifted type
+sets the same way.
+
+In practice that's idempotence rather than mutation, because the key carries the content: a version's
+key includes its content hash, and that hash is derived from exactly the fields the MERGE would
+overwrite, so anything landing on an existing key has identical content by construction. "Append-only"
+is the shape you observe; it isn't a promise the interface makes, and an implementation is not
+expected to reject a re-save.
+
+`contextKey` is a separate property from the domain-visible `contextId` for a Cypher-shaped reason:
+property-map equality against a literal `null` never matches, so MERGE-ing on a nullable `contextId`
+would send every global report down the CREATE branch and duplicate it on each retry. `contextKey`
+holds the context id when there is one and a sentinel when there isn't. Global reports stay
+idempotent, and two reports captured at the same instant for different contexts stay two nodes rather
+than one silent overwrite. Type sets are stored as JSON, not joined with a delimiter — the content
+hash's escape-safety argument, applied to storage.
+
+## Where this lives, and what's still a port
+
+`dice-metamodel` holds the contracts and the value types, with the three shipped defaults —
+`StructuralMetamodelDiffer`, `MentionTypeDriftQuarantinePolicy`, `DefaultDriftCheckRunner` — one
+package down in `support`, so the package layout marks the API boundary. It depends on the core
+`dice` module and nothing that talks to a database, and it has no Spring dependency: the defaults are
+ordinary constructor calls.
+
+Ready-made beans arrive with the autoconfigure slice rather than from here. `@ConditionalOnMissingBean`
+is only well defined inside a real auto-configuration class — Spring Boot orders those deliberately,
+where a plain `@Configuration` is evaluated in registration order — so "define your own bean and ours
+steps aside" is a promise only an `AutoConfiguration.imports` entry can actually keep.
+
+`MetamodelStore`'s Neo4j implementation, `DrivineMetamodelStore`, lives in `dice-storage` — one step
+out, where a graph driver is allowed. `ObservedSchemaSource` is still a port with no shipped
+implementation: the Neo4j one lands with the autoconfigure wiring that also assembles the
+`DriftCheckRunner` bean, since a runner is only useful once something can observe. Until then a
+deployment builds `DefaultDriftCheckRunner` itself, and tests supply a canned `ObservedSchema`.
+
+`DeclaredSchemaSource` has no default and never will — there's no such thing as a default declared
+schema. A consuming app maps whatever it already uses to define one, passing the bare relationship
+names alongside the stamp:
+
+```kotlin
+class MyAppDeclaredSchemaSource(
+    private val dataDictionary: DataDictionary,
+    private val allowedRelationshipNames: Set<String>, // e.g. {"WORKS_AT", "LOCATED_IN"}
+) : DeclaredSchemaSource {
+
+    override fun declare(): DeclaredSchema = DeclaredSchema(
+        version = MetamodelVersion.from(dataDictionary),
+        relationshipTypeNames = allowedRelationshipNames,
+    )
+}
+```
+
+Nothing schedules a check. `DriftCheckRunner` is a capability; when to call it — cron, an admin
+endpoint, a startup hook — is the consumer's decision, the same stance the collector takes (see
+[reclamation-and-collector](reclamation-and-collector.md)).
+
+## Known edges
+
+- `EntityTypeModified` only fires for types present in both versions. A type removed and re-added
+  under the same name shows up as `EntityTypeRemoved` + `EntityTypeAdded`.
+- `contentHash` ignores schema names, so it can't tell two identically-shaped schemas apart; pair it
+  with `schemaName` when identity matters.
+- A drift check reads every candidate proposition to evaluate quarantine. On a large graph, scope it.

--- a/docs/design/metamodel-governance.md
+++ b/docs/design/metamodel-governance.md
@@ -139,6 +139,10 @@ MERGE key, what `hasSameContentAs` compares, and what every drift report records
 a caller could supply it, two schemas with different types could claim the same hash, compare equal,
 and overwrite each other in storage.
 
+The public constructor snapshots its collections and rejects label/property map keys that are not
+present in `entityTypeNames`. Its `copy` method enforces the same invariant, so removing a type also
+means removing that type's label and property entries in the same call.
+
 **Every name, label, and property is length-prefixed** (`<len>:<token>`) before hashing, and each set
 is preceded by its size. These names come from free-text and LLM extraction; they routinely contain
 `;`, `[`, `=`, and spaces. A delimiter-joined encoding would let `["a;b"]` and `["a", "b"]` produce
@@ -273,7 +277,8 @@ beats gone. Two properties make the sweep safe to run as routine maintenance:
   come back as `QuarantineDecision.AlreadyQuarantined`, a third outcome alongside conforming and
   newly quarantined, so a caller counting conforming propositions isn't counting stale ones too.
 
-A diff with no lossy change short-circuits — every proposition comes back conforming.
+A diff with no lossy change short-circuits — every proposition except those already quarantined
+comes back conforming; previously quarantined propositions remain in their dedicated outcome.
 
 ## Scoping a check to one context
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <module>dice-storage-autoconfigure</module>
         <module>dice-report</module>
         <module>dice-ingestion</module>
+        <module>dice-metamodel</module>
         <module>dice-integration-tests</module>
     </modules>
 
@@ -68,6 +69,11 @@
             <dependency>
                 <groupId>com.embabel.dice</groupId>
                 <artifactId>dice-storage</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.embabel.dice</groupId>
+                <artifactId>dice-metamodel</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
First slice of #50 (refs #45): the metamodel API extracted onto current main, reviewed and hardened.

**In:** `dice-metamodel` — MetamodelVersion (derived content hash), declared-vs-observed diffing, DriftCheckRunner, DriftQuarantinePolicy, MetamodelStore SPI; pure-JVM defaults; 74 unit tests; docs/design/metamodel-governance.md; CHANGELOG.

**Hardened vs #50:** unforgeable contentHash, explicitly-scoped drift-report reads (driftReports/globalDriftReports/driftReportsInContext), one participle for drift sets, Spring wiring removed from the API module (arrives with the autoconfigure slice).

**Compatibility: additive.** No pre-existing src/main file modified; consumers tracking 0.2.0-SNAPSHOT unaffected.

**Follow-ups:** B Drivine persistence (ready locally, stacks on this) · C observed-schema + autoconfiguration · D storage hardening · E knowledge bundles. #50 stays open as the source branch until the train lands.

Full reactor green locally, including the Neo4j testcontainer ITs.
