### PR TITLE
Source-revision provenance: contract and revision-aware storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,3 +345,52 @@ and the consumer PRs that deliver it).
   graph stores. Aliases arrive in this same Unreleased block, so no consumer can be in that state
   on a published build. The API is additive: three read-only accessors and one public constant,
   and no existing signature changed.
+- Optional source revisions in the `dice` core provenance model, the first slice of DICE #64.
+  `ProvenanceEntry` gains a sixth field, `sourceRevision`: an opaque, provider-defined string,
+  non-blank when present, recording which version of a source a claim was read from.
+  `SourceLocator.key()` is untouched, so one document read at two revisions is still one source
+  identity — one `:Source` node, one "everything from this document" query.
+  `SourceRevisionRef(sourceKey, sourceRevision)` is the value that names one version of one source
+  for queries and carriage. Equality and dedup follow from the data class, so evidence at two
+  revisions over the same span now survives a fold as two entries where it previously collapsed into
+  one. Three context-scoped finders land on `PropositionRepository` — `findBySourceKey` (any
+  revision), `findBySourceRevision` (exact), and `findRevisionlessBySourceLocator`. Each comes in a
+  `ContextId`-typed form and a plain-String form; the typed form forwards to the String one, which is
+  the override point, so a backend written in either language stays reachable from both. In
+  `dice-storage`, `DrivinePropositionRepository` overrides all three and pushes them into Cypher
+  (its context read carries no provenance, so the in-memory defaults would return nothing there),
+  and `DerivedFrom` carries the revision as a `DERIVED_FROM` edge property. Two graph-write changes
+  come with that, each fixing a way a revision was lost before any query ran. Edges now carry an
+  `entryKey` identity and are written by MERGE on it, so one proposition citing one source at two
+  revisions stores two rows: relationship-fragment mapping identifies an edge by its endpoints alone
+  and collapsed them into one. And exact-text dedup now unions incoming evidence into the winner on
+  both the in-process and cross-instance-race paths, so re-extracting the same sentence from a newer
+  revision keeps that revision queryable instead of discarding it with the duplicate; an exact replay
+  writes nothing. Provenance reads use raw Cypher for the same cardinality reason. One behavioural
+  note for hosts that call `save` inside their own transaction: a cross-instance uniqueness race
+  still propagates to the caller rather than being recovered internally, because the losing insert
+  has already ended that transaction — recovery is the caller's to retry, and `save` recovers by
+  itself only when it owns the transaction. `PropositionStore` gains
+  the provenance-management operations `provenanceOf`, `addProvenance`, `setProvenance` and
+  `clearProvenance`, which previously sat only on `PropositionRepository`, so evidence-sensitive
+  callers can depend on the capability without probing for a richer type at runtime. Design note:
+  [docs/design/source-revisions.md](docs/design/source-revisions.md).
+  **Interim limitation.** Collapse records fold references as plain locator keys until the collector
+  slice lands, so undoing a collapse that folded revisioned evidence leaves those entries on the
+  survivor; evidence is retained, never wrongly deleted. Internally, `ProvenanceEvidenceKey` is the
+  codec that will make those references exact — it is `internal` to the `dice` module, machinery
+  behind fold and undo rather than API a consumer can call.
+  **Compatibility: additive, with a scoped ABI boundary.** Source, JSON, and Java
+  constructor-descriptor compatibility are claimed: existing Kotlin and Java call sites compile
+  unchanged, provenance JSON written before this change loads and round-trips with a null revision,
+  and `@JvmOverloads` preserves every concrete `ProvenanceEntry` constructor descriptor while the
+  revision adds one on the end. The same holds for `dice-storage`'s `DerivedFrom`, which gains
+  `@JvmOverloads` and takes `sourceRevision` and `entryKey` as trailing optional arguments. Full
+  Kotlin synthetic constructor and `copy` ABI is **not** claimed for either type: adding a field to a
+  data class changes the `copy` and `componentN` signatures and the synthetic `$default` constructor,
+  so Kotlin code compiled against an earlier jar must be recompiled rather than swapped in. Stored
+  graphs need no migration: a `DERIVED_FROM` edge with no `sourceRevision` reads back as a
+  revisionless entry, and an edge with no `entryKey` is adopted in place the first time an exactly
+  matching revisionless entry is written. The source queries carry no index hint, so they plan on a
+  store that never adopted the optional `(contextId, text)` uniqueness constraint. Pipeline,
+  collector, and REST behavior are unchanged; those arrive in the following Wave A slices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,13 +353,24 @@ and the consumer PRs that deliver it).
   `SourceRevisionRef(sourceKey, sourceRevision)` is the value that names one version of one source
   for queries and carriage. Equality and dedup follow from the data class, so evidence at two
   revisions over the same span now survives a fold as two entries where it previously collapsed into
-  one. Three context-scoped finders land on `PropositionRepository` — `findBySourceKey` (any
-  revision), `findBySourceRevision` (exact), and `findRevisionlessBySourceLocator`. Each comes in a
-  `ContextId`-typed form and a plain-String form; the typed form forwards to the String one, which is
-  the override point, so a backend written in either language stays reachable from both. In
-  `dice-storage`, `DrivinePropositionRepository` overrides all three and pushes them into Cypher
-  (its context read carries no provenance, so the in-memory defaults would return nothing there),
-  and `DerivedFrom` carries the revision as a `DERIVED_FROM` edge property. Two graph-write changes
+  one. Three context-scoped finders arrive on a new opt-in capability interface,
+  `SourceRevisionQueryCapable` — `findBySourceKey` (any revision), `findBySourceRevision` (exact),
+  and `findRevisionlessBySourceLocator`. Each comes in a `ContextId`-typed form and a plain-String
+  form; the typed form forwards to the String one, which is the implementation point, so a backend
+  written in either language stays reachable from both. The String forms are abstract, so a backend
+  that implements the interface has promised to answer for its own storage, and a backend that
+  cannot answer is simply absent from the type: a caller probes with `as?` and handles that absence
+  as its own case. `PropositionRepository` carries none of this surface. A shared default body
+  written over an ordinary context read would have returned an empty list on any backend that stores
+  evidence without projecting it, and an empty list already carries a meaning here — nothing in this
+  context cites that source — so an unsupported operation would have read as a false negative.
+  `ProvenanceScanningSourceRevisionQueries` supplies the in-memory scan for the stores whose reads do
+  carry every entry (`InMemoryPropositionRepository`, `JsonFilePropositionRepository`).
+  `EventEmittingPropositionRepository` carries the capability type and forwards to its delegate,
+  reporting `supportsSourceRevisionQueries = false` and throwing with the delegate named when the
+  delegate it was handed cannot answer. In `dice-storage`, `DrivinePropositionRepository` implements
+  the capability and pushes all three predicates into Cypher, because its context read carries no
+  provenance at all, and `DerivedFrom` carries the revision as a `DERIVED_FROM` edge property. Two graph-write changes
   come with that, each fixing a way a revision was lost before any query ran. Edges now carry an
   `entryKey` identity and are written by MERGE on it, so one proposition citing one source at two
   revisions stores two rows: relationship-fragment mapping identifies an edge by its endpoints alone
@@ -394,3 +405,23 @@ and the consumer PRs that deliver it).
   matching revisionless entry is written. The source queries carry no index hint, so they plan on a
   store that never adopted the optional `(contextId, text)` uniqueness constraint. Pipeline,
   collector, and REST behavior are unchanged; those arrive in the following Wave A slices.
+- Length ceilings on the externally supplied strings that become stored identity, in
+  `SourceIdentityBounds`: `MAX_SOURCE_KEY_LENGTH` (2048) and `MAX_SOURCE_REVISION_LENGTH` (1024).
+  Both are checked while `ProvenanceEntry` and `SourceRevisionRef` are being constructed, which sits
+  upstream of every hash and every indexed write, so a runaway value is refused with an
+  `IllegalArgumentException` naming the limit it broke, before any store is touched. The numbers are
+  roomy on purpose: 2048 is the practical ceiling browsers and proxies settled on for a URL, and 1024
+  is the longest real revision token we know of, an S3 object version id.
+  **Compatibility: behavioral.** A caller offering a source key or revision longer than the limit now
+  gets a rejection where it previously got an oversized index entry. Nothing a real connector emits
+  comes close to either number.
+
+### Fixed
+
+- `:Source.display` in the graph projection is write-once. A `:Source` node is global — one locator
+  key is one node across every context that cites it — and `display` used to be refreshed on every
+  write, so whichever writer ran last owned the label every other context read. It is now set on
+  create only. Identity is unaffected: `display` has never participated in `SourceLocator.key()`, and
+  each writer's evidence still lands on its own `DERIVED_FROM` edge.
+  **Compatibility: behavioral, `dice-storage` only.** An existing `:Source` node keeps the label it
+  currently has, and a later write leaves that label alone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,15 +406,18 @@ and the consumer PRs that deliver it).
   store that never adopted the optional `(contextId, text)` uniqueness constraint. Pipeline,
   collector, and REST behavior are unchanged; those arrive in the following Wave A slices.
 - Length ceilings on the externally supplied strings that become stored identity, in
-  `SourceIdentityBounds`: `MAX_SOURCE_KEY_LENGTH` (2048) and `MAX_SOURCE_REVISION_LENGTH` (1024).
-  Both are checked while `ProvenanceEntry` and `SourceRevisionRef` are being constructed, which sits
-  upstream of every hash and every indexed write, so a runaway value is refused with an
+  `SourceIdentityBounds`: `MAX_SOURCE_KEY_LENGTH` (2048), `MAX_SOURCE_REVISION_LENGTH` (1024),
+  `MAX_CHUNK_ID_LENGTH` (512), and `MAX_CONTENT_HASH_LENGTH` (256).
+  The key and revision are checked while `ProvenanceEntry` and `SourceRevisionRef` are constructed,
+  the chunk id and content hash while `ProvenanceEntry` is. Both sit upstream of every hash and
+  every indexed write, so a runaway value is refused with an
   `IllegalArgumentException` naming the limit it broke, before any store is touched. The numbers are
-  roomy on purpose: 2048 is the practical ceiling browsers and proxies settled on for a URL, and 1024
-  is the longest real revision token we know of, an S3 object version id.
-  **Compatibility: behavioral.** A caller offering a source key or revision longer than the limit now
-  gets a rejection where it previously got an oversized index entry. Nothing a real connector emits
-  comes close to either number.
+  roomy on purpose: 2048 is the practical ceiling browsers and proxies settled on for a URL, 1024
+  is the longest real revision token we know of (an S3 object version id), 512 leaves room for any
+  chunker-minted chunk id, and 256 comfortably covers a SHA-512 content hash in hex.
+  **Compatibility: behavioral.** A caller offering a source key, revision, chunk id or content hash
+  longer than its limit now gets a rejection where it previously got an oversized index entry.
+  Nothing a real connector emits comes close to any of the four.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,6 +405,10 @@ and the consumer PRs that deliver it).
   matching revisionless entry is written. The source queries carry no index hint, so they plan on a
   store that never adopted the optional `(contextId, text)` uniqueness constraint. Pipeline,
   collector, and REST behavior are unchanged; those arrive in the following Wave A slices.
+- A source's display label is stored per provenance edge, in `dice-storage`, and read from there.
+  Contexts sharing one `:Source` node no longer share a label: each writer's `DERIVED_FROM` edge
+  carries the label it supplied, and a provenance read takes `display` from the edge it belongs to.
+  Rows written before this change have no edge-level `display` and fall back to the node's label.
 - Length ceilings on the externally supplied strings that become stored identity, in
   `SourceIdentityBounds`: `MAX_SOURCE_KEY_LENGTH` (2048), `MAX_SOURCE_REVISION_LENGTH` (1024),
   `MAX_CHUNK_ID_LENGTH` (512), and `MAX_CONTENT_HASH_LENGTH` (256).

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
@@ -31,6 +31,8 @@ import com.embabel.dice.proposition.GraphQueryCapable
 import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.proposition.PropositionStoreType
 import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.SourceLocator
+import com.embabel.dice.provenance.SourceRevisionRef
 import com.embabel.dice.query.graph.GraphNeighborhood
 import com.embabel.dice.query.graph.GraphPath
 import com.embabel.dice.query.graph.PropositionLineage
@@ -43,9 +45,53 @@ import org.drivine.query.QuerySpecification
 import org.drivine.query.dsl.*
 import org.slf4j.LoggerFactory
 import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.Instant
+
+/**
+ * The three source-provenance queries, kept together so they stay in step with each other.
+ *
+ * Each scopes to the tenant first and then checks for a matching `DERIVED_FROM` edge, so provenance
+ * is only expanded for one tenant's propositions.
+ *
+ * There is deliberately no `USING INDEX` hint. Neo4j resolves hints at planning time and fails the
+ * whole query when the named index is absent, and `dice-storage`'s schema is adopter-supplied — the
+ * `(contextId, text)` constraint ships in `dice-storage-autoconfigure`'s catalog, so a host wiring
+ * this repository by hand may not have it. A hint would turn an optional dedup backstop into a hard
+ * runtime dependency for every source query. Without one, the planner still seeks on `contextId`
+ * where an index exists and falls back to a label scan where it does not.
+ */
+internal object SourceProvenanceQueryStatements {
+
+    val bySourceKey = """
+        MATCH (p:Proposition {contextId: ${'$'}contextId})
+        WHERE EXISTS {
+            MATCH (p)-[:DERIVED_FROM]->(:Source {key: ${'$'}sourceKey})
+        }
+        RETURN p.id AS id
+    """.trimIndent()
+
+    val bySourceRevision = """
+        MATCH (p:Proposition {contextId: ${'$'}contextId})
+        WHERE EXISTS {
+            MATCH (p)-[r:DERIVED_FROM]->(:Source {key: ${'$'}sourceKey})
+            WHERE r.sourceRevision = ${'$'}sourceRevision
+        }
+        RETURN p.id AS id
+    """.trimIndent()
+
+    val revisionlessBySourceKey = """
+        MATCH (p:Proposition {contextId: ${'$'}contextId})
+        WHERE EXISTS {
+            MATCH (p)-[r:DERIVED_FROM]->(:Source {key: ${'$'}sourceKey})
+            WHERE r.sourceRevision IS NULL
+        }
+        RETURN p.id AS id
+    """.trimIndent()
+}
 
 /**
  * Graph-backed [PropositionRepository] over Drivine / Neo4j.
@@ -104,8 +150,40 @@ class DrivinePropositionRepository(
      * sibling. If a foreign sibling turns out to be ACTIVE too (only reachable without the
      * `(contextId, text)` constraint), that's a live duplicate this method won't silently create by
      * redirecting, but won't collapse either — it logs a WARN naming both ids for the dedup sweep.
+     *
+     * Two transaction shapes, because recovery from a uniqueness race needs a transaction the race
+     * did not already poison:
+     * - **A caller's transaction is active**: this joins it and stays inside it. A uniqueness
+     *   violation marks that transaction rollback-only, and no write of ours could commit in it
+     *   afterwards, so the violation propagates to the caller untouched — the same behaviour as
+     *   before evidence union existed. Recovery is the caller's to retry. Opening a nested
+     *   transaction to sneak a write out would break the atomicity the caller asked for.
+     * - **No caller transaction**: `SUPPORTS` keeps the proxy from opening one, so [txTemplate] owns
+     *   the attempted insert, and after that transaction rolls back the recovery runs in a fresh
+     *   one and can commit.
      */
-    override fun save(proposition: Proposition): Proposition {
+    @Transactional(propagation = Propagation.SUPPORTS)
+    override fun save(proposition: Proposition): Proposition =
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            saveInCallerTransaction(proposition)
+        } else {
+            saveInOwnedTransaction(proposition)
+        }
+
+    private fun saveInCallerTransaction(proposition: Proposition): Proposition {
+        val text = proposition.text
+        if (text.isBlank()) {
+            return doPersist(proposition)
+        }
+        val contextId = proposition.contextId.value
+        return synchronized(lockFor(contextId, text)) {
+            // A uniqueness race has already aborted the caller's transaction by the time we could
+            // react, so recovery cannot commit here. Preserve atomicity and let it propagate.
+            findOrPersist(proposition, contextId, text)
+        }
+    }
+
+    private fun saveInOwnedTransaction(proposition: Proposition): Proposition {
         val text = proposition.text
         if (text.isBlank()) {
             return txTemplate.execute { doPersist(proposition) }!!
@@ -117,9 +195,10 @@ class DrivinePropositionRepository(
             } catch (e: RuntimeException) {
                 if (!isUniquenessViolation(e)) throw e
                 // Cross-instance race: another writer inserted the same (contextId, text) and the DB
-                // (contextId, text) uniqueness constraint rejected ours. The dupe now exists — reuse it.
+                // (contextId, text) uniqueness constraint rejected ours. The dupe now exists — reuse
+                // it, in a transaction of its own so the failed attempt cannot roll this back.
                 logger.debug("Dedup constraint hit for context {} — reusing existing: '{}'", contextId, text)
-                txTemplate.execute { findDuplicateId(contextId, text, proposition.id)?.let(::findById) } ?: throw e
+                txTemplate.execute { recoverDuplicate(proposition, contextId, text) } ?: throw e
             }
         }
     }
@@ -138,7 +217,7 @@ class DrivinePropositionRepository(
                 "Dedup: proposition already present as {} in context {} — reusing: '{}'",
                 existingId, contextId, text,
             )
-            existing
+            mergeDeduplicatedProvenance(existing, proposition.provenanceEntries)
         } else {
             // An update lands on its own node even when a same-text sibling exists. If that sibling is
             // also ACTIVE, this mints a second live copy of the same fact (only reachable without the
@@ -176,26 +255,100 @@ class DrivinePropositionRepository(
     }
 
     /**
+     * Re-find the winner after a cross-instance uniqueness race and union the losing writer's
+     * evidence into it. The relationship MERGE is keyed by evidence identity, so a retry is a no-op.
+     */
+    private fun recoverDuplicate(proposition: Proposition, contextId: String, text: String): Proposition? {
+        val winnerId = findDuplicateId(contextId, text, proposition.id) ?: return null
+        val winner = findById(winnerId) ?: return null
+        return mergeDeduplicatedProvenance(winner, proposition.provenanceEntries)
+    }
+
+    /**
+     * Union evidence from a deduplicated insert into its winner.
+     *
+     * Without this, a second extraction that produced identical text over a newer revision of the
+     * source would be answered with the existing proposition and its evidence dropped on the floor,
+     * so the newer revision would never be queryable. A genuinely new entry is a metadata change and
+     * advances `lastTouched`; an exact replay finds nothing novel and stays a no-op.
+     */
+    private fun mergeDeduplicatedProvenance(
+        winner: Proposition,
+        incomingEntries: List<ProvenanceEntry>,
+    ): Proposition {
+        // Validate every incoming entry, including ones the winner appears to already hold. "Appears"
+        // is the operative word: a locator's equality is its key, and a key can be ambiguous — a
+        // connector id containing a colon can produce the same key as a different (connectorId,
+        // externalId) split — so an entry can compare equal to a stored one while naming a
+        // structurally different source. Validating first stops that evidence being filed under the
+        // wrong source by the no-op path below. These are reads, so an exact replay still writes
+        // nothing.
+        incomingEntries.forEach(::validateSourceIdentity)
+        val knownEntries = winner.provenanceEntries.toHashSet()
+        val novelEntries = incomingEntries.filterNot(knownEntries::contains)
+        if (novelEntries.isEmpty()) return winner
+        val revisedWinner = winner.withProvenanceEntries(novelEntries)
+        doPersist(revisedWinner)
+        return findById(winner.id) ?: revisedWinner
+    }
+
+    /**
+     * Read-only check that an incoming entry's locator agrees with the `:Source` already stored under
+     * its key. Nothing stored yet means nothing to disagree with.
+     *
+     * Separate from the upsert in [upsertSource] so it can run on the exact-replay path, which must
+     * not write.
+     */
+    private fun validateSourceIdentity(entry: ProvenanceEntry) {
+        val source = PropositionGraphMapper.toDerivedFrom(entry).source
+        val stored = storedSourceIdentity(source.key) ?: return
+        require(sourceIdentityMatches(stored, source)) {
+            "Source key collision for '${source.key}': stored source identity differs from incoming locator"
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun storedSourceIdentity(sourceKey: String): Map<String, Any?>? =
+        (persistenceManager.query(
+            QuerySpecification.withStatement(
+                """
+                MATCH (s:Source {key: ${'$'}sourceKey})
+                RETURN {
+                    kind: s.kind,
+                    uri: s.uri,
+                    path: s.path,
+                    contentHash: s.contentHash,
+                    connectorId: s.connectorId,
+                    externalId: s.externalId
+                } AS row
+                """.trimIndent()
+            ).bind(mapOf("sourceKey" to sourceKey))
+        ) as List<Map<String, Any?>>).singleOrNull()
+
+    private fun sourceIdentityMatches(stored: Map<String, Any?>, source: SourceNode): Boolean =
+        stored["kind"] == source.kind &&
+            stored["uri"] == source.uri &&
+            stored["path"] == source.path &&
+            stored["contentHash"] == source.contentHash &&
+            stored["connectorId"] == source.connectorId &&
+            stored["externalId"] == source.externalId
+
+    /**
      * Persist node, mentions, and (append-only) provenance.
      *
-     * Two writes with deliberately different cascades — Drivine applies one cascade per `save`:
+     * Two writes with different ownership:
      * - **Node + mentions** via the lean [PropositionView] with `DELETE_ORPHAN`: authoritative, so a
      *   changed mention set is reconciled and stale Mention nodes are cleaned. Provenance is *not* in
      *   this view, so existing `DERIVED_FROM` edges are left intact.
-     * - **Provenance** via [PropositionWithProvenanceView] with `PRESERVE`: additive — edges are merged,
-     *   never deleted, and idempotent by the shared `:Source` key. So the all-in-one save never drops
-     *   evidence it didn't load (the lean query/findAll paths, the decay sweep). Authoritative
-     *   replacement/removal is the job of [setProvenance] / [clearProvenance].
+     * - **Provenance** via raw Cypher keyed by the whole evidence tuple: additive and idempotent, and
+     *   it keeps parallel revisions apart. Relationship-fragment mapping identifies an edge by its
+     *   two endpoints, so one proposition citing one source at two revisions would store a single
+     *   row and lose a revision. Authoritative replacement is the job of [setProvenance].
      */
     private fun doPersist(proposition: Proposition): Proposition {
         val embedding = embeddingFor(proposition)
         graphObjectManager.save(PropositionGraphMapper.toView(proposition, embedding), CascadeType.DELETE_ORPHAN)
-        if (proposition.provenanceEntries.isNotEmpty()) {
-            graphObjectManager.save(
-                PropositionGraphMapper.toProvenanceView(proposition, embedding),
-                CascadeType.PRESERVE,
-            )
-        }
+        appendProvenance(proposition.id, proposition.provenanceEntries)
         return proposition
     }
 
@@ -203,19 +356,152 @@ class DrivinePropositionRepository(
         proposition.text.takeIf { it.isNotBlank() }?.let { embeddingService.embed(it).toList() }
 
     /**
-     * Authoritative provenance replace (unlike the append-only [save]): save the provenance view with
-     * `DELETE_ORPHAN`, so `DERIVED_FROM` edges — and any thereby-orphaned `:Source` nodes — not in
-     * [entries] are removed. [clearProvenance] funnels here with an empty list.
+     * Append evidence, one MERGE per entry keyed by its storage identity.
+     */
+    private fun appendProvenance(propositionId: String, entries: List<ProvenanceEntry>) {
+        entries.map(PropositionGraphMapper::toDerivedFrom).forEach { edge ->
+            val entryKey = requireNotNull(edge.entryKey) { "Provenance entryKey must be computed before persistence" }
+            val params = provenanceParameters(propositionId, entryKey, edge)
+            upsertSource(edge.source, params)
+            if (edge.sourceRevision == null && adoptExactLegacyEdge(params)) return@forEach
+            persistenceManager.execute(
+                QuerySpecification.withStatement(
+                    """
+                    MATCH (p:Proposition {id: ${'$'}propositionId})
+                    MATCH (s:Source {key: ${'$'}sourceKey})
+                    MERGE (p)-[r:DERIVED_FROM {entryKey: ${'$'}entryKey}]->(s)
+                    SET r.sourceRevision = ${'$'}sourceRevision,
+                        r.chunkId = ${'$'}chunkId,
+                        r.startOffset = ${'$'}startOffset,
+                        r.endOffset = ${'$'}endOffset,
+                        r.contentHash = ${'$'}contentHash
+                    """.trimIndent()
+                ).bind(params),
+            )
+        }
+    }
+
+    /**
+     * Upsert the shared `:Source` node and reject a key collision.
+     *
+     * Two structurally different locators that produce one key would otherwise take turns rewriting
+     * each other's node, so the incoming identity is compared against what is stored and a mismatch
+     * fails the write rather than corrupting the shared node. `display` is presentation-only and is
+     * refreshed on every write; the identity fields are set once, on create.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun upsertSource(source: SourceNode, params: Map<String, Any?>) {
+        val stored = (persistenceManager.query(
+            QuerySpecification.withStatement(
+                """
+                MERGE (s:Source {key: ${'$'}sourceKey})
+                ON CREATE SET s.kind = ${'$'}sourceKind,
+                              s.uri = ${'$'}sourceUri,
+                              s.path = ${'$'}sourcePath,
+                              s.contentHash = ${'$'}sourceContentHash,
+                              s.connectorId = ${'$'}connectorId,
+                              s.externalId = ${'$'}externalId
+                SET s.display = ${'$'}sourceDisplay
+                RETURN {
+                    kind: s.kind,
+                    uri: s.uri,
+                    path: s.path,
+                    contentHash: s.contentHash,
+                    connectorId: s.connectorId,
+                    externalId: s.externalId
+                } AS row
+                """.trimIndent()
+            ).bind(params)
+        ) as List<Map<String, Any?>>).single()
+        require(sourceIdentityMatches(stored, source)) {
+            "Source key collision for '${source.key}': stored source identity differs from incoming locator"
+        }
+    }
+
+    /**
+     * Claim an edge written before `entryKey` existed. Only an exactly equal revisionless entry may
+     * adopt one: revisioned evidence has no way to know which revision the legacy edge recorded, so
+     * it writes its own row instead.
+     */
+    private fun adoptExactLegacyEdge(params: Map<String, Any?>): Boolean {
+        val adopted = persistenceManager.maybeGetOne(
+            QuerySpecification.withStatement(
+                """
+                MATCH (p:Proposition {id: ${'$'}propositionId})-[r:DERIVED_FROM]->(s:Source {key: ${'$'}sourceKey})
+                WHERE r.entryKey IS NULL
+                  AND r.sourceRevision IS NULL
+                  AND ((r.chunkId IS NULL AND ${'$'}chunkId IS NULL) OR r.chunkId = ${'$'}chunkId)
+                  AND ((r.startOffset IS NULL AND ${'$'}startOffset IS NULL) OR r.startOffset = ${'$'}startOffset)
+                  AND ((r.endOffset IS NULL AND ${'$'}endOffset IS NULL) OR r.endOffset = ${'$'}endOffset)
+                  AND ((r.contentHash IS NULL AND ${'$'}contentHash IS NULL) OR r.contentHash = ${'$'}contentHash)
+                WITH r LIMIT 1
+                SET r.entryKey = ${'$'}entryKey
+                RETURN count(r) AS adopted
+                """.trimIndent()
+            ).bind(params).transform(Long::class.java)
+        ) ?: 0L
+        return adopted > 0
+    }
+
+    /**
+     * Authoritative provenance replace (unlike the append-only [save]). Wanted evidence is upserted
+     * first, edges outside [entries] are deleted by their storage identity, and only globally
+     * unreferenced `:Source` nodes are pruned. [clearProvenance] funnels here with an empty list.
      */
     @Transactional
     override fun setProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? {
         val updated = (findById(propositionId) ?: return null).withProvenance(entries)
-        graphObjectManager.save(
-            PropositionGraphMapper.toProvenanceView(updated, embeddingFor(updated)),
-            CascadeType.DELETE_ORPHAN,
-        )
+        graphObjectManager.save(PropositionGraphMapper.toView(updated, embeddingFor(updated)), CascadeType.DELETE_ORPHAN)
+        replaceProvenance(propositionId, entries)
         return updated
     }
+
+    /**
+     * Drop the edges this replacement no longer wants, then prune only the sources those edges
+     * pointed at.
+     *
+     * The prune is scoped for the same reason `clear_propositions.cypher` scopes its own: a
+     * store-wide sweep would delete orphaned sources that have nothing to do with this call. It also
+     * requires a source to have no relationships at all, so a `:Source` that some later feature
+     * attaches another edge type to is left alone instead of deleted or erroring the write.
+     */
+    private fun replaceProvenance(propositionId: String, entries: List<ProvenanceEntry>) {
+        appendProvenance(propositionId, entries)
+        val entryKeys = entries.map(::provenanceStorageEntryKey)
+        persistenceManager.execute(
+            QuerySpecification.withStatement(
+                """
+                MATCH (p:Proposition {id: ${'$'}propositionId})-[r:DERIVED_FROM]->(s:Source)
+                WHERE r.entryKey IS NULL OR NOT r.entryKey IN ${'$'}entryKeys
+                WITH collect(DISTINCT s) AS touched, collect(r) AS doomed
+                FOREACH (rel IN doomed | DELETE rel)
+                FOREACH (orphan IN [src IN touched WHERE NOT (src)--()] | DELETE orphan)
+                """.trimIndent()
+            ).bind(mapOf("propositionId" to propositionId, "entryKeys" to entryKeys)),
+        )
+    }
+
+    private fun provenanceParameters(
+        propositionId: String,
+        entryKey: String,
+        edge: DerivedFrom,
+    ): Map<String, Any?> = mapOf(
+        "propositionId" to propositionId,
+        "entryKey" to entryKey,
+        "sourceKey" to edge.source.key,
+        "sourceKind" to edge.source.kind,
+        "sourceDisplay" to edge.source.display,
+        "sourceUri" to edge.source.uri,
+        "sourcePath" to edge.source.path,
+        "sourceContentHash" to edge.source.contentHash,
+        "connectorId" to edge.source.connectorId,
+        "externalId" to edge.source.externalId,
+        "sourceRevision" to edge.sourceRevision,
+        "chunkId" to edge.chunkId,
+        "startOffset" to edge.startOffset,
+        "endOffset" to edge.endOffset,
+        "contentHash" to edge.contentHash,
+    )
 
     /**
      * Id of an existing proposition with the same `contextId` and exact `text` (excluding the
@@ -248,7 +534,9 @@ class DrivinePropositionRepository(
 
     @Transactional(readOnly = true)
     override fun findById(id: String): Proposition? =
-        graphObjectManager.load<PropositionWithProvenanceView>(id)?.let(PropositionGraphMapper::toProposition)
+        graphObjectManager.load<PropositionView>(id)
+            ?.let(PropositionGraphMapper::toProposition)
+            ?.let { withRawProvenance(listOf(it)).single() }
 
     @Transactional(readOnly = true)
     override fun findAll(): List<Proposition> =
@@ -284,6 +572,56 @@ class DrivinePropositionRepository(
         graphObjectManager.loadAll<PropositionView> {
             where { proposition.contextId eq contextId.value }
         }.map(PropositionGraphMapper::toProposition)
+
+    // ---- Source provenance queries ----
+    //
+    // The interface defaults filter loaded provenance in memory, and this backend's context read is
+    // lean — it carries no provenance at all — so without these overrides all three finders would
+    // return nothing here. Each one pushes its predicate into Cypher instead. The overrides sit on
+    // the plain-String variant because that is the one every typed call also routes through.
+
+    @Transactional(readOnly = true)
+    override fun findBySourceKey(contextIdValue: String, sourceKey: String): List<Proposition> =
+        executeSourceQuery(
+            SourceProvenanceQueryStatements.bySourceKey,
+            mapOf("contextId" to contextIdValue, "sourceKey" to sourceKey),
+        )
+
+    @Transactional(readOnly = true)
+    override fun findBySourceRevision(
+        contextIdValue: String,
+        ref: SourceRevisionRef,
+    ): List<Proposition> =
+        executeSourceQuery(
+            SourceProvenanceQueryStatements.bySourceRevision,
+            mapOf(
+                "contextId" to contextIdValue,
+                "sourceKey" to ref.sourceKey,
+                "sourceRevision" to ref.sourceRevision,
+            ),
+        )
+
+    @Transactional(readOnly = true)
+    override fun findRevisionlessBySourceLocator(
+        contextIdValue: String,
+        locator: SourceLocator,
+    ): List<Proposition> =
+        executeSourceQuery(
+            SourceProvenanceQueryStatements.revisionlessBySourceKey,
+            mapOf("contextId" to contextIdValue, "sourceKey" to locator.key()),
+        )
+
+    /**
+     * Run one source query, then load the matched ids back with every provenance row attached.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun executeSourceQuery(statement: String, params: Map<String, Any>): List<Proposition> {
+        val ids = persistenceManager.query(
+            QuerySpecification.withStatement(statement).bind(params)
+        ) as List<String>
+        val byId = hydrate(ids)
+        return enrichWithProvenance(ids.distinct().mapNotNull { byId[it] })
+    }
 
     @Transactional(readOnly = true)
     override fun findByGrounding(chunkId: String): List<Proposition> =
@@ -321,10 +659,7 @@ class DrivinePropositionRepository(
 
     @Transactional(readOnly = true)
     override fun findAll(withProvenance: Boolean): List<Proposition> =
-        if (!withProvenance) findAll()
-        else graphObjectManager.loadAll<PropositionWithProvenanceView> {
-            where { proposition.contextId.isNotNull() } // skip malformed/foreign :Proposition nodes (see findAll)
-        }.map(PropositionGraphMapper::toProposition)
+        if (!withProvenance) findAll() else withRawProvenance(findAll())
 
     /**
      * The materialised `effectiveConfidence` (default k = 2.0, as of the last sweep) only matches a
@@ -366,14 +701,75 @@ class DrivinePropositionRepository(
         return query.limit?.let { list.take(it) } ?: list
     }
 
-    /** Re-load a lean result set's ids through the provenance view (one batch query), preserving order. */
-    private fun enrichWithProvenance(lean: List<Proposition>): List<Proposition> {
+    /** Add provenance to a lean result set in one batch query, preserving order. */
+    private fun enrichWithProvenance(lean: List<Proposition>): List<Proposition> = withRawProvenance(lean)
+
+    /**
+     * Read every `DERIVED_FROM` row for these propositions as raw Cypher.
+     *
+     * The demonstrated problem is on the write side: relationship-fragment mapping identifies an edge
+     * by its endpoints, so saving one proposition with two revisions of one source stored a single
+     * row. Reverting the write path to that mapping drops the edge count from two to one, which is
+     * what `one proposition holding two revisions of one source keeps both` pins.
+     *
+     * Reading through the object view was *not* shown to lose parallel edges — that same test passed
+     * against a view-based `findAll(withProvenance = true)`. The raw read is here so every provenance
+     * read goes through one path with one set of guarantees, rather than leaving some reads on a
+     * mapping whose behaviour on parallel edges nothing pins.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun withRawProvenance(lean: List<Proposition>): List<Proposition> {
         if (lean.isEmpty()) return lean
-        val ids = lean.map { it.id }
-        val byId = graphObjectManager.loadAll<PropositionWithProvenanceView> { where { proposition.id inList ids } }
-            .associate { it.proposition.id to PropositionGraphMapper.toProposition(it) }
-        return lean.map { byId[it.id] ?: it }
+        val rows = persistenceManager.query(
+            QuerySpecification.withStatement(
+                """
+                MATCH (p:Proposition)-[r:DERIVED_FROM]->(s:Source)
+                WHERE p.id IN ${'$'}ids
+                RETURN {
+                    propositionId: p.id,
+                    chunkId: r.chunkId,
+                    startOffset: r.startOffset,
+                    endOffset: r.endOffset,
+                    contentHash: r.contentHash,
+                    sourceRevision: r.sourceRevision,
+                    sourceKey: s.key,
+                    sourceKind: s.kind,
+                    sourceDisplay: s.display,
+                    sourceUri: s.uri,
+                    sourcePath: s.path,
+                    sourceContentHash: s.contentHash,
+                    connectorId: s.connectorId,
+                    externalId: s.externalId
+                } AS row
+                """.trimIndent()
+            ).bind(mapOf("ids" to lean.map { it.id }))
+        ) as List<Map<String, Any?>>
+        val byId = rows.groupBy { it["propositionId"] as String }
+        return lean.map { proposition ->
+            proposition.copy(provenanceEntries = byId[proposition.id].orEmpty().map(::toProvenanceEntry))
+        }
     }
+
+    private fun toProvenanceEntry(row: Map<String, Any?>): ProvenanceEntry =
+        PropositionGraphMapper.toProvenanceEntry(
+            DerivedFrom(
+                source = SourceNode(
+                    key = row["sourceKey"] as String,
+                    kind = row["sourceKind"] as String,
+                    display = row["sourceDisplay"] as? String,
+                    uri = row["sourceUri"] as? String,
+                    path = row["sourcePath"] as? String,
+                    contentHash = row["sourceContentHash"] as? String,
+                    connectorId = row["connectorId"] as? String,
+                    externalId = row["externalId"] as? String,
+                ),
+                chunkId = row["chunkId"] as? String,
+                startOffset = (row["startOffset"] as? Number)?.toInt(),
+                endOffset = (row["endOffset"] as? Number)?.toInt(),
+                contentHash = row["contentHash"] as? String,
+                sourceRevision = row["sourceRevision"] as? String,
+            ),
+        )
 
     /** Shared `where { }` filter block (PropositionView DSL); reused by query and the filtered-vector path. */
     context(builder: WhereBuilder<PropositionViewQueryDsl>)

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
@@ -29,6 +29,7 @@ import com.embabel.dice.proposition.PropositionQuery.OrderBy
 import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.GraphQueryCapable
 import com.embabel.dice.proposition.PropositionStatus
+import com.embabel.dice.proposition.SourceRevisionQueryCapable
 import com.embabel.dice.proposition.PropositionStoreType
 import com.embabel.dice.provenance.ProvenanceEntry
 import com.embabel.dice.provenance.SourceLocator
@@ -119,7 +120,7 @@ class DrivinePropositionRepository(
      * [findClusters] Cypher. Defaults to the canonical [VECTOR_INDEX]; overridable only for tests.
      */
     private val vectorIndexName: String = VECTOR_INDEX,
-) : PropositionRepository, GraphQueryCapable {
+) : PropositionRepository, GraphQueryCapable, SourceRevisionQueryCapable {
 
     private val logger = LoggerFactory.getLogger(DrivinePropositionRepository::class.java)
 
@@ -386,8 +387,13 @@ class DrivinePropositionRepository(
      *
      * Two structurally different locators that produce one key would otherwise take turns rewriting
      * each other's node, so the incoming identity is compared against what is stored and a mismatch
-     * fails the write rather than corrupting the shared node. `display` is presentation-only and is
-     * refreshed on every write; the identity fields are set once, on create.
+     * fails the write and leaves the shared node alone.
+     *
+     * Every property here is set once, on create — `display` included. The `:Source` node is global:
+     * one locator key is one node across every context that cites it. A refresh-on-write `display`
+     * therefore leaked one context's label into all the others, because whichever writer ran last
+     * owned the label everybody read. Write-once keeps the shared node stable while each writer's
+     * own evidence still lands on its own `DERIVED_FROM` edge.
      */
     @Suppress("UNCHECKED_CAST")
     private fun upsertSource(source: SourceNode, params: Map<String, Any?>) {
@@ -400,8 +406,8 @@ class DrivinePropositionRepository(
                               s.path = ${'$'}sourcePath,
                               s.contentHash = ${'$'}sourceContentHash,
                               s.connectorId = ${'$'}connectorId,
-                              s.externalId = ${'$'}externalId
-                SET s.display = ${'$'}sourceDisplay
+                              s.externalId = ${'$'}externalId,
+                              s.display = ${'$'}sourceDisplay
                 RETURN {
                     kind: s.kind,
                     uri: s.uri,
@@ -575,10 +581,10 @@ class DrivinePropositionRepository(
 
     // ---- Source provenance queries ----
     //
-    // The interface defaults filter loaded provenance in memory, and this backend's context read is
-    // lean — it carries no provenance at all — so without these overrides all three finders would
-    // return nothing here. Each one pushes its predicate into Cypher instead. The overrides sit on
-    // the plain-String variant because that is the one every typed call also routes through.
+    // This backend's context read is lean: it carries no provenance at all. That is exactly why
+    // SourceRevisionQueryCapable declares these finders abstract, and why this store has to earn the
+    // capability by pushing each predicate into Cypher. Implementations sit on the plain-String
+    // variant because that is the one every typed call also routes through.
 
     @Transactional(readOnly = true)
     override fun findBySourceKey(contextIdValue: String, sourceKey: String): List<Proposition> =

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
@@ -375,7 +375,8 @@ class DrivinePropositionRepository(
                         r.chunkId = ${'$'}chunkId,
                         r.startOffset = ${'$'}startOffset,
                         r.endOffset = ${'$'}endOffset,
-                        r.contentHash = ${'$'}contentHash
+                        r.contentHash = ${'$'}contentHash,
+                        r.display = ${'$'}sourceDisplay
                     """.trimIndent()
                 ).bind(params),
             )
@@ -389,11 +390,12 @@ class DrivinePropositionRepository(
      * each other's node, so the incoming identity is compared against what is stored and a mismatch
      * fails the write and leaves the shared node alone.
      *
-     * Every property here is set once, on create — `display` included. The `:Source` node is global:
-     * one locator key is one node across every context that cites it. A refresh-on-write `display`
-     * therefore leaked one context's label into all the others, because whichever writer ran last
-     * owned the label everybody read. Write-once keeps the shared node stable while each writer's
-     * own evidence still lands on its own `DERIVED_FROM` edge.
+     * Every property here is set once, on create, `display` included, so a reader of the bare node
+     * still sees a label. The `:Source` node is global: one locator key is one node across every
+     * context that cites it, so a label set here is shared, not owned by any one writer. The label a
+     * writer actually supplied travels on that writer's own `DERIVED_FROM` edge (see
+     * `appendProvenance`), and provenance reads take `display` from the edge, not the node, so no
+     * context ever sees another context's label.
      */
     @Suppress("UNCHECKED_CAST")
     private fun upsertSource(source: SourceNode, params: Map<String, Any?>) {
@@ -441,7 +443,8 @@ class DrivinePropositionRepository(
                   AND ((r.endOffset IS NULL AND ${'$'}endOffset IS NULL) OR r.endOffset = ${'$'}endOffset)
                   AND ((r.contentHash IS NULL AND ${'$'}contentHash IS NULL) OR r.contentHash = ${'$'}contentHash)
                 WITH r LIMIT 1
-                SET r.entryKey = ${'$'}entryKey
+                SET r.entryKey = ${'$'}entryKey,
+                    r.display = ${'$'}sourceDisplay
                 RETURN count(r) AS adopted
                 """.trimIndent()
             ).bind(params).transform(Long::class.java)
@@ -740,7 +743,7 @@ class DrivinePropositionRepository(
                     sourceRevision: r.sourceRevision,
                     sourceKey: s.key,
                     sourceKind: s.kind,
-                    sourceDisplay: s.display,
+                    sourceDisplay: coalesce(r.display, s.display),
                     sourceUri: s.uri,
                     sourcePath: s.path,
                     sourceContentHash: s.contentHash,

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/PropositionGraphMapper.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/PropositionGraphMapper.kt
@@ -40,11 +40,13 @@ import com.embabel.dice.temporal.TemporalMetadata
  * `metadata` rides along as a Drivine `@PropertyBag`.
  *
  * Two views over the same `:Proposition` node:
- * - [PropositionView] — lean (mentions only); the bulk/query/vector workhorse. [toProposition] from it
- *   returns a [Proposition] with **empty** `provenanceEntries` (provenance isn't projected).
- * - [PropositionWithProvenanceView] — adds `DERIVED_FROM` → shared [SourceNode]; used by `save` and
- *   `findById`. Sources are MERGEd by `SourceLocator.key()`, so a source cited by many propositions is
- *   one node.
+ * - [PropositionView] — lean (mentions only); the bulk/query/vector workhorse, and now the read side
+ *   of every path. [toProposition] from it returns a [Proposition] with **empty**
+ *   `provenanceEntries` (provenance isn't projected).
+ * - [PropositionWithProvenanceView] — adds `DERIVED_FROM` → shared [SourceNode]. Sources are MERGEd
+ *   by `SourceLocator.key()`, so a source cited by many propositions is one node. Its only remaining
+ *   use is the cascade in `DrivinePropositionRepository.delete`: provenance writes and reads both
+ *   moved to raw Cypher so parallel source revisions keep their own edges.
  *
  * The graph carries an `embedding` that is *not* part of [Proposition]; the repository owns it and
  * passes it in. `EntityMention.hints` is not yet persisted.
@@ -55,7 +57,13 @@ object PropositionGraphMapper {
     fun toView(p: Proposition, embedding: List<Float>? = null): PropositionView =
         PropositionView(proposition = nodeOf(p, embedding), mentions = mentionsOf(p))
 
-    /** Full view: mentions + provenance (`DERIVED_FROM` → shared [SourceNode]). */
+    /**
+     * Full view: mentions + provenance (`DERIVED_FROM` → shared [SourceNode]).
+     *
+     * No production caller left once provenance writes moved to raw Cypher. Kept for now because
+     * `delete` still cascades through the view it builds; slice 2 of the source-revision work decides
+     * whether both go.
+     */
     fun toProvenanceView(p: Proposition, embedding: List<Float>? = null): PropositionWithProvenanceView =
         PropositionWithProvenanceView(
             proposition = nodeOf(p, embedding),
@@ -168,22 +176,25 @@ object PropositionGraphMapper {
 
     // ---- Provenance: ProvenanceEntry <-> (DERIVED_FROM edge + shared Source node) ----
 
-    private fun toDerivedFrom(e: ProvenanceEntry): DerivedFrom =
+    internal fun toDerivedFrom(e: ProvenanceEntry): DerivedFrom =
         DerivedFrom(
             chunkId = e.chunkId,
             startOffset = e.startOffset,
             endOffset = e.endOffset,
             contentHash = e.contentHash,
             source = toSourceNode(e.locator),
+            sourceRevision = e.sourceRevision,
+            entryKey = provenanceStorageEntryKey(e),
         )
 
-    private fun toProvenanceEntry(df: DerivedFrom): ProvenanceEntry =
+    internal fun toProvenanceEntry(df: DerivedFrom): ProvenanceEntry =
         ProvenanceEntry(
             locator = toLocator(df.source),
             chunkId = df.chunkId,
             startOffset = df.startOffset,
             endOffset = df.endOffset,
             contentHash = df.contentHash,
+            sourceRevision = df.sourceRevision,
         )
 
     private fun toSourceNode(loc: SourceLocator): SourceNode =
@@ -228,3 +239,24 @@ object PropositionGraphMapper {
         )
     }
 }
+
+/**
+ * The storage identity of one `DERIVED_FROM` edge: every field of the evidence tuple, length-framed
+ * so a `-1` stands for null and no value needs escaping.
+ *
+ * This is deliberately a separate encoding from the domain's `ProvenanceEvidenceKey`, which is
+ * `internal` to the `dice` module and is the format collector traces record. Graph rows and fold
+ * records have different lifetimes, and pinning one to the other would make a change to either a
+ * migration of both.
+ */
+internal fun provenanceStorageEntryKey(entry: ProvenanceEntry): String =
+    listOf(
+        entry.locator.key(),
+        entry.sourceRevision,
+        entry.chunkId,
+        entry.startOffset?.toString(),
+        entry.endOffset?.toString(),
+        entry.contentHash,
+    ).joinToString(separator = "") { value ->
+        if (value == null) "-1:" else "${value.length}:$value"
+    }

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/DerivedFrom.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/DerivedFrom.kt
@@ -21,12 +21,24 @@ import org.drivine.annotation.RelationshipFragment
  * The `DERIVED_FROM` edge from a proposition to a shared [SourceNode]. The per-proposition span
  * (`chunkId`, offsets, the entry's own content hash) rides on the relationship; the source itself is
  * the shared node. Together they reconstitute a dice `ProvenanceEntry`.
+ *
+ * `sourceRevision` rides here too, for the same reason the span does: which version of a source a
+ * claim was read from is a fact about this citation, and the `:Source` node stays shared across
+ * every revision of it.
+ *
+ * `entryKey` is the edge's own identity, a length-framed encoding of the whole evidence tuple. The
+ * relationship needs one because a proposition can cite one source at several revisions, and an
+ * edge identified only by its two endpoints would collapse those into a single row. Writes MERGE on
+ * it. Edges written before revisions existed have no `entryKey`; they are adopted on first touch by
+ * an exactly matching revisionless entry.
  */
 @RelationshipFragment
-data class DerivedFrom(
+data class DerivedFrom @JvmOverloads constructor(
     val chunkId: String? = null,
     val startOffset: Int? = null,
     val endOffset: Int? = null,
     val contentHash: String? = null,
     val source: SourceNode,
+    val sourceRevision: String? = null,
+    val entryKey: String? = null,
 )

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -914,6 +914,67 @@ class DrivinePropositionStoreIntegrationTest {
         assertEquals(1L, edgeCount(stored.id))
     }
 
+    /**
+     * A `:Source` node is global: one locator key is one node, shared by every context that cites it.
+     * Its `display` label used to be refreshed on every write, so whichever writer ran last owned the
+     * label everybody else read — one context's presentation leaking into all the others.
+     *
+     * Two writers, same locator key, different labels. The second writer's evidence must land in
+     * full while the first writer's label survives untouched.
+     */
+    @Test
+    fun `a second writer cannot repaint a shared Source display`() {
+        val uri = "https://example.com/shared-display"
+        val firstWriter = UriLocator(uri, display = "First writer label")
+        val secondWriter = UriLocator(uri, display = "Second writer label")
+        assertEquals(firstWriter.key(), secondWriter.key(), "the two writers name one shared Source")
+
+        val first = repository.save(
+            prop("first writer fact", context = "ctx-display-a", provenance = listOf(evidence(firstWriter, "r1"))),
+        )
+        val second = repository.save(
+            prop("second writer fact", context = "ctx-display-b", provenance = listOf(evidence(secondWriter, "r2"))),
+        )
+
+        assertEquals(
+            "First writer label",
+            storedSourceDisplay(firstWriter.key()),
+            "display is write-once: the first writer owns the shared label",
+        )
+        assertEquals(
+            1L,
+            persistenceManager.getOne(
+                QuerySpecification
+                    .withStatement("MATCH (s:Source {key: \$sourceKey}) RETURN count(s) AS c")
+                    .bind(mapOf("sourceKey" to firstWriter.key()))
+                    .transform(Long::class.java),
+            ),
+            "both writers still share one Source node",
+        )
+
+        assertEquals(
+            listOf(first.id),
+            repository.findBySourceRevision(ContextId("ctx-display-a"), SourceRevisionRef(firstWriter.key(), "r1"))
+                .map { it.id },
+            "the first writer's evidence is queryable",
+        )
+        assertEquals(
+            listOf(second.id),
+            repository.findBySourceRevision(ContextId("ctx-display-b"), SourceRevisionRef(secondWriter.key(), "r2"))
+                .map { it.id },
+            "the second writer's evidence landed in full",
+        )
+        assertEquals("r2", repository.provenanceOf(second.id).single().sourceRevision)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun storedSourceDisplay(sourceKey: String): String? =
+        (persistenceManager.query(
+            QuerySpecification
+                .withStatement("MATCH (s:Source {key: \$sourceKey}) RETURN {display: s.display} AS row")
+                .bind(mapOf("sourceKey" to sourceKey)),
+        ) as List<Map<String, Any?>>).single()["display"] as String?
+
     private fun evidence(locator: UriLocator, revision: String?): ProvenanceEntry =
         ProvenanceEntry(locator = locator, sourceRevision = revision)
 

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -35,6 +35,7 @@ import com.embabel.dice.temporal.TemporalMetadata
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -872,46 +873,45 @@ class DrivinePropositionStoreIntegrationTest {
     }
 
     /**
-     * `ConnectorRef` builds its key by joining on colons, so `("a:b", "c")` and `("a", "b:c")` produce
-     * one key, and locator equality is key-based — the two entries compare *equal*. The novelty check
-     * therefore finds nothing new and would take the no-op path, filing the second connector's
-     * evidence under the first connector's source. Structural validation runs ahead of that path, so
-     * the write is rejected instead.
+     * `ConnectorRef` used to build its key by joining on a bare colon, so `("a:b", "c")` and
+     * `("a", "b:c")` rendered one key and, because locator equality is key-based, the two entries
+     * compared *equal*. Without the defensive guard that ran ahead of it, a second write naming the
+     * same fact and the once-colliding locator would have looked like an exact replay and taken the
+     * no-op path — the second connector's evidence would never have been persisted, silently. With
+     * the keys distinct there's no guard needed for this pair any more: the entries no longer compare
+     * equal, so the second write's locator is recognised as new evidence and folds onto the winner.
      */
     @Test
-    fun `dedup rejects a colliding connector source even when the entry looks already known`() {
+    fun `dedup no longer mistakes a source that used to collide for one it already knows`() {
         val original = ConnectorRef("a:b", "c")
-        val colliding = ConnectorRef("a", "b:c")
-        assertEquals(original.key(), colliding.key(), "the fixture depends on these keys colliding")
-        assertEquals(
+        val formerlyColliding = ConnectorRef("a", "b:c")
+        assertNotEquals(original.key(), formerlyColliding.key(), "the fixture used to depend on these keys colliding")
+        assertNotEquals(
             ProvenanceEntry(original),
-            ProvenanceEntry(colliding),
-            "and on the entries comparing equal, which is what reaches the no-op path",
+            ProvenanceEntry(formerlyColliding),
+            "and on the entries no longer comparing equal, which is what lets the second write's evidence count as new",
         )
         val stored = repository.save(
             prop("collision-prone fact", context = "ctx-collide", provenance = listOf(ProvenanceEntry(original))),
         )
 
-        val thrown = assertThrows<Exception> {
-            repository.save(
-                prop("collision-prone fact", context = "ctx-collide", provenance = listOf(ProvenanceEntry(colliding))),
-            )
-        }
-        assertTrue(
-            generateSequence(thrown as Throwable?) { it.cause }.any {
-                it is IllegalArgumentException && it.message?.contains("Source key collision") == true
-            },
-            "the colliding write must report the structural Source key collision; got: $thrown",
+        val second = repository.save(
+            prop(
+                "collision-prone fact",
+                context = "ctx-collide",
+                provenance = listOf(ProvenanceEntry(formerlyColliding)),
+            ),
         )
 
+        assertEquals(1, repository.count(), "dedup still collapses onto one proposition")
+        assertEquals(stored.id, second.id)
         val survivor = repository.findById(stored.id)!!
-        assertEquals(1, repository.count(), "the rejected write must not add a proposition")
         assertEquals(
-            listOf("a:b"),
-            survivor.provenanceEntries.map { (it.locator as ConnectorRef).connectorId },
-            "the stored source keeps its own identity",
+            setOf(original.key(), formerlyColliding.key()),
+            survivor.provenanceEntries.map { it.locator.key() }.toSet(),
+            "both tuples' evidence lands on the one proposition rather than the second replacing nothing",
         )
-        assertEquals(1L, edgeCount(stored.id))
+        assertEquals(2L, edgeCount(stored.id))
     }
 
     /**

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -917,13 +917,14 @@ class DrivinePropositionStoreIntegrationTest {
     /**
      * A `:Source` node is global: one locator key is one node, shared by every context that cites it.
      * Its `display` label used to be refreshed on every write, so whichever writer ran last owned the
-     * label everybody else read — one context's presentation leaking into all the others.
+     * label everybody else read, one context's presentation leaking into all the others. `display`
+     * now travels on each writer's own `DERIVED_FROM` edge, so provenance reads take it from there.
      *
-     * Two writers, same locator key, different labels. The second writer's evidence must land in
-     * full while the first writer's label survives untouched.
+     * Two writers, same locator key, different labels. Each context must read back its own label,
+     * and the two writers still share one `:Source` node.
      */
     @Test
-    fun `a second writer cannot repaint a shared Source display`() {
+    fun `each context reads back its own Source display`() {
         val uri = "https://example.com/shared-display"
         val firstWriter = UriLocator(uri, display = "First writer label")
         val secondWriter = UriLocator(uri, display = "Second writer label")
@@ -938,8 +939,15 @@ class DrivinePropositionStoreIntegrationTest {
 
         assertEquals(
             "First writer label",
-            storedSourceDisplay(firstWriter.key()),
-            "display is write-once: the first writer owns the shared label",
+            repository.findBySourceRevision(ContextId("ctx-display-a"), SourceRevisionRef(firstWriter.key(), "r1"))
+                .single().provenanceEntries.single().locator.display,
+            "ctx-display-a reads back its own writer's label",
+        )
+        assertEquals(
+            "Second writer label",
+            repository.findBySourceRevision(ContextId("ctx-display-b"), SourceRevisionRef(secondWriter.key(), "r2"))
+                .single().provenanceEntries.single().locator.display,
+            "ctx-display-b reads back its own writer's label, not ctx-display-a's",
         )
         assertEquals(
             1L,
@@ -952,28 +960,9 @@ class DrivinePropositionStoreIntegrationTest {
             "both writers still share one Source node",
         )
 
-        assertEquals(
-            listOf(first.id),
-            repository.findBySourceRevision(ContextId("ctx-display-a"), SourceRevisionRef(firstWriter.key(), "r1"))
-                .map { it.id },
-            "the first writer's evidence is queryable",
-        )
-        assertEquals(
-            listOf(second.id),
-            repository.findBySourceRevision(ContextId("ctx-display-b"), SourceRevisionRef(secondWriter.key(), "r2"))
-                .map { it.id },
-            "the second writer's evidence landed in full",
-        )
+        assertEquals("r1", repository.provenanceOf(first.id).single().sourceRevision)
         assertEquals("r2", repository.provenanceOf(second.id).single().sourceRevision)
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun storedSourceDisplay(sourceKey: String): String? =
-        (persistenceManager.query(
-            QuerySpecification
-                .withStatement("MATCH (s:Source {key: \$sourceKey}) RETURN {display: s.display} AS row")
-                .bind(mapOf("sourceKey" to sourceKey)),
-        ) as List<Map<String, Any?>>).single()["display"] as String?
 
     private fun evidence(locator: UriLocator, revision: String?): ProvenanceEntry =
         ProvenanceEntry(locator = locator, sourceRevision = revision)

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -27,13 +27,16 @@ import com.embabel.dice.proposition.MentionRole
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionQuery
 import com.embabel.dice.proposition.PropositionStatus
+import com.embabel.dice.provenance.ConnectorRef
 import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.SourceRevisionRef
 import com.embabel.dice.provenance.UriLocator
 import com.embabel.dice.temporal.TemporalMetadata
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -41,13 +44,20 @@ import org.drivine.manager.CascadeType
 import org.drivine.manager.GraphObjectManager
 import org.drivine.manager.PersistenceManager
 import org.drivine.query.QuerySpecification
+import org.springframework.aop.framework.ProxyFactory
+import org.springframework.aop.support.AopUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource
+import org.springframework.transaction.interceptor.TransactionInterceptor
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 /**
  * Integration tests for the graph storage stack against a Neo4j testcontainer. Not `@Transactional`:
@@ -574,6 +584,391 @@ class DrivinePropositionStoreIntegrationTest {
             QuerySpecification.withStatement("MATCH (s:Source) RETURN count(s) AS c").transform(Long::class.java),
         )
         assertEquals(2L, sourceCount, "repeating a source must not create a duplicate :Source node")
+    }
+
+    /**
+     * The three source finders against the real backend. Their interface defaults filter loaded
+     * provenance in memory, and this backend's context read carries none, so without the pushdown
+     * overrides every assertion here would see an empty list.
+     */
+    @Test
+    fun `source queries push down by context and distinguish exact and revisionless evidence`() {
+        val locator = UriLocator("https://example.com/query-source")
+        val revisionless = repository.save(
+            prop("revisionless ctx-a", context = "ctx-a", provenance = listOf(evidence(locator, null))),
+        )
+        val revisionOne = repository.save(
+            prop("r1 ctx-a", context = "ctx-a", provenance = listOf(evidence(locator, "r1"))),
+        )
+        val revisionTwo = repository.save(
+            prop("r2 ctx-a", context = "ctx-a", provenance = listOf(evidence(locator, "r2"))),
+        )
+        repository.save(
+            prop("r1 ctx-b", context = "ctx-b", provenance = listOf(evidence(locator, "r1"))),
+        )
+        val context = ContextId("ctx-a")
+
+        assertEquals(
+            setOf(revisionless.id, revisionOne.id, revisionTwo.id),
+            repository.findBySourceKey(context, locator.key()).map { it.id }.toSet(),
+            "every revision of the source, and only this tenant's",
+        )
+        assertEquals(
+            listOf(revisionOne.id),
+            repository.findBySourceRevision(context, SourceRevisionRef(locator.key(), "r1")).map { it.id },
+        )
+        assertEquals(
+            listOf(revisionless.id),
+            repository.findRevisionlessBySourceLocator(context, locator).map { it.id },
+        )
+        assertEquals(
+            "r1",
+            repository.findBySourceRevision(context, SourceRevisionRef(locator.key(), "r1"))
+                .single().provenanceEntries.single().sourceRevision,
+            "the matched proposition carries its revision back out of the graph",
+        )
+    }
+
+    /** The same three finders reached through their plain-String variants, as a Java caller would. */
+    @Test
+    fun `string source queries reach the same pushdown`() {
+        val locator = UriLocator("https://example.com/string-source")
+        val saved = repository.save(
+            prop("string r1", context = "ctx-string", provenance = listOf(evidence(locator, "r1"))),
+        )
+
+        assertEquals(
+            listOf(saved.id),
+            repository.findBySourceKey("ctx-string", locator.key()).map { it.id },
+        )
+        assertEquals(
+            listOf(saved.id),
+            repository.findBySourceRevision("ctx-string", SourceRevisionRef(locator.key(), "r1"))
+                .map { it.id },
+        )
+        assertEquals(
+            emptyList<String>(),
+            repository.findRevisionlessBySourceLocator("ctx-string", locator).map { it.id },
+        )
+    }
+
+    /**
+     * A graph written before the revision existed: the `DERIVED_FROM` edge simply has no
+     * `sourceRevision` property. It must read back as revisionless evidence and answer the
+     * revisionless query, which is what makes this change need no migration.
+     */
+    @Test
+    fun `an edge with no sourceRevision property reads back as revisionless`() {
+        val locator = UriLocator("https://example.com/pre-existing")
+        val saved = repository.save(prop("pre-existing fact", context = "ctx-legacy"))
+        persistenceManager.execute(
+            QuerySpecification
+                .withStatement(
+                    "MATCH (p:Proposition {id: \$id}) " +
+                        "MERGE (s:Source {key: \$sourceKey}) " +
+                        "SET s.kind = 'uri', s.uri = \$uri " +
+                        "MERGE (p)-[:DERIVED_FROM {chunkId: 'legacy-chunk'}]->(s)",
+                )
+                .bind(
+                    mapOf(
+                        "id" to saved.id,
+                        "sourceKey" to locator.key(),
+                        "uri" to locator.uri,
+                    ),
+                ),
+        )
+
+        val entry = repository.provenanceOf(saved.id).single()
+        assertNull(entry.sourceRevision, "a missing edge property is absence, not a value")
+        assertEquals("legacy-chunk", entry.chunkId)
+        assertEquals(
+            listOf(saved.id),
+            repository.findRevisionlessBySourceLocator(ContextId("ctx-legacy"), locator).map { it.id },
+        )
+        assertEquals(
+            listOf(saved.id),
+            repository.findBySourceKey(ContextId("ctx-legacy"), locator.key()).map { it.id },
+        )
+    }
+
+    /**
+     * One proposition citing one source at two revisions. Relationship-fragment mapping identifies
+     * an edge by its endpoints alone, which would store a single row here and lose a revision, so
+     * this asserts two edges, both exact-revision queries, and a full read carrying both entries.
+     */
+    @Test
+    fun `one proposition holding two revisions of one source keeps both`() {
+        val locator = UriLocator("https://example.com/parallel")
+        val revisionOne = evidence(locator, "r1")
+        val revisionTwo = evidence(locator, "r2")
+        val saved = repository.save(
+            prop("parallel revisions", context = "ctx-parallel", provenance = listOf(revisionOne, revisionTwo)),
+        )
+        val context = ContextId("ctx-parallel")
+
+        val sourceCount = persistenceManager.getOne(
+            QuerySpecification
+                .withStatement("MATCH (s:Source {key: \$sourceKey}) RETURN count(s) AS c")
+                .bind(mapOf("sourceKey" to locator.key()))
+                .transform(Long::class.java),
+        )
+        val edgeCount = persistenceManager.getOne(
+            QuerySpecification
+                .withStatement(
+                    "MATCH (:Proposition {id: \$id})-[r:DERIVED_FROM]->(:Source {key: \$sourceKey}) " +
+                        "RETURN count(r) AS c",
+                )
+                .bind(mapOf("id" to saved.id, "sourceKey" to locator.key()))
+                .transform(Long::class.java),
+        )
+        assertEquals(1L, sourceCount, "both revisions cite one shared Source node")
+        assertEquals(2L, edgeCount, "each revision needs its own DERIVED_FROM edge")
+
+        assertEquals(
+            listOf(saved.id),
+            repository.findBySourceRevision(context, SourceRevisionRef(locator.key(), "r1")).map { it.id },
+        )
+        assertEquals(
+            listOf(saved.id),
+            repository.findBySourceRevision(context, SourceRevisionRef(locator.key(), "r2")).map { it.id },
+        )
+
+        val expected = setOf(revisionOne, revisionTwo)
+        assertEquals(expected, repository.findById(saved.id)!!.provenanceEntries.toSet())
+        assertEquals(
+            expected,
+            repository.findAll(withProvenance = true).single { it.id == saved.id }.provenanceEntries.toSet(),
+        )
+        assertEquals(
+            expected,
+            repository.query(PropositionQuery.forContextId(context), withProvenance = true)
+                .single { it.id == saved.id }.provenanceEntries.toSet(),
+        )
+    }
+
+    /**
+     * A later extraction over a newer revision that produces the same fact text. Exact-text dedup
+     * answers with the existing proposition, so unless its evidence is unioned in, the newer
+     * revision is silently lost and never becomes queryable.
+     */
+    @Test
+    fun `exact-text dedup unions a second revision into the winner`() {
+        val locator = UriLocator("https://example.com/dedup-source")
+        val context = ContextId("ctx-dedup")
+        val first = repository.save(
+            prop("the same extracted fact", context = "ctx-dedup", provenance = listOf(evidence(locator, "r1"))),
+        )
+        val second = repository.save(
+            prop("the same extracted fact", context = "ctx-dedup", provenance = listOf(evidence(locator, "r2"))),
+        )
+
+        assertEquals(first.id, second.id, "the second save collapses onto the existing proposition")
+        assertEquals(
+            1L,
+            persistenceManager.getOne(
+                QuerySpecification
+                    .withStatement(
+                        "MATCH (p:Proposition {contextId: \$contextId}) WHERE p.text = \$text RETURN count(p) AS c",
+                    )
+                    .bind(mapOf("contextId" to "ctx-dedup", "text" to "the same extracted fact"))
+                    .transform(Long::class.java),
+            ),
+        )
+        assertEquals(
+            listOf(first.id),
+            repository.findBySourceRevision(context, SourceRevisionRef(locator.key(), "r1")).map { it.id },
+        )
+        assertEquals(
+            listOf(first.id),
+            repository.findBySourceRevision(context, SourceRevisionRef(locator.key(), "r2")).map { it.id },
+            "the deduped revision must still be queryable",
+        )
+        assertEquals(
+            setOf("r1", "r2"),
+            repository.findById(first.id)!!.provenanceEntries.map { it.sourceRevision }.toSet(),
+        )
+
+        val beforeReplay = repository.findById(first.id)!!
+        repository.save(prop("the same extracted fact", context = "ctx-dedup", provenance = listOf(evidence(locator, "r2"))))
+        val afterReplay = repository.findById(first.id)!!
+        assertEquals(2, afterReplay.provenanceEntries.size, "replaying an existing revision adds nothing")
+        assertEquals(
+            beforeReplay.metadataRevised,
+            afterReplay.metadataRevised,
+            "an exact replay must not write — metadataRevised would advance if it did",
+        )
+    }
+
+    /**
+     * The source queries must plan on a store that never adopted the optional `(contextId, text)`
+     * constraint — `dice-storage`'s schema is adopter-supplied, and Neo4j fails a query outright
+     * when an index hint names something absent.
+     */
+    @Test
+    fun `source queries run without the optional context-text constraint`() {
+        val locator = UriLocator("https://example.com/no-constraint")
+        withoutContextTextConstraint {
+            val saved = repository.save(
+                prop("unconstrained", context = "ctx-bare", provenance = listOf(evidence(locator, "r1"))),
+            )
+            val context = ContextId("ctx-bare")
+
+            assertEquals(listOf(saved.id), repository.findBySourceKey(context, locator.key()).map { it.id })
+            assertEquals(
+                listOf(saved.id),
+                repository.findBySourceRevision(context, SourceRevisionRef(locator.key(), "r1")).map { it.id },
+            )
+            assertEquals(
+                emptyList<String>(),
+                repository.findRevisionlessBySourceLocator(context, locator).map { it.id },
+            )
+        }
+    }
+
+    /**
+     * Two Spring-proxied repositories racing on one `(contextId, text)`, each carrying a different
+     * revision. Separate targets mean separate lock stripes, so the loser reaches the database and is
+     * rejected by the uniqueness constraint; its recovery then has to union its revision into the
+     * winner. Recovery can only commit if it runs in a transaction the failed attempt did not poison.
+     */
+    @Test
+    fun `two proxied repositories racing on one text land both revisions on the winner`() {
+        val locator = UriLocator("https://example.com/race")
+        val revisionOne = evidence(locator, "r1")
+        val revisionTwo = evidence(locator, "r2")
+        val first = prop("cross-instance fact", context = "ctx-race", provenance = listOf(revisionOne))
+        val second = prop("cross-instance fact", context = "ctx-race", provenance = listOf(revisionTwo))
+        val barrier = CountDownLatch(2)
+        val firstRepository = newTransactionProxiedRepository(
+            DedupLookupBarrierPersistenceManager(persistenceManager, barrier),
+        )
+        val secondRepository = newTransactionProxiedRepository(
+            DedupLookupBarrierPersistenceManager(persistenceManager, barrier),
+        )
+        assertTrue(AopUtils.isAopProxy(firstRepository), "the writer must carry the transaction advisor")
+        assertTrue(AopUtils.isAopProxy(secondRepository), "the sibling writer must carry it too")
+
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val winners = listOf(
+                executor.submit<Proposition> { firstRepository.save(first) },
+                executor.submit<Proposition> { secondRepository.save(second) },
+            ).map { it.get(30, TimeUnit.SECONDS) }
+
+            assertEquals(1, winners.map { it.id }.toSet().size, "both writers must return the database winner")
+            val winnerId = winners.first().id
+            assertEquals(
+                setOf(revisionOne, revisionTwo),
+                repository.findById(winnerId)!!.provenanceEntries.toSet(),
+                "the losing writer's recovery must commit its revision onto the winner",
+            )
+            assertEquals(2L, edgeCount(winnerId))
+
+            secondRepository.save(second)
+            assertEquals(2L, edgeCount(winnerId), "retrying recovered evidence stays idempotent")
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    /**
+     * `ConnectorRef` builds its key by joining on colons, so `("a:b", "c")` and `("a", "b:c")` produce
+     * one key, and locator equality is key-based — the two entries compare *equal*. The novelty check
+     * therefore finds nothing new and would take the no-op path, filing the second connector's
+     * evidence under the first connector's source. Structural validation runs ahead of that path, so
+     * the write is rejected instead.
+     */
+    @Test
+    fun `dedup rejects a colliding connector source even when the entry looks already known`() {
+        val original = ConnectorRef("a:b", "c")
+        val colliding = ConnectorRef("a", "b:c")
+        assertEquals(original.key(), colliding.key(), "the fixture depends on these keys colliding")
+        assertEquals(
+            ProvenanceEntry(original),
+            ProvenanceEntry(colliding),
+            "and on the entries comparing equal, which is what reaches the no-op path",
+        )
+        val stored = repository.save(
+            prop("collision-prone fact", context = "ctx-collide", provenance = listOf(ProvenanceEntry(original))),
+        )
+
+        val thrown = assertThrows<Exception> {
+            repository.save(
+                prop("collision-prone fact", context = "ctx-collide", provenance = listOf(ProvenanceEntry(colliding))),
+            )
+        }
+        assertTrue(
+            generateSequence(thrown as Throwable?) { it.cause }.any {
+                it is IllegalArgumentException && it.message?.contains("Source key collision") == true
+            },
+            "the colliding write must report the structural Source key collision; got: $thrown",
+        )
+
+        val survivor = repository.findById(stored.id)!!
+        assertEquals(1, repository.count(), "the rejected write must not add a proposition")
+        assertEquals(
+            listOf("a:b"),
+            survivor.provenanceEntries.map { (it.locator as ConnectorRef).connectorId },
+            "the stored source keeps its own identity",
+        )
+        assertEquals(1L, edgeCount(stored.id))
+    }
+
+    private fun evidence(locator: UriLocator, revision: String?): ProvenanceEntry =
+        ProvenanceEntry(locator = locator, sourceRevision = revision)
+
+    private fun edgeCount(propositionId: String): Long =
+        persistenceManager.getOne(
+            QuerySpecification
+                .withStatement(
+                    "MATCH (:Proposition {id: \$propositionId})-[r:DERIVED_FROM]->() RETURN count(r) AS c",
+                )
+                .bind(mapOf("propositionId" to propositionId))
+                .transform(Long::class.java),
+        )
+
+    /**
+     * A repository target behind the same transaction interceptor a Spring Boot app puts in front of
+     * it. Separate targets model two application instances — and so two lock stripes.
+     *
+     * The interceptor is built here rather than borrowed off the injected bean, because this test
+     * context does not enable transaction management, so the injected bean is not proxied. Production
+     * is: Boot's `TransactionAutoConfiguration` proxies any `@Transactional` bean. Without this
+     * wrapper the annotations on `save` never run, which is exactly why the transaction-joining bug
+     * was invisible to every other test in this class.
+     */
+    private fun newTransactionProxiedRepository(
+        repositoryPersistenceManager: PersistenceManager = persistenceManager,
+    ): DrivinePropositionRepository {
+        val proxyFactory = ProxyFactory(
+            DrivinePropositionRepository(
+                graphObjectManager,
+                repositoryPersistenceManager,
+                embeddingService,
+                transactionManager,
+            ),
+        )
+        proxyFactory.setProxyTargetClass(true)
+        proxyFactory.addAdvice(
+            TransactionInterceptor(transactionManager, AnnotationTransactionAttributeSource()),
+        )
+        return proxyFactory.proxy as DrivinePropositionRepository
+    }
+
+    /** Holds both writers at the dedup lookup until each has seen no duplicate, forcing the race. */
+    private class DedupLookupBarrierPersistenceManager(
+        private val delegate: PersistenceManager,
+        private val barrier: CountDownLatch,
+    ) : PersistenceManager by delegate {
+
+        override fun <T : Any> maybeGetOne(spec: QuerySpecification<T>): T? {
+            val result = delegate.maybeGetOne(spec)
+            if (result == null && spec.parameters.keys == setOf("contextId", "text", "excludeId")) {
+                barrier.countDown()
+                assertTrue(barrier.await(10, TimeUnit.SECONDS), "both repositories must observe no duplicate")
+            }
+            return result
+        }
     }
 
     /** Provenance management: setProvenance authoritatively replaces and orphans the dropped source. */

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingPropositionRepository.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingPropositionRepository.kt
@@ -22,6 +22,8 @@ import com.embabel.common.core.types.ZeroToOne
 import com.embabel.dice.common.DiceEventListener
 import com.embabel.dice.common.PropositionPersisted
 import com.embabel.dice.common.PropositionStatusChanged
+import com.embabel.dice.provenance.SourceLocator
+import com.embabel.dice.provenance.SourceRevisionRef
 import org.slf4j.LoggerFactory
 
 /**
@@ -63,9 +65,13 @@ import org.slf4j.LoggerFactory
 class EventEmittingPropositionRepository(
     private val delegate: PropositionRepository,
     private val listener: DiceEventListener = DiceEventListener.DEV_NULL,
-) : PropositionRepository by delegate {
+) : PropositionRepository by delegate, SourceRevisionQueryCapable {
 
     private val logger = LoggerFactory.getLogger(EventEmittingPropositionRepository::class.java)
+
+    /** The delegate's source-revision capability, if it has one. Resolved once at construction. */
+    private val delegateRevisionQueries: SourceRevisionQueryCapable? =
+        delegate as? SourceRevisionQueryCapable
 
     /**
      * Persists via the delegate, then emits one lifecycle event carrying the saved instance.
@@ -145,4 +151,41 @@ class EventEmittingPropositionRepository(
         query: PropositionQuery,
     ): List<Cluster<Proposition>> =
         delegate.findClusters(similarityThreshold, topK, query)
+
+    // ========================================================================
+    // Source-revision capability forwarding
+    //
+    // The delegate is typed as PropositionRepository, which carries no source-revision surface, so
+    // this decorator can only forward what the concrete delegate happens to bring. A decorator that
+    // silently answered empty would reintroduce the false negative the capability split exists to
+    // remove, so an unable delegate is reported two ways: supportsSourceRevisionQueries goes false,
+    // and a call that gets through anyway throws with the delegate named.
+    // ========================================================================
+
+    /** True when the wrapped repository can genuinely answer source-revision queries. */
+    override val supportsSourceRevisionQueries: Boolean
+        get() = delegateRevisionQueries?.supportsSourceRevisionQueries == true
+
+    override fun findBySourceKey(contextIdValue: String, sourceKey: String): List<Proposition> =
+        requireRevisionQueries("findBySourceKey").findBySourceKey(contextIdValue, sourceKey)
+
+    override fun findBySourceRevision(contextIdValue: String, ref: SourceRevisionRef): List<Proposition> =
+        requireRevisionQueries("findBySourceRevision").findBySourceRevision(contextIdValue, ref)
+
+    override fun findRevisionlessBySourceLocator(
+        contextIdValue: String,
+        locator: SourceLocator,
+    ): List<Proposition> =
+        requireRevisionQueries("findRevisionlessBySourceLocator")
+            .findRevisionlessBySourceLocator(contextIdValue, locator)
+
+    /**
+     * The delegate's capability, or a thrown explanation naming the delegate that lacks it.
+     */
+    private fun requireRevisionQueries(operation: String): SourceRevisionQueryCapable =
+        delegateRevisionQueries?.takeIf { it.supportsSourceRevisionQueries }
+            ?: throw UnsupportedOperationException(
+                "$operation needs a delegate that implements SourceRevisionQueryCapable; " +
+                    "${delegate.javaClass.name} cannot answer source-revision queries",
+            )
 }

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingPropositionRepository.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingPropositionRepository.kt
@@ -22,8 +22,6 @@ import com.embabel.common.core.types.ZeroToOne
 import com.embabel.dice.common.DiceEventListener
 import com.embabel.dice.common.PropositionPersisted
 import com.embabel.dice.common.PropositionStatusChanged
-import com.embabel.dice.provenance.SourceLocator
-import com.embabel.dice.provenance.SourceRevisionRef
 import org.slf4j.LoggerFactory
 
 /**
@@ -51,9 +49,14 @@ import org.slf4j.LoggerFactory
  * Throw isolation is the listener's responsibility — wrap the listener in `SafeDiceEventListener`
  * if you need graceful degradation.
  *
+ * This class does not itself implement `SourceRevisionQueryCapable`, so it carries the capability
+ * only when its delegate does: use [wrapping] to build the right shape for whatever delegate you
+ * hand it, so a caller's `as? SourceRevisionQueryCapable` probe on the wrapper answers the same way
+ * it would on the delegate.
+ *
  * Example usage:
  * ```kotlin
- * val repo = EventEmittingPropositionRepository(
+ * val repo = EventEmittingPropositionRepository.wrapping(
  *     delegate = inMemoryRepository,
  *     listener = SafeDiceEventListener(myListener),
  * )
@@ -62,16 +65,33 @@ import org.slf4j.LoggerFactory
  * @property delegate The underlying repository. All non-write methods forward here.
  * @property listener Notified after each persist. Defaults to [DiceEventListener.DEV_NULL] (no-op).
  */
-class EventEmittingPropositionRepository(
-    private val delegate: PropositionRepository,
+open class EventEmittingPropositionRepository(
+    protected val delegate: PropositionRepository,
     private val listener: DiceEventListener = DiceEventListener.DEV_NULL,
-) : PropositionRepository by delegate, SourceRevisionQueryCapable {
+) : PropositionRepository by delegate {
 
     private val logger = LoggerFactory.getLogger(EventEmittingPropositionRepository::class.java)
 
-    /** The delegate's source-revision capability, if it has one. Resolved once at construction. */
-    private val delegateRevisionQueries: SourceRevisionQueryCapable? =
-        delegate as? SourceRevisionQueryCapable
+    companion object {
+        /**
+         * Build the decorator over [delegate], picking the shape that matches what [delegate] can
+         * do: when it implements [SourceRevisionQueryCapable], the returned instance does too and
+         * forwards to it, so a caller's `as?` probe on the wrapper answers the way it answers on the
+         * delegate. Over a plain repository, the returned instance carries no source-revision
+         * surface at all.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun wrapping(
+            delegate: PropositionRepository,
+            listener: DiceEventListener = DiceEventListener.DEV_NULL,
+        ): EventEmittingPropositionRepository =
+            if (delegate is SourceRevisionQueryCapable) {
+                SourceRevisionEventEmittingPropositionRepository(delegate, listener)
+            } else {
+                EventEmittingPropositionRepository(delegate, listener)
+            }
+    }
 
     /**
      * Persists via the delegate, then emits one lifecycle event carrying the saved instance.
@@ -151,41 +171,20 @@ class EventEmittingPropositionRepository(
         query: PropositionQuery,
     ): List<Cluster<Proposition>> =
         delegate.findClusters(similarityThreshold, topK, query)
-
-    // ========================================================================
-    // Source-revision capability forwarding
-    //
-    // The delegate is typed as PropositionRepository, which carries no source-revision surface, so
-    // this decorator can only forward what the concrete delegate happens to bring. A decorator that
-    // silently answered empty would reintroduce the false negative the capability split exists to
-    // remove, so an unable delegate is reported two ways: supportsSourceRevisionQueries goes false,
-    // and a call that gets through anyway throws with the delegate named.
-    // ========================================================================
-
-    /** True when the wrapped repository can genuinely answer source-revision queries. */
-    override val supportsSourceRevisionQueries: Boolean
-        get() = delegateRevisionQueries?.supportsSourceRevisionQueries == true
-
-    override fun findBySourceKey(contextIdValue: String, sourceKey: String): List<Proposition> =
-        requireRevisionQueries("findBySourceKey").findBySourceKey(contextIdValue, sourceKey)
-
-    override fun findBySourceRevision(contextIdValue: String, ref: SourceRevisionRef): List<Proposition> =
-        requireRevisionQueries("findBySourceRevision").findBySourceRevision(contextIdValue, ref)
-
-    override fun findRevisionlessBySourceLocator(
-        contextIdValue: String,
-        locator: SourceLocator,
-    ): List<Proposition> =
-        requireRevisionQueries("findRevisionlessBySourceLocator")
-            .findRevisionlessBySourceLocator(contextIdValue, locator)
-
-    /**
-     * The delegate's capability, or a thrown explanation naming the delegate that lacks it.
-     */
-    private fun requireRevisionQueries(operation: String): SourceRevisionQueryCapable =
-        delegateRevisionQueries?.takeIf { it.supportsSourceRevisionQueries }
-            ?: throw UnsupportedOperationException(
-                "$operation needs a delegate that implements SourceRevisionQueryCapable; " +
-                    "${delegate.javaClass.name} cannot answer source-revision queries",
-            )
 }
+
+/**
+ * The same event-emitting decorator, over a delegate that also answers source-revision queries.
+ *
+ * Carrying `SourceRevisionQueryCapable by delegate` here and not on the base class is what makes
+ * the capability honest: a caller's `as? SourceRevisionQueryCapable` probe on this wrapper answers
+ * exactly the way it would on the delegate. It cannot pass the type check and then fail at call
+ * time. Built by [EventEmittingPropositionRepository.wrapping]; construct it directly only if you
+ * already have a delegate typed as both interfaces in hand.
+ */
+class SourceRevisionEventEmittingPropositionRepository<T>(
+    delegate: T,
+    listener: DiceEventListener = DiceEventListener.DEV_NULL,
+) : EventEmittingPropositionRepository(delegate, listener),
+    SourceRevisionQueryCapable by delegate
+    where T : PropositionRepository, T : SourceRevisionQueryCapable

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/Proposition.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/Proposition.kt
@@ -20,6 +20,7 @@ import com.embabel.agent.core.ContextId
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.common.core.types.ZeroToOne
 import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import com.embabel.dice.temporal.TemporalMetadata
 import org.jetbrains.annotations.ApiStatus
 import java.time.Instant
@@ -337,9 +338,9 @@ data class Proposition(
     /**
      * Create a copy with exactly [groundingToRemove], [provenanceRefsToRemove] and
      * [sourceIdsToRemove] taken out of this proposition's evidence — the inverse of
-     * [absorbEvidence] for one loser's contribution. Provenance entries are matched by
-     * [com.embabel.dice.provenance.SourceLocator.key], the same identity [absorbEvidence]'s
-     * caller uses to record a loser's folded refs (see `RetiredProposition.foldedProvenanceRefs`).
+     * [absorbEvidence] for one loser's contribution. Provenance refs use the shared evidence-key
+     * contract so current refs identify one full entry while legacy locator refs match only
+     * revisionless evidence.
      *
      * Callers subtracting one collapsed member's evidence from a survivor that absorbed several
      * members must first drop any ref another still-retired member also contributed, or this
@@ -355,7 +356,9 @@ data class Proposition(
         val provenanceRefSet = provenanceRefsToRemove.toSet()
         return copy(
             grounding = grounding - groundingToRemove.toSet(),
-            provenanceEntries = provenanceEntries.filterNot { it.locator.key() in provenanceRefSet },
+            provenanceEntries = provenanceEntries.filterNot { entry ->
+                provenanceRefSet.any { ProvenanceEvidenceKey.matches(entry, it) }
+            },
             sourceIds = sourceIds - sourceIdsToRemove.toSet(),
             metadataRevised = Instant.now(),
         )

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionRepository.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionRepository.kt
@@ -22,8 +22,6 @@ import com.embabel.common.core.types.SimilarityResult
 import com.embabel.common.core.types.TextSimilaritySearchRequest
 import com.embabel.common.util.loggerFor
 import com.embabel.dice.provenance.ProvenanceEntry
-import com.embabel.dice.provenance.SourceLocator
-import com.embabel.dice.provenance.SourceRevisionRef
 
 /**
  * The full proposition repository: combines the base persistence port with every opt-in
@@ -75,81 +73,6 @@ interface PropositionRepository :
      * delegates to the lean [findAll] — fine for backends that always carry provenance (e.g. in-memory).
      */
     fun findAll(withProvenance: Boolean): List<Proposition> = findAll()
-
-    // ========================================================================
-    // Source provenance queries
-    //
-    // Each finder is a pair: a typed entry point taking a ContextId, and a plain-String variant that
-    // holds the default body. The typed one forwards to the String one, matching
-    // findByContextId -> findByContextIdValue in PropositionStore. Overrides belong on the String
-    // variant, because ContextId is a value class: the typed method's JVM name is mangled and a Java
-    // backend cannot override it, so an override placed there would be invisible to Java callers.
-    // The String variant has an ordinary JVM signature and sits on the path of every typed call.
-    //
-    // The default bodies read the context and filter loaded provenance in memory, which is correct
-    // for any backend whose context read carries provenance. A backend whose context read is lean
-    // MUST override all three, or its callers get empty results; dice-storage's
-    // DrivinePropositionRepository does, pushing each predicate into Cypher.
-    // ========================================================================
-
-    /**
-     * Find propositions in [contextId] with evidence from any revision of [sourceKey].
-     *
-     * Both revisioned and revisionless evidence matches when its locator key equals [sourceKey].
-     */
-    fun findBySourceKey(contextId: ContextId, sourceKey: String): List<Proposition> =
-        findBySourceKey(contextId.value, sourceKey)
-
-    /**
-     * [findBySourceKey] by plain context-id string — the override point, and what Java callers use.
-     */
-    fun findBySourceKey(contextIdValue: String, sourceKey: String): List<Proposition> =
-        findByContextId(ContextId(contextIdValue)).filter { proposition ->
-            proposition.provenanceEntries.any { it.locator.key() == sourceKey }
-        }
-
-    /**
-     * Find propositions in [contextId] with evidence from exactly [ref]'s source key and revision.
-     */
-    fun findBySourceRevision(contextId: ContextId, ref: SourceRevisionRef): List<Proposition> =
-        findBySourceRevision(contextId.value, ref)
-
-    /**
-     * [findBySourceRevision] by plain context-id string — the override point, and what Java callers
-     * use.
-     */
-    fun findBySourceRevision(contextIdValue: String, ref: SourceRevisionRef): List<Proposition> =
-        findByContextId(ContextId(contextIdValue)).filter { proposition ->
-            proposition.provenanceEntries.any {
-                it.locator.key() == ref.sourceKey && it.sourceRevision == ref.sourceRevision
-            }
-        }
-
-    /**
-     * Find propositions in [contextId] with revisionless evidence whose locator key equals
-     * [locator]'s key.
-     *
-     * Evidence carrying any revision does not match.
-     */
-    fun findRevisionlessBySourceLocator(
-        contextId: ContextId,
-        locator: SourceLocator,
-    ): List<Proposition> =
-        findRevisionlessBySourceLocator(contextId.value, locator)
-
-    /**
-     * [findRevisionlessBySourceLocator] by plain context-id string — the override point, and what
-     * Java callers use.
-     */
-    fun findRevisionlessBySourceLocator(
-        contextIdValue: String,
-        locator: SourceLocator,
-    ): List<Proposition> =
-        findByContextId(ContextId(contextIdValue)).filter { proposition ->
-            proposition.provenanceEntries.any {
-                it.locator.key() == locator.key() && it.sourceRevision == null
-            }
-        }
 
     // ========================================================================
     // Administrative operations - bulk re-embed and coarse deletion

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionRepository.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionRepository.kt
@@ -15,12 +15,15 @@
  */
 package com.embabel.dice.proposition
 
+import com.embabel.agent.core.ContextId
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.service.CoreSearchOperations
 import com.embabel.common.core.types.SimilarityResult
 import com.embabel.common.core.types.TextSimilaritySearchRequest
 import com.embabel.common.util.loggerFor
 import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.SourceLocator
+import com.embabel.dice.provenance.SourceRevisionRef
 
 /**
  * The full proposition repository: combines the base persistence port with every opt-in
@@ -72,6 +75,81 @@ interface PropositionRepository :
      * delegates to the lean [findAll] — fine for backends that always carry provenance (e.g. in-memory).
      */
     fun findAll(withProvenance: Boolean): List<Proposition> = findAll()
+
+    // ========================================================================
+    // Source provenance queries
+    //
+    // Each finder is a pair: a typed entry point taking a ContextId, and a plain-String variant that
+    // holds the default body. The typed one forwards to the String one, matching
+    // findByContextId -> findByContextIdValue in PropositionStore. Overrides belong on the String
+    // variant, because ContextId is a value class: the typed method's JVM name is mangled and a Java
+    // backend cannot override it, so an override placed there would be invisible to Java callers.
+    // The String variant has an ordinary JVM signature and sits on the path of every typed call.
+    //
+    // The default bodies read the context and filter loaded provenance in memory, which is correct
+    // for any backend whose context read carries provenance. A backend whose context read is lean
+    // MUST override all three, or its callers get empty results; dice-storage's
+    // DrivinePropositionRepository does, pushing each predicate into Cypher.
+    // ========================================================================
+
+    /**
+     * Find propositions in [contextId] with evidence from any revision of [sourceKey].
+     *
+     * Both revisioned and revisionless evidence matches when its locator key equals [sourceKey].
+     */
+    fun findBySourceKey(contextId: ContextId, sourceKey: String): List<Proposition> =
+        findBySourceKey(contextId.value, sourceKey)
+
+    /**
+     * [findBySourceKey] by plain context-id string — the override point, and what Java callers use.
+     */
+    fun findBySourceKey(contextIdValue: String, sourceKey: String): List<Proposition> =
+        findByContextId(ContextId(contextIdValue)).filter { proposition ->
+            proposition.provenanceEntries.any { it.locator.key() == sourceKey }
+        }
+
+    /**
+     * Find propositions in [contextId] with evidence from exactly [ref]'s source key and revision.
+     */
+    fun findBySourceRevision(contextId: ContextId, ref: SourceRevisionRef): List<Proposition> =
+        findBySourceRevision(contextId.value, ref)
+
+    /**
+     * [findBySourceRevision] by plain context-id string — the override point, and what Java callers
+     * use.
+     */
+    fun findBySourceRevision(contextIdValue: String, ref: SourceRevisionRef): List<Proposition> =
+        findByContextId(ContextId(contextIdValue)).filter { proposition ->
+            proposition.provenanceEntries.any {
+                it.locator.key() == ref.sourceKey && it.sourceRevision == ref.sourceRevision
+            }
+        }
+
+    /**
+     * Find propositions in [contextId] with revisionless evidence whose locator key equals
+     * [locator]'s key.
+     *
+     * Evidence carrying any revision does not match.
+     */
+    fun findRevisionlessBySourceLocator(
+        contextId: ContextId,
+        locator: SourceLocator,
+    ): List<Proposition> =
+        findRevisionlessBySourceLocator(contextId.value, locator)
+
+    /**
+     * [findRevisionlessBySourceLocator] by plain context-id string — the override point, and what
+     * Java callers use.
+     */
+    fun findRevisionlessBySourceLocator(
+        contextIdValue: String,
+        locator: SourceLocator,
+    ): List<Proposition> =
+        findByContextId(ContextId(contextIdValue)).filter { proposition ->
+            proposition.provenanceEntries.any {
+                it.locator.key() == locator.key() && it.sourceRevision == null
+            }
+        }
 
     // ========================================================================
     // Administrative operations - bulk re-embed and coarse deletion
@@ -141,31 +219,31 @@ interface PropositionRepository :
     /**
      * The provenance entries of a proposition, or an empty list if it has none or does not exist.
      */
-    fun provenanceOf(propositionId: String): List<ProvenanceEntry> =
-        findById(propositionId)?.provenanceEntries ?: emptyList()
+    override fun provenanceOf(propositionId: String): List<ProvenanceEntry> =
+        super<PropositionStore>.provenanceOf(propositionId)
 
     /**
      * Append provenance to a proposition (deduplicated); never removes existing entries.
      *
      * @return the updated proposition, or null if no proposition with that id exists.
      */
-    fun addProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? =
-        findById(propositionId)?.let { save(it.withProvenanceEntries(entries)) }
+    override fun addProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? =
+        super<PropositionStore>.addProvenance(propositionId, entries)
 
     /**
      * Authoritatively set a proposition's provenance to exactly [entries], removing any not listed.
      *
      * @return the updated proposition, or null if no proposition with that id exists.
      */
-    fun setProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? =
-        findById(propositionId)?.let { save(it.withProvenance(entries)) }
+    override fun setProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? =
+        super<PropositionStore>.setProvenance(propositionId, entries)
 
     /**
      * Remove all provenance from a proposition.
      *
      * @return the updated proposition, or null if no proposition with that id exists.
      */
-    fun clearProvenance(propositionId: String): Proposition? =
+    override fun clearProvenance(propositionId: String): Proposition? =
         setProvenance(propositionId, emptyList())
 
     // RAG VectorSearch bridge — only Proposition is supported

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionStore.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionStore.kt
@@ -18,6 +18,7 @@ package com.embabel.dice.proposition
 import com.embabel.agent.core.ContextId
 import com.embabel.agent.rag.service.RetrievableIdentifier
 import com.embabel.dice.common.DiceMetadataKeys
+import com.embabel.dice.provenance.ProvenanceEntry
 import org.slf4j.LoggerFactory
 import java.time.Instant
 
@@ -174,6 +175,44 @@ interface PropositionStore {
      * Get the total count of propositions.
      */
     fun count(): Int
+
+    // ========================================================================
+    // Provenance management — authoritative evidence replacement
+    // ========================================================================
+
+    /**
+     * The provenance entries of a proposition, or an empty list if it has none or does not exist.
+     */
+    fun provenanceOf(propositionId: String): List<ProvenanceEntry> =
+        findById(propositionId)?.provenanceEntries ?: emptyList()
+
+    /**
+     * Append provenance to a proposition (deduplicated); never removes existing entries.
+     *
+     * @return the updated proposition, or null if no proposition with that id exists.
+     */
+    fun addProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? =
+        findById(propositionId)?.let { save(it.withProvenanceEntries(entries)) }
+
+    /**
+     * Authoritatively set a proposition's provenance to exactly [entries], removing any not listed.
+     *
+     * Backends whose normal [save] path preserves unloaded provenance must override this operation.
+     * It lives on the base store contract so evidence-sensitive callers such as collector undo can
+     * ask for it directly, without probing for a richer repository type at runtime.
+     *
+     * @return the updated proposition, or null if no proposition with that id exists.
+     */
+    fun setProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? =
+        findById(propositionId)?.let { save(it.withProvenance(entries)) }
+
+    /**
+     * Remove all provenance from a proposition.
+     *
+     * @return the updated proposition, or null if no proposition with that id exists.
+     */
+    fun clearProvenance(propositionId: String): Proposition? =
+        setProvenance(propositionId, emptyList())
 
     /**
      * Refresh [Proposition.lastAccessed] to now for [ids] — the read-side reinforcement that lets a

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/SourceRevisionQueryCapable.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/SourceRevisionQueryCapable.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.proposition
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.provenance.SourceLocator
+import com.embabel.dice.provenance.SourceRevisionRef
+
+/**
+ * Opt-in capability for asking which propositions were read from a source, and from which revision
+ * of that source.
+ *
+ * These finders live outside [PropositionStore] and [PropositionRepository] deliberately. Answering
+ * them takes provenance, and plenty of backends store evidence without projecting it on an ordinary
+ * context read. A shared default body written over such a read would return an empty list on those
+ * backends, and an empty list already has a meaning here: nothing in this context cites that source.
+ * A store that cannot look would then be indistinguishable from one that looked and found nothing.
+ *
+ * Implementing this interface is the promise that the backend really can look. A caller holding a
+ * plain [PropositionRepository] asks for the capability with an `as?` test and handles its absence
+ * as its own case:
+ *
+ * ```kotlin
+ * val revisionQueries = repository as? SourceRevisionQueryCapable
+ *     ?: error("this backend cannot answer source-revision queries")
+ * ```
+ *
+ * Each finder is a pair: a typed entry point taking a [ContextId], and a plain-String variant that
+ * carries the work. The typed one forwards to the String one, matching `findByContextId ->
+ * findByContextIdValue` on [PropositionStore]. Implementations live on the String variant, because
+ * [ContextId] is a value class: the typed method's JVM name is mangled and a Java backend cannot
+ * override it, so an implementation placed there would be invisible to Java callers. The String
+ * variant has an ordinary JVM signature and sits on the path of every typed call.
+ *
+ * A store whose reads already carry every provenance entry can pick up all three String variants
+ * from [ProvenanceScanningSourceRevisionQueries].
+ */
+interface SourceRevisionQueryCapable {
+
+    /**
+     * Whether this particular instance can actually answer these queries. Implementing the interface
+     * is a type-level promise; this is the runtime truth. A decorator that forwards to a backend it
+     * only discovers at construction time reports here whether the backend it got can answer. Callers
+     * check this before trusting an empty result.
+     */
+    val supportsSourceRevisionQueries: Boolean get() = true
+
+    /**
+     * Find propositions in [contextId] with evidence from any revision of [sourceKey].
+     *
+     * Both revisioned and revisionless evidence matches when its locator key equals [sourceKey].
+     */
+    fun findBySourceKey(contextId: ContextId, sourceKey: String): List<Proposition> =
+        findBySourceKey(contextId.value, sourceKey)
+
+    /**
+     * [findBySourceKey] by plain context-id string — the implementation point, and what Java callers
+     * use.
+     */
+    fun findBySourceKey(contextIdValue: String, sourceKey: String): List<Proposition>
+
+    /**
+     * Find propositions in [contextId] with evidence from exactly [ref]'s source key and revision.
+     */
+    fun findBySourceRevision(contextId: ContextId, ref: SourceRevisionRef): List<Proposition> =
+        findBySourceRevision(contextId.value, ref)
+
+    /**
+     * [findBySourceRevision] by plain context-id string — the implementation point, and what Java
+     * callers use.
+     */
+    fun findBySourceRevision(contextIdValue: String, ref: SourceRevisionRef): List<Proposition>
+
+    /**
+     * Find propositions in [contextId] with revisionless evidence whose locator key equals
+     * [locator]'s key.
+     *
+     * Evidence carrying any revision is excluded.
+     */
+    fun findRevisionlessBySourceLocator(
+        contextId: ContextId,
+        locator: SourceLocator,
+    ): List<Proposition> =
+        findRevisionlessBySourceLocator(contextId.value, locator)
+
+    /**
+     * [findRevisionlessBySourceLocator] by plain context-id string — the implementation point, and
+     * what Java callers use.
+     */
+    fun findRevisionlessBySourceLocator(
+        contextIdValue: String,
+        locator: SourceLocator,
+    ): List<Proposition>
+}
+
+/**
+ * The three source-revision finders answered by reading the context and filtering loaded provenance
+ * in memory.
+ *
+ * Only a store whose context read carries every provenance entry may implement this. That is the
+ * condition the whole capability turns on: the in-memory and JSON-file stores keep entries on the
+ * proposition itself, so scanning them is exact. A backend with a lean context read implements
+ * [SourceRevisionQueryCapable] directly and pushes each predicate into its own query language.
+ */
+interface ProvenanceScanningSourceRevisionQueries : SourceRevisionQueryCapable, PropositionStore {
+
+    override fun findBySourceKey(contextIdValue: String, sourceKey: String): List<Proposition> =
+        findByContextId(ContextId(contextIdValue)).filter { proposition ->
+            proposition.provenanceEntries.any { it.locator.key() == sourceKey }
+        }
+
+    override fun findBySourceRevision(contextIdValue: String, ref: SourceRevisionRef): List<Proposition> =
+        findByContextId(ContextId(contextIdValue)).filter { proposition ->
+            proposition.provenanceEntries.any {
+                it.locator.key() == ref.sourceKey && it.sourceRevision == ref.sourceRevision
+            }
+        }
+
+    override fun findRevisionlessBySourceLocator(
+        contextIdValue: String,
+        locator: SourceLocator,
+    ): List<Proposition> =
+        findByContextId(ContextId(contextIdValue)).filter { proposition ->
+            proposition.provenanceEntries.any {
+                it.locator.key() == locator.key() && it.sourceRevision == null
+            }
+        }
+}

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/SourceRevisionQueryCapable.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/SourceRevisionQueryCapable.kt
@@ -18,6 +18,7 @@ package com.embabel.dice.proposition
 import com.embabel.agent.core.ContextId
 import com.embabel.dice.provenance.SourceLocator
 import com.embabel.dice.provenance.SourceRevisionRef
+import org.jetbrains.annotations.ApiStatus
 
 /**
  * Opt-in capability for asking which propositions were read from a source, and from which revision
@@ -48,6 +49,7 @@ import com.embabel.dice.provenance.SourceRevisionRef
  * A store whose reads already carry every provenance entry can pick up all three String variants
  * from [ProvenanceScanningSourceRevisionQueries].
  */
+@ApiStatus.Experimental
 interface SourceRevisionQueryCapable {
 
     /**
@@ -115,6 +117,7 @@ interface SourceRevisionQueryCapable {
  * proposition itself, so scanning them is exact. A backend with a lean context read implements
  * [SourceRevisionQueryCapable] directly and pushes each predicate into its own query language.
  */
+@ApiStatus.Experimental
 interface ProvenanceScanningSourceRevisionQueries : SourceRevisionQueryCapable, PropositionStore {
 
     override fun findBySourceKey(contextIdValue: String, sourceKey: String): List<Proposition> =

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/store/InMemoryPropositionRepository.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/store/InMemoryPropositionRepository.kt
@@ -23,6 +23,7 @@ import com.embabel.common.core.types.SimilarityResult
 import com.embabel.common.core.types.TextSimilaritySearchRequest
 import com.embabel.common.core.types.ZeroToOne
 import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.ProvenanceScanningSourceRevisionQueries
 import com.embabel.dice.proposition.PropositionQuery
 import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
@@ -45,7 +46,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class InMemoryPropositionRepository(
     private val embeddingService: EmbeddingService? = null,
-) : PropositionRepository {
+) : PropositionRepository, ProvenanceScanningSourceRevisionQueries {
 
     private val logger = LoggerFactory.getLogger(InMemoryPropositionRepository::class.java)
 

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/store/JsonFilePropositionRepository.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/store/JsonFilePropositionRepository.kt
@@ -20,6 +20,7 @@ import com.embabel.common.ai.model.EmbeddingService
 import com.embabel.common.core.types.SimilarityResult
 import com.embabel.common.core.types.TextSimilaritySearchRequest
 import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.ProvenanceScanningSourceRevisionQueries
 import com.embabel.dice.proposition.PropositionQuery
 import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
@@ -51,7 +52,7 @@ import java.util.concurrent.ConcurrentHashMap
 class JsonFilePropositionRepository @JvmOverloads constructor(
     private val path: Path,
     private val embeddingService: EmbeddingService? = null,
-) : PropositionRepository {
+) : PropositionRepository, ProvenanceScanningSourceRevisionQueries {
 
     private val logger = LoggerFactory.getLogger(JsonFilePropositionRepository::class.java)
 

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEntry.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEntry.kt
@@ -53,5 +53,11 @@ data class ProvenanceEntry @JvmOverloads constructor(
         require(sourceRevision == null || sourceRevision.isNotBlank()) {
             "sourceRevision must not be blank"
         }
+        // Bound both identity strings here, at the moment evidence is formed. This is upstream of
+        // every hash and every indexed write: the locator key and the revision are what
+        // ProvenanceEvidenceKey encodes and what the graph stores on the :Source node and the
+        // DERIVED_FROM edge, and an entry that cannot be built never reaches a store at all.
+        SourceIdentityBounds.requireSourceKeyWithinBounds(locator.key())
+        sourceRevision?.let(SourceIdentityBounds::requireSourceRevisionWithinBounds)
     }
 }

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEntry.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEntry.kt
@@ -33,6 +33,7 @@ package com.embabel.dice.provenance
  * @property endOffset Optional exclusive end character offset within the source/chunk
  * @property contentHash Optional hash of the source content. Comparing it against the
  *   source later can reveal that the source has since changed.
+ * @property sourceRevision Optional provider-defined opaque revision of the source
  */
 data class ProvenanceEntry @JvmOverloads constructor(
     val locator: SourceLocator,
@@ -40,6 +41,7 @@ data class ProvenanceEntry @JvmOverloads constructor(
     val startOffset: Int? = null,
     val endOffset: Int? = null,
     val contentHash: String? = null,
+    val sourceRevision: String? = null,
 ) {
 
     init {
@@ -48,5 +50,8 @@ data class ProvenanceEntry @JvmOverloads constructor(
         require(
             startOffset == null || endOffset == null || endOffset >= startOffset
         ) { "endOffset must be >= startOffset" }
+        require(sourceRevision == null || sourceRevision.isNotBlank()) {
+            "sourceRevision must not be blank"
+        }
     }
 }

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEntry.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEntry.kt
@@ -53,11 +53,14 @@ data class ProvenanceEntry @JvmOverloads constructor(
         require(sourceRevision == null || sourceRevision.isNotBlank()) {
             "sourceRevision must not be blank"
         }
-        // Bound both identity strings here, at the moment evidence is formed. This is upstream of
-        // every hash and every indexed write: the locator key and the revision are what
-        // ProvenanceEvidenceKey encodes and what the graph stores on the :Source node and the
-        // DERIVED_FROM edge, and an entry that cannot be built never reaches a store at all.
+        // Bound every identity string here, at the moment evidence is formed. This is upstream of
+        // every hash and every indexed write: the locator key, the revision, the chunk id, and the
+        // content hash are what ProvenanceEvidenceKey encodes and what the graph stores on the
+        // :Source node and the DERIVED_FROM edge, and an entry that cannot be built never reaches a
+        // store at all.
         SourceIdentityBounds.requireSourceKeyWithinBounds(locator.key())
         sourceRevision?.let(SourceIdentityBounds::requireSourceRevisionWithinBounds)
+        chunkId?.let(SourceIdentityBounds::requireChunkIdWithinBounds)
+        contentHash?.let(SourceIdentityBounds::requireContentHashWithinBounds)
     }
 }

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKey.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKey.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+/**
+ * The stable string identity of one piece of evidence. Producers encode an entry, hand the string
+ * to whoever records the fold, and [matches] later checks a live entry against it.
+ *
+ * Fields are length-framed in a fixed order, so no value needs escaping however many colons it
+ * contains. A length of `-1` stands for null, which keeps absence distinct from every string value
+ * — including the string `"null"`.
+ *
+ * A ref that lacks the `dice-provenance:` prefix is a legacy locator key, written before revisions
+ * existed. Those match revisionless evidence only, so an old trace can never remove evidence from a
+ * revision it never saw. Anything that carries the prefix and then fails to parse matches nothing.
+ */
+internal object ProvenanceEvidenceKey {
+
+    private const val MAGIC_PREFIX = "dice-provenance:"
+    private const val VERSION_PREFIX = "${MAGIC_PREFIX}v1:"
+
+    fun encode(entry: ProvenanceEntry): String =
+        buildString(VERSION_PREFIX.length + 64) {
+            append(VERSION_PREFIX)
+            appendFrame(entry.locator.key())
+            appendFrame(entry.sourceRevision)
+            appendFrame(entry.chunkId)
+            appendFrame(entry.startOffset?.toString())
+            appendFrame(entry.endOffset?.toString())
+            appendFrame(entry.contentHash)
+        }
+
+    fun matches(entry: ProvenanceEntry, encoded: String): Boolean {
+        if (!encoded.startsWith(MAGIC_PREFIX)) {
+            return entry.sourceRevision == null && encoded == entry.locator.key()
+        }
+        if (!encoded.startsWith(VERSION_PREFIX)) {
+            return false
+        }
+
+        val matcher = FrameMatcher(encoded, VERSION_PREFIX.length)
+        return matcher.matches(entry.locator.key()) &&
+                matcher.matches(entry.sourceRevision) &&
+                matcher.matches(entry.chunkId) &&
+                matcher.matches(entry.startOffset?.toString()) &&
+                matcher.matches(entry.endOffset?.toString()) &&
+                matcher.matches(entry.contentHash) &&
+                matcher.isExhausted()
+    }
+
+    private fun StringBuilder.appendFrame(value: String?) {
+        if (value == null) {
+            append("-1:")
+        } else {
+            append(value.length)
+            append(':')
+            append(value)
+        }
+    }
+
+    private class FrameMatcher(
+        private val encoded: String,
+        private var offset: Int,
+    ) {
+
+        fun matches(value: String?): Boolean {
+            val separator = encoded.indexOf(':', offset)
+            if (separator < 0) {
+                return false
+            }
+            val length = parseLength(separator) ?: return false
+            offset = separator + 1
+            if (length == -1) {
+                return value == null
+            }
+            if (value == null || length != value.length || length > encoded.length - offset) {
+                return false
+            }
+            if (!encoded.regionMatches(offset, value, 0, length)) {
+                return false
+            }
+            offset += length
+            return true
+        }
+
+        fun isExhausted(): Boolean = offset == encoded.length
+
+        private fun parseLength(separator: Int): Int? {
+            if (separator == offset) {
+                return null
+            }
+            if (encoded[offset] == '-') {
+                return if (separator == offset + 2 && encoded[offset + 1] == '1') -1 else null
+            }
+            if (separator > offset + 1 && encoded[offset] == '0') {
+                return null
+            }
+
+            var length = 0
+            for (index in offset until separator) {
+                val character = encoded[index]
+                if (character !in '0'..'9') {
+                    return null
+                }
+                val digit = character - '0'
+                if (length > (Int.MAX_VALUE - digit) / 10) {
+                    return null
+                }
+                length = length * 10 + digit
+            }
+            return length
+        }
+    }
+}

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/SourceIdentityBounds.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/SourceIdentityBounds.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+/**
+ * Length ceilings for the two strings that arrive from outside DICE and end up inside stored
+ * identity: the canonical source key from [SourceLocator.key], and a provider-defined source
+ * revision.
+ *
+ * Both get hashed into an evidence key and written to an indexed graph property, so an unbounded
+ * value is a real hazard: it inflates every index entry that mentions it, and a graph store has its
+ * own hard ceiling on an indexed property that surfaces as an opaque database error deep inside a
+ * write. Checking here turns that into an [IllegalArgumentException] at the moment the value is
+ * offered, before anything is hashed and before any store is touched.
+ *
+ * The limits are deliberately roomy. Nothing a real connector produces comes close; they exist to
+ * stop a runaway or hostile value, and they are stated as constants so a caller can check its own
+ * input against the same number DICE will.
+ */
+object SourceIdentityBounds {
+
+    /**
+     * Longest accepted canonical source key.
+     *
+     * A key is a short kind prefix plus whatever the locator wraps, and the longest of those is a
+     * URI. 2048 characters is the practical ceiling browsers and proxies have settled on for a URL,
+     * which leaves generous headroom over any URI, file path, content hash, or connector id pair
+     * that shows up in practice.
+     */
+    const val MAX_SOURCE_KEY_LENGTH: Int = 2048
+
+    /**
+     * Longest accepted source revision.
+     *
+     * A revision is an opaque token from whichever provider owns the source: a git SHA is 40 or 64
+     * characters, an HTTP ETag a few dozen, a Slack or Notion timestamp about 20. The longest real
+     * one we know of is an S3 object version id, which AWS caps at 1024, so that is the number.
+     */
+    const val MAX_SOURCE_REVISION_LENGTH: Int = 1024
+
+    /**
+     * Check a canonical source key against [MAX_SOURCE_KEY_LENGTH] and hand it back unchanged.
+     *
+     * @param sourceKey the key to check
+     * @return [sourceKey], for use inline in a constructor
+     * @throws IllegalArgumentException if the key is longer than [MAX_SOURCE_KEY_LENGTH]
+     */
+    @JvmStatic
+    fun requireSourceKeyWithinBounds(sourceKey: String): String {
+        require(sourceKey.length <= MAX_SOURCE_KEY_LENGTH) {
+            "source key is ${sourceKey.length} characters, over the " +
+                "SourceIdentityBounds.MAX_SOURCE_KEY_LENGTH limit of $MAX_SOURCE_KEY_LENGTH"
+        }
+        return sourceKey
+    }
+
+    /**
+     * Check a source revision against [MAX_SOURCE_REVISION_LENGTH] and hand it back unchanged.
+     *
+     * @param sourceRevision the revision to check
+     * @return [sourceRevision], for use inline in a constructor
+     * @throws IllegalArgumentException if the revision is longer than [MAX_SOURCE_REVISION_LENGTH]
+     */
+    @JvmStatic
+    fun requireSourceRevisionWithinBounds(sourceRevision: String): String {
+        require(sourceRevision.length <= MAX_SOURCE_REVISION_LENGTH) {
+            "source revision is ${sourceRevision.length} characters, over the " +
+                "SourceIdentityBounds.MAX_SOURCE_REVISION_LENGTH limit of $MAX_SOURCE_REVISION_LENGTH"
+        }
+        return sourceRevision
+    }
+}

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/SourceIdentityBounds.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/SourceIdentityBounds.kt
@@ -15,6 +15,8 @@
  */
 package com.embabel.dice.provenance
 
+import org.jetbrains.annotations.ApiStatus
+
 /**
  * Length ceilings for the two strings that arrive from outside DICE and end up inside stored
  * identity: the canonical source key from [SourceLocator.key], and a provider-defined source
@@ -30,6 +32,7 @@ package com.embabel.dice.provenance
  * stop a runaway or hostile value, and they are stated as constants so a caller can check its own
  * input against the same number DICE will.
  */
+@ApiStatus.Experimental
 object SourceIdentityBounds {
 
     /**

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/SourceIdentityBounds.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/SourceIdentityBounds.kt
@@ -18,9 +18,9 @@ package com.embabel.dice.provenance
 import org.jetbrains.annotations.ApiStatus
 
 /**
- * Length ceilings for the two strings that arrive from outside DICE and end up inside stored
- * identity: the canonical source key from [SourceLocator.key], and a provider-defined source
- * revision.
+ * Length ceilings for the strings that arrive from outside DICE and end up inside stored
+ * identity: the canonical source key from [SourceLocator.key], a provider-defined source
+ * revision, a chunk id, and a content hash.
  *
  * Both get hashed into an evidence key and written to an indexed graph property, so an unbounded
  * value is a real hazard: it inflates every index entry that mentions it, and a graph store has its
@@ -55,6 +55,22 @@ object SourceIdentityBounds {
     const val MAX_SOURCE_REVISION_LENGTH: Int = 1024
 
     /**
+     * Longest accepted chunk id.
+     *
+     * A chunk id is a chunker-minted identifier: a UUID, a digest, or the fixed `"__assertion__"`
+     * marker. 512 leaves generous room for any of those, even with a connector-added prefix.
+     */
+    const val MAX_CHUNK_ID_LENGTH: Int = 512
+
+    /**
+     * Longest accepted content hash.
+     *
+     * A content hash is a digest, and SHA-512 in hex is the longest common one at 128 characters,
+     * so 256 covers that with room to spare for any other encoding a connector might use.
+     */
+    const val MAX_CONTENT_HASH_LENGTH: Int = 256
+
+    /**
      * Check a canonical source key against [MAX_SOURCE_KEY_LENGTH] and hand it back unchanged.
      *
      * @param sourceKey the key to check
@@ -84,5 +100,37 @@ object SourceIdentityBounds {
                 "SourceIdentityBounds.MAX_SOURCE_REVISION_LENGTH limit of $MAX_SOURCE_REVISION_LENGTH"
         }
         return sourceRevision
+    }
+
+    /**
+     * Check a chunk id against [MAX_CHUNK_ID_LENGTH] and hand it back unchanged.
+     *
+     * @param chunkId the chunk id to check
+     * @return [chunkId], for use inline in a constructor
+     * @throws IllegalArgumentException if the chunk id is longer than [MAX_CHUNK_ID_LENGTH]
+     */
+    @JvmStatic
+    fun requireChunkIdWithinBounds(chunkId: String): String {
+        require(chunkId.length <= MAX_CHUNK_ID_LENGTH) {
+            "chunk id is ${chunkId.length} characters, over the " +
+                "SourceIdentityBounds.MAX_CHUNK_ID_LENGTH limit of $MAX_CHUNK_ID_LENGTH"
+        }
+        return chunkId
+    }
+
+    /**
+     * Check a content hash against [MAX_CONTENT_HASH_LENGTH] and hand it back unchanged.
+     *
+     * @param contentHash the content hash to check
+     * @return [contentHash], for use inline in a constructor
+     * @throws IllegalArgumentException if the content hash is longer than [MAX_CONTENT_HASH_LENGTH]
+     */
+    @JvmStatic
+    fun requireContentHashWithinBounds(contentHash: String): String {
+        require(contentHash.length <= MAX_CONTENT_HASH_LENGTH) {
+            "content hash is ${contentHash.length} characters, over the " +
+                "SourceIdentityBounds.MAX_CONTENT_HASH_LENGTH limit of $MAX_CONTENT_HASH_LENGTH"
+        }
+        return contentHash
     }
 }

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/SourceRevisionRef.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/SourceRevisionRef.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+/**
+ * Identifies an opaque revision of a source.
+ *
+ * @property sourceKey Canonical source identity produced by [SourceLocator.key]
+ * @property sourceRevision Provider-defined opaque revision value
+ */
+data class SourceRevisionRef(
+    val sourceKey: String,
+    val sourceRevision: String,
+) {
+
+    init {
+        require(sourceKey.isNotBlank()) { "sourceKey must not be blank" }
+        require(sourceRevision.isNotBlank()) { "sourceRevision must not be blank" }
+    }
+}

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/SourceRevisionRef.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/SourceRevisionRef.kt
@@ -18,6 +18,9 @@ package com.embabel.dice.provenance
 /**
  * Identifies an opaque revision of a source.
  *
+ * Both halves are checked against [SourceIdentityBounds] on construction, so a value too long to
+ * store or index is refused here, before it can reach a query or a write.
+ *
  * @property sourceKey Canonical source identity produced by [SourceLocator.key]
  * @property sourceRevision Provider-defined opaque revision value
  */
@@ -29,5 +32,7 @@ data class SourceRevisionRef(
     init {
         require(sourceKey.isNotBlank()) { "sourceKey must not be blank" }
         require(sourceRevision.isNotBlank()) { "sourceRevision must not be blank" }
+        SourceIdentityBounds.requireSourceKeyWithinBounds(sourceKey)
+        SourceIdentityBounds.requireSourceRevisionWithinBounds(sourceRevision)
     }
 }

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/SourceRevisionRef.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/SourceRevisionRef.kt
@@ -15,6 +15,8 @@
  */
 package com.embabel.dice.provenance
 
+import org.jetbrains.annotations.ApiStatus
+
 /**
  * Identifies an opaque revision of a source.
  *
@@ -24,6 +26,7 @@ package com.embabel.dice.provenance
  * @property sourceKey Canonical source identity produced by [SourceLocator.key]
  * @property sourceRevision Provider-defined opaque revision value
  */
+@ApiStatus.Experimental
 data class SourceRevisionRef(
     val sourceKey: String,
     val sourceRevision: String,

--- a/dice/src/test/java/com/embabel/dice/SourceRevisionJavaInteropTest.java
+++ b/dice/src/test/java/com/embabel/dice/SourceRevisionJavaInteropTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice;
+
+import com.embabel.dice.provenance.ContentAddressedLocator;
+import com.embabel.dice.provenance.ProvenanceEntry;
+import com.embabel.dice.provenance.SourceLocator;
+import com.embabel.dice.provenance.SourceRevisionRef;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Java's view of the revision contract. {@code @JvmOverloads} on {@link ProvenanceEntry} means
+ * every constructor descriptor a Java caller could already have compiled against survives, and the
+ * new revision argument arrives as one extra descriptor on the end.
+ */
+class SourceRevisionJavaInteropTest {
+
+    @Test
+    void retainsEveryLegacyJavaConcreteConstructorDescriptor() throws Exception {
+        Class<?>[][] provenanceParameters = {
+                {SourceLocator.class},
+                {SourceLocator.class, String.class},
+                {SourceLocator.class, String.class, Integer.class},
+                {SourceLocator.class, String.class, Integer.class, Integer.class},
+                {SourceLocator.class, String.class, Integer.class, Integer.class, String.class},
+        };
+        for (Class<?>[] parameters : provenanceParameters) {
+            ProvenanceEntry.class.getConstructor(parameters);
+        }
+        ProvenanceEntry.class.getConstructor(
+                SourceLocator.class,
+                String.class,
+                Integer.class,
+                Integer.class,
+                String.class,
+                String.class
+        );
+    }
+
+    @Test
+    void javaCallersReadAndBuildRevisionValues() {
+        SourceLocator locator = new ContentAddressedLocator("java-source");
+        SourceRevisionRef revision = new SourceRevisionRef(locator.key(), "opaque-r1");
+        assertEquals(locator.key(), revision.getSourceKey());
+        assertEquals("opaque-r1", revision.getSourceRevision());
+
+        ProvenanceEntry legacy = new ProvenanceEntry(locator);
+        assertNull(legacy.getSourceRevision());
+
+        ProvenanceEntry revisioned = new ProvenanceEntry(
+                locator,
+                "chunk",
+                0,
+                4,
+                "hash",
+                revision.getSourceRevision()
+        );
+        assertEquals("opaque-r1", revisioned.getSourceRevision());
+        assertEquals("hash", revisioned.getContentHash());
+    }
+}

--- a/dice/src/test/kotlin/com/embabel/dice/SourceRevisionCompatibilityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/SourceRevisionCompatibilityTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice
+
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.provenance.ContentAddressedLocator
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.SourceRevisionRef
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the compatibility boundary this slice claims: Kotlin source-level constructor and `copy`
+ * calls keep compiling, stored JSON keeps loading, and the old synthetic constructor and `copy`
+ * descriptors are gone.
+ */
+class SourceRevisionCompatibilityTest {
+
+    private val mapper = ObjectMapper()
+        .registerModule(KotlinModule.Builder().build())
+        .registerModule(JavaTimeModule())
+
+    @Test
+    fun `legacy Kotlin source constructors and copy calls recompile against the candidate`() {
+        val locator = ContentAddressedLocator("legacy-kotlin-source")
+        val provenance = ProvenanceEntry(locator).copy(contentHash = "updated")
+        assertEquals("updated", provenance.contentHash)
+        assertNull(provenance.sourceRevision)
+    }
+
+    @Test
+    fun `new Kotlin source constructors and copy calls carry an opaque revision`() {
+        val locator = ContentAddressedLocator("revisioned-kotlin-source")
+        val revision = SourceRevisionRef(locator.key(), "opaque::r/1")
+        val provenance = ProvenanceEntry(
+            locator = locator,
+            sourceRevision = revision.sourceRevision,
+        ).copy(contentHash = "updated")
+        assertEquals("opaque::r/1", provenance.sourceRevision)
+        assertEquals("updated", provenance.contentHash)
+    }
+
+    @Test
+    fun `revisionless stored JSON remains readable and revisioned JSON round trips`() {
+        val revisionless = mapper.readValue<Proposition>(fixture("proposition-revisionless.json"))
+        assertNull(revisionless.provenanceEntries.single().sourceRevision)
+        assertEquals(
+            revisionless,
+            mapper.readValue<Proposition>(mapper.writeValueAsString(revisionless)),
+        )
+
+        val revisioned = mapper.readValue<Proposition>(fixture("proposition-revisioned.json"))
+        assertEquals(listOf("r1", "null"), revisioned.provenanceEntries.map { it.sourceRevision })
+        assertEquals(
+            revisioned,
+            mapper.readValue<Proposition>(mapper.writeValueAsString(revisioned)),
+        )
+    }
+
+    @Test
+    fun `old Kotlin synthetic constructor and copy descriptors are outside the approved boundary`() {
+        val marker = Class.forName("kotlin.jvm.internal.DefaultConstructorMarker")
+
+        assertThrows(NoSuchMethodException::class.java) {
+            ProvenanceEntry::class.java.getDeclaredConstructor(
+                com.embabel.dice.provenance.SourceLocator::class.java,
+                String::class.java,
+                Int::class.javaObjectType,
+                Int::class.javaObjectType,
+                String::class.java,
+                Int::class.javaPrimitiveType,
+                marker,
+            )
+        }
+        assertThrows(NoSuchMethodException::class.java) {
+            ProvenanceEntry::class.java.getDeclaredMethod(
+                "copy",
+                com.embabel.dice.provenance.SourceLocator::class.java,
+                String::class.java,
+                Int::class.javaObjectType,
+                Int::class.javaObjectType,
+                String::class.java,
+            )
+        }
+    }
+
+    private fun fixture(name: String): String =
+        requireNotNull(javaClass.getResource("/provenance/$name")) {
+            "Missing provenance fixture: $name"
+        }.readText()
+}

--- a/dice/src/test/kotlin/com/embabel/dice/proposition/PropositionFoldEvidenceTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/proposition/PropositionFoldEvidenceTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.proposition
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
+import com.embabel.dice.provenance.UriLocator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PropositionFoldEvidenceTest {
+
+    private val locator = UriLocator("obsidian://vault/note")
+
+    @Test
+    fun `undo removes only folded revision while preserving survivor evidence and collisions`() {
+        val survivorR1 = evidence(
+            revision = "r1",
+            chunkId = "chunk|shared",
+            contentHash = "hash",
+        )
+        val foldedR2 = evidence(
+            revision = "r2",
+            chunkId = "chunk|shared",
+            contentHash = "hash",
+        )
+        val collision = evidence(
+            revision = "r2",
+            chunkId = "chunk",
+            contentHash = "shared|hash",
+        )
+        val survivor = proposition(
+            grounding = listOf("survivor-grounding"),
+            sourceIds = listOf("survivor-source"),
+            provenanceEntries = listOf(survivorR1, collision),
+        )
+        val loser = proposition(
+            grounding = listOf("folded-grounding"),
+            sourceIds = listOf("folded-source"),
+            provenanceEntries = listOf(foldedR2),
+        )
+
+        val restored = survivor.absorbEvidence(loser).withoutFoldedEvidence(
+            groundingToRemove = loser.grounding,
+            provenanceRefsToRemove = listOf(ProvenanceEvidenceKey.encode(foldedR2)),
+            sourceIdsToRemove = loser.sourceIds,
+        )
+
+        assertEquals(listOf(survivorR1, collision), restored.provenanceEntries)
+        assertEquals(listOf("survivor-grounding"), restored.grounding)
+        assertEquals(listOf("survivor-source"), restored.sourceIds)
+    }
+
+    @Test
+    fun `legacy locator trace removes only revisionless evidence`() {
+        val revisionless = evidence(revision = null)
+        val revisioned = evidence(revision = "r1")
+        val proposition = proposition(provenanceEntries = listOf(revisionless, revisioned))
+
+        val restored = proposition.withoutFoldedEvidence(
+            groundingToRemove = emptyList(),
+            provenanceRefsToRemove = listOf(locator.key()),
+            sourceIdsToRemove = emptyList(),
+        )
+
+        assertEquals(listOf(revisioned), restored.provenanceEntries)
+    }
+
+    @Test
+    fun `malformed versioned trace fails closed without deleting evidence`() {
+        val evidence = evidence(revision = "r2")
+        val malformedVersionedKey = ProvenanceEvidenceKey.encode(evidence).dropLast(1)
+        val proposition = proposition(provenanceEntries = listOf(evidence))
+
+        val restored = proposition.withoutFoldedEvidence(
+            groundingToRemove = emptyList(),
+            provenanceRefsToRemove = listOf(malformedVersionedKey),
+            sourceIdsToRemove = emptyList(),
+        )
+
+        assertEquals(listOf(evidence), restored.provenanceEntries)
+    }
+
+    private fun evidence(
+        revision: String?,
+        chunkId: String? = "chunk",
+        contentHash: String? = "hash",
+    ) = ProvenanceEntry(
+        locator = locator,
+        sourceRevision = revision,
+        chunkId = chunkId,
+        startOffset = 1,
+        endOffset = 2,
+        contentHash = contentHash,
+    )
+
+    private fun proposition(
+        grounding: List<String> = emptyList(),
+        sourceIds: List<String> = emptyList(),
+        provenanceEntries: List<ProvenanceEntry> = emptyList(),
+    ) = Proposition(
+        id = "proposition",
+        contextId = ContextId("test"),
+        text = "Test proposition",
+        mentions = emptyList(),
+        confidence = 0.8,
+        grounding = grounding,
+        sourceIds = sourceIds,
+        provenanceEntries = provenanceEntries,
+    )
+}

--- a/dice/src/test/kotlin/com/embabel/dice/proposition/PropositionRepositoryDelegationTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/proposition/PropositionRepositoryDelegationTest.kt
@@ -20,6 +20,9 @@ import com.embabel.agent.rag.service.RetrievableIdentifier
 import com.embabel.common.core.types.SimilarityResult
 import com.embabel.common.core.types.TextSimilaritySearchRequest
 import com.embabel.dice.common.DiceEventListener
+import com.embabel.dice.provenance.SourceLocator
+import com.embabel.dice.provenance.SourceRevisionRef
+import com.embabel.dice.provenance.UriLocator
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -48,7 +51,7 @@ class PropositionRepositoryDelegationTest {
      * findByContextIdValue to their default implementations, which is exactly the
      * recursion site under test.
      */
-    private inner class MinimalRepository : PropositionRepository {
+    private open inner class MinimalRepository : PropositionRepository {
         private val store = mutableMapOf<String, Proposition>()
         fun seed(p: Proposition) { store[p.id] = p }
 
@@ -63,6 +66,45 @@ class PropositionRepositoryDelegationTest {
         override fun findAll(): List<Proposition> = store.values.toList()
         override fun delete(id: String): Boolean = store.remove(id) != null
         override fun count(): Int = store.size
+    }
+
+    /**
+     * Overrides only the plain-String source finders. That is the override point a Java backend can
+     * actually reach, since the ContextId-typed methods compile to mangled JVM names.
+     */
+    private inner class StringSourceOverrideRepository : MinimalRepository() {
+        val sourceKeyResult = listOf(proposition(contextId, "source-key"))
+        val sourceRevisionResult = listOf(proposition(contextId, "source-revision"))
+        val revisionlessResult = listOf(proposition(contextId, "revisionless"))
+
+        var sourceKeyCalls = 0
+        var sourceRevisionCalls = 0
+        var revisionlessCalls = 0
+        val receivedContexts = mutableListOf<String>()
+
+        override fun findBySourceKey(contextIdValue: String, sourceKey: String): List<Proposition> {
+            sourceKeyCalls++
+            receivedContexts += contextIdValue
+            return sourceKeyResult
+        }
+
+        override fun findBySourceRevision(
+            contextIdValue: String,
+            ref: SourceRevisionRef,
+        ): List<Proposition> {
+            sourceRevisionCalls++
+            receivedContexts += contextIdValue
+            return sourceRevisionResult
+        }
+
+        override fun findRevisionlessBySourceLocator(
+            contextIdValue: String,
+            locator: SourceLocator,
+        ): List<Proposition> {
+            revisionlessCalls++
+            receivedContexts += contextIdValue
+            return revisionlessResult
+        }
     }
 
     @Test
@@ -96,5 +138,38 @@ class PropositionRepositoryDelegationTest {
         val expected = delegate.findAll().filter { it.contextId.value == contextId.value }
         assertEquals(expected.toSet(), result.toSet())
         assertEquals(1, result.size)
+    }
+
+    /**
+     * Calls the typed entry points against a backend that overrode only the String variants. A
+     * failure here means a typed call site skips the override — the shape that would make a Java
+     * backend's pushdown unreachable from Kotlin.
+     */
+    @Test
+    fun `typed source finders dispatch once through the overridable string variant`() {
+        val repository = StringSourceOverrideRepository()
+        val locator = UriLocator("https://example.com/source")
+        val ref = SourceRevisionRef(sourceKey = locator.key(), sourceRevision = "rev-1")
+
+        assertEquals(
+            repository.sourceKeyResult,
+            repository.findBySourceKey(contextId, locator.key()),
+        )
+        assertEquals(
+            repository.sourceRevisionResult,
+            repository.findBySourceRevision(contextId, ref),
+        )
+        assertEquals(
+            repository.revisionlessResult,
+            repository.findRevisionlessBySourceLocator(contextId, locator),
+        )
+
+        assertEquals(1, repository.sourceKeyCalls)
+        assertEquals(1, repository.sourceRevisionCalls)
+        assertEquals(1, repository.revisionlessCalls)
+        assertEquals(
+            listOf(contextId.value, contextId.value, contextId.value),
+            repository.receivedContexts,
+        )
     }
 }

--- a/dice/src/test/kotlin/com/embabel/dice/proposition/PropositionRepositoryDelegationTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/proposition/PropositionRepositoryDelegationTest.kt
@@ -25,6 +25,10 @@ import com.embabel.dice.provenance.SourceRevisionRef
 import com.embabel.dice.provenance.UriLocator
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
@@ -69,10 +73,11 @@ class PropositionRepositoryDelegationTest {
     }
 
     /**
-     * Overrides only the plain-String source finders. That is the override point a Java backend can
-     * actually reach, since the ContextId-typed methods compile to mangled JVM names.
+     * A backend that opts in to [SourceRevisionQueryCapable] and implements only the plain-String
+     * finders. That is the implementation point a Java backend can actually reach, since the
+     * ContextId-typed methods compile to mangled JVM names.
      */
-    private inner class StringSourceOverrideRepository : MinimalRepository() {
+    private inner class StringSourceOverrideRepository : MinimalRepository(), SourceRevisionQueryCapable {
         val sourceKeyResult = listOf(proposition(contextId, "source-key"))
         val sourceRevisionResult = listOf(proposition(contextId, "source-revision"))
         val revisionlessResult = listOf(proposition(contextId, "revisionless"))
@@ -146,7 +151,7 @@ class PropositionRepositoryDelegationTest {
      * backend's pushdown unreachable from Kotlin.
      */
     @Test
-    fun `typed source finders dispatch once through the overridable string variant`() {
+    fun `typed source finders dispatch once through the implementable string variant`() {
         val repository = StringSourceOverrideRepository()
         val locator = UriLocator("https://example.com/source")
         val ref = SourceRevisionRef(sourceKey = locator.key(), sourceRevision = "rev-1")
@@ -170,6 +175,55 @@ class PropositionRepositoryDelegationTest {
         assertEquals(
             listOf(contextId.value, contextId.value, contextId.value),
             repository.receivedContexts,
+        )
+    }
+
+    /**
+     * The capability split, checked at the type level. A store that implements only
+     * [PropositionRepository] has no source-revision surface at all, so a call site asks for the
+     * capability with `as?` and gets null. That null is the honest answer "this backend cannot look",
+     * which an empty result list could never have expressed.
+     */
+    @Test
+    fun `a plain repository does not satisfy a source-revision call site`() {
+        val plain: PropositionRepository = MinimalRepository().apply {
+            seed(proposition(contextId, "a1"))
+        }
+
+        assertNull(
+            plain as? SourceRevisionQueryCapable,
+            "a store that never promised to answer must report absence where an empty list would lie",
+        )
+        assertNotNull(
+            StringSourceOverrideRepository() as? SourceRevisionQueryCapable,
+            "a store that did promise is reachable through the capability type",
+        )
+    }
+
+    /**
+     * The event-emitting decorator wraps a plain [PropositionRepository], so whether it can answer
+     * depends on the delegate it was handed. It carries the capability type either way, which makes
+     * [SourceRevisionQueryCapable.supportsSourceRevisionQueries] the runtime truth, and a call that
+     * gets past the flag names the delegate that cannot answer.
+     */
+    @Test
+    fun `the decorator reports and refuses what its delegate cannot answer`() {
+        val capableDelegate = StringSourceOverrideRepository()
+        val capableDecorator = EventEmittingPropositionRepository(capableDelegate, DiceEventListener.DEV_NULL)
+        assertEquals(true, capableDecorator.supportsSourceRevisionQueries)
+        assertEquals(
+            capableDelegate.sourceKeyResult,
+            capableDecorator.findBySourceKey(contextId, "uri:https://example.com/source"),
+        )
+
+        val plainDecorator = EventEmittingPropositionRepository(MinimalRepository(), DiceEventListener.DEV_NULL)
+        assertEquals(false, plainDecorator.supportsSourceRevisionQueries)
+        val failure = assertThrows(UnsupportedOperationException::class.java) {
+            plainDecorator.findBySourceKey(contextId, "uri:https://example.com/source")
+        }
+        assertTrue(
+            failure.message!!.contains("MinimalRepository"),
+            "the refusal names the delegate that cannot answer: ${failure.message}",
         )
     }
 }

--- a/dice/src/test/kotlin/com/embabel/dice/proposition/PropositionRepositoryDelegationTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/proposition/PropositionRepositoryDelegationTest.kt
@@ -27,8 +27,6 @@ import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
@@ -201,29 +199,27 @@ class PropositionRepositoryDelegationTest {
     }
 
     /**
-     * The event-emitting decorator wraps a plain [PropositionRepository], so whether it can answer
-     * depends on the delegate it was handed. It carries the capability type either way, which makes
-     * [SourceRevisionQueryCapable.supportsSourceRevisionQueries] the runtime truth, and a call that
-     * gets past the flag names the delegate that cannot answer.
+     * The event-emitting decorator wraps a plain [PropositionRepository], and only implements
+     * [SourceRevisionQueryCapable] when [EventEmittingPropositionRepository.wrapping] was handed a
+     * delegate that does. A wrapper built over a capable delegate answers `as?` with itself and
+     * forwards to the delegate; a wrapper built over a plain repository answers `as?` with null,
+     * the same honest absence the delegate itself would report.
      */
     @Test
-    fun `the decorator reports and refuses what its delegate cannot answer`() {
+    fun `the decorator carries the capability only when its delegate does`() {
         val capableDelegate = StringSourceOverrideRepository()
-        val capableDecorator = EventEmittingPropositionRepository(capableDelegate, DiceEventListener.DEV_NULL)
-        assertEquals(true, capableDecorator.supportsSourceRevisionQueries)
+        val capableWrapper = EventEmittingPropositionRepository.wrapping(capableDelegate, DiceEventListener.DEV_NULL)
+        val capableRevisionQueries = capableWrapper as? SourceRevisionQueryCapable
+        assertNotNull(capableRevisionQueries, "a wrapper over a capable delegate must carry the capability")
         assertEquals(
             capableDelegate.sourceKeyResult,
-            capableDecorator.findBySourceKey(contextId, "uri:https://example.com/source"),
+            capableRevisionQueries!!.findBySourceKey(contextId, "uri:https://example.com/source"),
         )
 
-        val plainDecorator = EventEmittingPropositionRepository(MinimalRepository(), DiceEventListener.DEV_NULL)
-        assertEquals(false, plainDecorator.supportsSourceRevisionQueries)
-        val failure = assertThrows(UnsupportedOperationException::class.java) {
-            plainDecorator.findBySourceKey(contextId, "uri:https://example.com/source")
-        }
-        assertTrue(
-            failure.message!!.contains("MinimalRepository"),
-            "the refusal names the delegate that cannot answer: ${failure.message}",
+        val plainWrapper = EventEmittingPropositionRepository.wrapping(MinimalRepository(), DiceEventListener.DEV_NULL)
+        assertNull(
+            plainWrapper as? SourceRevisionQueryCapable,
+            "a wrapper over a plain repository must not satisfy the capability probe",
         )
     }
 }

--- a/dice/src/test/kotlin/com/embabel/dice/proposition/store/InMemoryPropositionProvenanceTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/proposition/store/InMemoryPropositionProvenanceTest.kt
@@ -18,7 +18,7 @@ package com.embabel.dice.proposition.store
 import com.embabel.agent.core.ContextId
 import com.embabel.common.ai.model.EmbeddingService
 import com.embabel.dice.proposition.Proposition
-import com.embabel.dice.proposition.PropositionRepository
+import com.embabel.dice.proposition.SourceRevisionQueryCapable
 import com.embabel.dice.provenance.ProvenanceEntry
 import com.embabel.dice.provenance.SourceRevisionRef
 import com.embabel.dice.provenance.UriLocator
@@ -104,8 +104,16 @@ internal class PortableSourceQueryFixture {
         )
 }
 
+/**
+ * The portable behaviour every source-revision backend owes, run against one seeded store.
+ *
+ * The parameter type is the whole point of the capability split. This call site needs
+ * [SourceRevisionQueryCapable]; a store that only implements
+ * [com.embabel.dice.proposition.PropositionRepository] will not compile here, so nobody can reach
+ * these finders on a backend that never promised to answer them.
+ */
 internal fun assertPortableSourceQueries(
-    repository: PropositionRepository,
+    repository: SourceRevisionQueryCapable,
     fixture: PortableSourceQueryFixture,
 ) {
     val allSourceVersions = repository.findBySourceKey(

--- a/dice/src/test/kotlin/com/embabel/dice/proposition/store/InMemoryPropositionProvenanceTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/proposition/store/InMemoryPropositionProvenanceTest.kt
@@ -18,7 +18,9 @@ package com.embabel.dice.proposition.store
 import com.embabel.agent.core.ContextId
 import com.embabel.common.ai.model.EmbeddingService
 import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.SourceRevisionRef
 import com.embabel.dice.provenance.UriLocator
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -27,6 +29,124 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+
+internal class PortableSourceQueryFixture {
+
+    val contextId = ContextId("portable-source-query")
+    private val foreignContextId = ContextId("portable-source-query-foreign")
+    val locator = UriLocator("https://example.com/shared-source")
+    val revisionOneRef = SourceRevisionRef(locator.key(), "r1")
+    val revisionTwoRef = SourceRevisionRef(locator.key(), "r2")
+
+    val revisionless = proposition(
+        contextId = contextId,
+        text = "revisionless",
+        entries = listOf(entry()),
+    )
+    val revisionOne = proposition(
+        contextId = contextId,
+        text = "r1",
+        entries = listOf(entry("r1")),
+    )
+    val revisionTwo = proposition(
+        contextId = contextId,
+        text = "r2",
+        entries = listOf(entry("r2")),
+    )
+    val duplicateRevisionOne = proposition(
+        contextId = contextId,
+        text = "duplicate r1 evidence",
+        entries = listOf(
+            entry("r1", "duplicate-r1-a"),
+            entry("r1", "duplicate-r1-b"),
+        ),
+    )
+    val foreignContext = proposition(
+        contextId = foreignContextId,
+        text = "foreign context",
+        entries = listOf(
+            entry(),
+            entry("r1", "foreign-r1-a"),
+            entry("r1", "foreign-r1-b"),
+            entry("r2"),
+        ),
+    )
+
+    val propositions = listOf(
+        revisionless,
+        revisionOne,
+        revisionTwo,
+        duplicateRevisionOne,
+        foreignContext,
+    )
+
+    private fun entry(
+        sourceRevision: String? = null,
+        chunkId: String? = null,
+    ): ProvenanceEntry =
+        ProvenanceEntry(
+            locator = locator,
+            sourceRevision = sourceRevision,
+            chunkId = chunkId,
+        )
+
+    private fun proposition(
+        contextId: ContextId,
+        text: String,
+        entries: List<ProvenanceEntry>,
+    ): Proposition =
+        Proposition(
+            contextId = contextId,
+            text = text,
+            mentions = emptyList(),
+            confidence = 0.9,
+            provenanceEntries = entries,
+        )
+}
+
+internal fun assertPortableSourceQueries(
+    repository: PropositionRepository,
+    fixture: PortableSourceQueryFixture,
+) {
+    val allSourceVersions = repository.findBySourceKey(
+        fixture.contextId,
+        fixture.locator.key(),
+    )
+    val exactRevisionOne = repository.findBySourceRevision(
+        fixture.contextId,
+        fixture.revisionOneRef,
+    )
+    val exactRevisionTwo = repository.findBySourceRevision(
+        fixture.contextId,
+        fixture.revisionTwoRef,
+    )
+    val revisionless = repository.findRevisionlessBySourceLocator(
+        fixture.contextId,
+        fixture.locator,
+    )
+
+    assertEquals(
+        setOf(
+            fixture.revisionless.id,
+            fixture.revisionOne.id,
+            fixture.revisionTwo.id,
+            fixture.duplicateRevisionOne.id,
+        ),
+        allSourceVersions.map { it.id }.toSet(),
+    )
+    assertEquals(
+        setOf(fixture.revisionOne.id, fixture.duplicateRevisionOne.id),
+        exactRevisionOne.map { it.id }.toSet(),
+    )
+    assertEquals(setOf(fixture.revisionTwo.id), exactRevisionTwo.map { it.id }.toSet())
+    assertEquals(setOf(fixture.revisionless.id), revisionless.map { it.id }.toSet())
+
+    listOf(allSourceVersions, exactRevisionOne, exactRevisionTwo, revisionless).forEach { result ->
+        assertEquals(result.size, result.map { it.id }.toSet().size)
+        assertEquals(setOf(fixture.contextId), result.map { it.contextId }.toSet())
+        assertEquals(false, result.any { it.id == fixture.foreignContext.id })
+    }
+}
 
 /**
  * The provenance-management defaults on [com.embabel.dice.proposition.PropositionRepository] over the
@@ -88,5 +208,13 @@ class InMemoryPropositionProvenanceTest {
         assertNull(repo.addProvenance("missing", listOf(uri("https://example.com/a"))))
         assertNull(repo.setProvenance("missing", listOf(uri("https://example.com/a"))))
         assertEquals(emptyList<ProvenanceEntry>(), repo.provenanceOf("missing"))
+    }
+
+    @Test
+    fun `portable source queries distinguish revisions without duplicates or context leaks`() {
+        val fixture = PortableSourceQueryFixture()
+        repo.saveAll(fixture.propositions)
+
+        assertPortableSourceQueries(repo, fixture)
     }
 }

--- a/dice/src/test/kotlin/com/embabel/dice/proposition/store/JsonFilePropositionRepositoryTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/proposition/store/JsonFilePropositionRepositoryTest.kt
@@ -18,10 +18,14 @@ package com.embabel.dice.proposition.store
 import com.embabel.agent.core.ContextId
 import com.embabel.common.core.types.TextSimilaritySearchRequest
 import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.SourceRevisionRef
+import com.embabel.dice.provenance.UriLocator
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
 import java.nio.file.Path
 
 class JsonFilePropositionRepositoryTest {
@@ -29,12 +33,17 @@ class JsonFilePropositionRepositoryTest {
     private val contextA = ContextId("user-a")
     private val contextB = ContextId("user-b")
 
-    private fun proposition(contextId: ContextId, text: String): Proposition =
+    private fun proposition(
+        contextId: ContextId,
+        text: String,
+        provenanceEntries: List<ProvenanceEntry> = emptyList(),
+    ): Proposition =
         Proposition(
             contextId = contextId,
             text = text,
             mentions = emptyList(),
             confidence = 0.9,
+            provenanceEntries = provenanceEntries,
         )
 
     @Test
@@ -75,5 +84,60 @@ class JsonFilePropositionRepositoryTest {
         )
 
         assertTrue(results.isEmpty())
+    }
+
+    @Test
+    fun `portable source queries retain their meanings across a JSON reload`(
+        @TempDir tempDir: Path,
+    ) {
+        val storeFile = tempDir.resolve("propositions.json")
+        val fixture = PortableSourceQueryFixture()
+        val repository = JsonFilePropositionRepository(storeFile)
+        repository.saveAll(fixture.propositions)
+
+        assertPortableSourceQueries(repository, fixture)
+        assertPortableSourceQueries(JsonFilePropositionRepository(storeFile), fixture)
+    }
+
+    @Test
+    fun `legacy JSON without source revision participates only as revisionless evidence`(
+        @TempDir tempDir: Path,
+    ) {
+        val storeFile = tempDir.resolve("propositions.json")
+        val locator = UriLocator("https://example.com/legacy-source")
+        val local = proposition(
+            contextA,
+            "legacy local",
+            listOf(ProvenanceEntry(locator = locator, sourceRevision = "legacy-r1")),
+        )
+        val foreign = proposition(
+            contextB,
+            "legacy foreign",
+            listOf(ProvenanceEntry(locator = locator, sourceRevision = "legacy-r1")),
+        )
+        JsonFilePropositionRepository(storeFile).saveAll(listOf(local, foreign))
+
+        val currentJson = Files.readString(storeFile)
+        val oldJson = currentJson.replace(
+            Regex(",\\s*\"sourceRevision\"\\s*:\\s*(?:null|\"(?:\\\\.|[^\"\\\\])*\")"),
+            "",
+        )
+        assertTrue(oldJson != currentJson)
+        assertTrue(!oldJson.contains("\"sourceRevision\""))
+        Files.writeString(storeFile, oldJson)
+
+        val reloaded = JsonFilePropositionRepository(storeFile)
+        val allSourceVersions = reloaded.findBySourceKey(contextA, locator.key())
+        val exactRevision = reloaded.findBySourceRevision(
+            contextA,
+            SourceRevisionRef(locator.key(), "legacy-r1"),
+        )
+        val revisionless = reloaded.findRevisionlessBySourceLocator(contextA, locator)
+
+        assertEquals(listOf(local.id), allSourceVersions.map { it.id })
+        assertEquals(emptyList<Proposition>(), exactRevision)
+        assertEquals(listOf(local.id), revisionless.map { it.id })
+        assertEquals(false, allSourceVersions.any { it.id == foreign.id })
+        assertEquals(false, revisionless.any { it.id == foreign.id })
     }
 }

--- a/dice/src/test/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKeyTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKeyTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ProvenanceEvidenceKeyTest {
+
+    private val locator = UriLocator("https://example.com/source")
+
+    @Test
+    fun `full evidence identity participates in encoding`() {
+        val entry = ProvenanceEntry(
+            locator = locator,
+            sourceRevision = "r1",
+            chunkId = "chunk",
+            startOffset = 3,
+            endOffset = 17,
+            contentHash = "sha256:abc",
+        )
+        val variants = listOf(
+            entry.copy(locator = UriLocator("https://example.com/other")),
+            entry.copy(sourceRevision = "r2"),
+            entry.copy(chunkId = "other"),
+            entry.copy(startOffset = 4),
+            entry.copy(endOffset = 18),
+            entry.copy(contentHash = "sha256:def"),
+        )
+        val encoded = ProvenanceEvidenceKey.encode(entry)
+
+        assertThat(ProvenanceEvidenceKey.matches(entry, encoded)).isTrue()
+        assertThat(variants.map(ProvenanceEvidenceKey::encode) + encoded)
+            .doesNotHaveDuplicates()
+        variants.forEach {
+            assertThat(ProvenanceEvidenceKey.matches(it, encoded)).isFalse()
+        }
+    }
+
+    @Test
+    fun `null and literal null remain distinct without delimiter or unicode collisions`() {
+        val revisionless = ProvenanceEntry(
+            locator = UriLocator("https://example.com/a:|💾"),
+            chunkId = "null:|雪",
+            contentHash = "",
+        )
+        val literalNull = revisionless.copy(sourceRevision = "null")
+        val revisionlessKey = ProvenanceEvidenceKey.encode(revisionless)
+        val literalNullKey = ProvenanceEvidenceKey.encode(literalNull)
+
+        assertThat(revisionlessKey).isNotEqualTo(literalNullKey)
+        assertThat(ProvenanceEvidenceKey.matches(revisionless, revisionlessKey)).isTrue()
+        assertThat(ProvenanceEvidenceKey.matches(literalNull, literalNullKey)).isTrue()
+        assertThat(ProvenanceEvidenceKey.matches(revisionless, literalNullKey)).isFalse()
+        assertThat(ProvenanceEvidenceKey.matches(literalNull, revisionlessKey)).isFalse()
+    }
+
+    @Test
+    fun `revision values and legacy raw keys match conservatively`() {
+        val revisionless = ProvenanceEntry(locator = locator)
+        val revisionOne = revisionless.copy(sourceRevision = "r1")
+        val revisionTwo = revisionless.copy(sourceRevision = "r2")
+
+        assertThat(ProvenanceEvidenceKey.matches(revisionless, locator.key())).isTrue()
+        assertThat(ProvenanceEvidenceKey.matches(revisionOne, locator.key())).isFalse()
+        assertThat(ProvenanceEvidenceKey.matches(revisionTwo, locator.key())).isFalse()
+        assertThat(
+            ProvenanceEvidenceKey.matches(
+                revisionOne,
+                ProvenanceEvidenceKey.encode(revisionTwo),
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `truncated malformed and unknown version keys fail closed`() {
+        val entry = ProvenanceEntry(
+            locator = locator,
+            sourceRevision = "r1",
+            chunkId = "chunk",
+        )
+        val encoded = ProvenanceEvidenceKey.encode(entry)
+        val malformed = listOf(
+            "dice-provenance:v1:",
+            "dice-provenance:v1::",
+            "dice-provenance:v1:-2:",
+            "dice-provenance:v1:01:x",
+            "dice-provenance:v1:１:x",
+            "dice-provenance:v1:999999999999999999999:",
+            "$encoded!",
+        )
+
+        for (end in "dice-provenance:v1:".length until encoded.length) {
+            assertThat(ProvenanceEvidenceKey.matches(entry, encoded.substring(0, end))).isFalse()
+        }
+        malformed.forEach {
+            assertThat(ProvenanceEvidenceKey.matches(entry, it)).isFalse()
+        }
+        assertThat(
+            ProvenanceEvidenceKey.matches(
+                entry.copy(
+                    locator = UriLocator("dice-provenance:v2:legacy-looking"),
+                    sourceRevision = null,
+                ),
+                "dice-provenance:v2:legacy-looking",
+            )
+        ).isFalse()
+    }
+}

--- a/dice/src/test/kotlin/com/embabel/dice/provenance/ProvenanceJsonCompatibilityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/provenance/ProvenanceJsonCompatibilityTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+import com.embabel.dice.proposition.Proposition
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ProvenanceJsonCompatibilityTest {
+
+    private val defaultMapper = ObjectMapper()
+        .registerModule(KotlinModule.Builder().build())
+        .registerModule(JavaTimeModule())
+
+    /**
+     * A locally built mapper standing in for a lenient importer. No DICE component is configured
+     * this way today — bundle import arrives after external #46 — so this only records the
+     * convention an importer would have to adopt, and shows what the strict default does instead.
+     */
+    private val lenientReader = ObjectMapper()
+        .registerModule(KotlinModule.Builder().build())
+        .registerModule(JavaTimeModule())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+    @Test
+    fun `revisionless fixture loads a null source revision`() {
+        val proposition = defaultMapper.readValue<Proposition>(fixture("proposition-revisionless.json"))
+        val evidence = proposition.provenanceEntries.single()
+
+        assertNull(evidence.sourceRevision)
+        assertEquals("chunk-legacy", evidence.chunkId)
+        assertEquals("uri:https://example.com/legacy", evidence.locator.key())
+        assertEquals(
+            proposition,
+            defaultMapper.readValue<Proposition>(defaultMapper.writeValueAsString(proposition)),
+        )
+    }
+
+    @Test
+    fun `revision scalars round trip losslessly and literal null remains a value`() {
+        val fixture = fixture("proposition-revisioned.json")
+        val proposition = defaultMapper.readValue<Proposition>(fixture)
+
+        assertTrue(fixture.contains("\"sourceRevision\": \"null\""))
+        assertEquals(listOf("r1", "null"), proposition.provenanceEntries.map { it.sourceRevision })
+
+        val roundTripped = defaultMapper.readValue<Proposition>(
+            defaultMapper.writeValueAsString(proposition),
+        )
+        assertEquals(proposition, roundTripped)
+        assertEquals("null", roundTripped.provenanceEntries.last().sourceRevision)
+    }
+
+    /**
+     * A convention pin, not coverage of shipped behaviour: both mappers are built here in the test.
+     * It records that a strict mapper rejects an unknown evidence field and that opting out of
+     * [DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES] is what an importer would need, while
+     * still reading the revisions correctly. Nothing in DICE reads propositions leniently today.
+     */
+    @Test
+    fun `a strict mapper rejects an unknown evidence field and a lenient one reads past it`() {
+        val tree = defaultMapper.readTree(fixture("proposition-revisioned.json")) as ObjectNode
+        (tree.withArray("provenanceEntries")[0] as ObjectNode)
+            .put("futureEvidenceField", "future-value")
+        val withFutureField = tree.toString()
+
+        assertTrue(defaultMapper.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES))
+        assertThrows(UnrecognizedPropertyException::class.java) {
+            defaultMapper.readValue<Proposition>(withFutureField)
+        }
+
+        val imported = lenientReader.readValue<Proposition>(withFutureField)
+        assertEquals(listOf("r1", "null"), imported.provenanceEntries.map { it.sourceRevision })
+    }
+
+    private fun fixture(name: String): String =
+        requireNotNull(javaClass.getResource("/provenance/$name")) {
+            "Missing provenance fixture: $name"
+        }.readText()
+}

--- a/dice/src/test/kotlin/com/embabel/dice/provenance/SourceIdentityBoundsTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/provenance/SourceIdentityBoundsTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+import com.embabel.agent.core.ContextId
+import com.embabel.agent.rag.service.RetrievableIdentifier
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionStatus
+import com.embabel.dice.proposition.PropositionStore
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The length ceilings on externally supplied source identity and revision strings.
+ *
+ * Each limit is checked three ways: a value exactly at the limit is accepted, a value one character
+ * over it is refused with a message naming the limit, and the refusal happens while the value object
+ * is being built — upstream of any hash and of any call into a store.
+ */
+class SourceIdentityBoundsTest {
+
+    /**
+     * A store that counts every call anything makes into it. Used to prove a rejected write never
+     * got as far as the persistence port.
+     */
+    private class InteractionCountingStore : PropositionStore {
+
+        var interactions = 0
+            private set
+
+        override fun save(proposition: Proposition): Proposition {
+            interactions++
+            return proposition
+        }
+
+        override fun findById(id: String): Proposition? {
+            interactions++
+            return null
+        }
+
+        override fun findByEntity(entityIdentifier: RetrievableIdentifier): List<Proposition> {
+            interactions++
+            return emptyList()
+        }
+
+        override fun findByStatus(status: PropositionStatus): List<Proposition> {
+            interactions++
+            return emptyList()
+        }
+
+        override fun findByGrounding(chunkId: String): List<Proposition> {
+            interactions++
+            return emptyList()
+        }
+
+        override fun findByMinLevel(minLevel: Int): List<Proposition> {
+            interactions++
+            return emptyList()
+        }
+
+        override fun findAll(): List<Proposition> {
+            interactions++
+            return emptyList()
+        }
+
+        override fun delete(id: String): Boolean {
+            interactions++
+            return false
+        }
+
+        override fun count(): Int {
+            interactions++
+            return 0
+        }
+    }
+
+    /** A `uri:` locator whose canonical key comes out at exactly [keyLength] characters. */
+    private fun locatorWithKeyLength(keyLength: Int): UriLocator {
+        val prefix = "https://example.com/"
+        val padding = keyLength - "uri:".length - prefix.length
+        return UriLocator(prefix + "a".repeat(padding))
+    }
+
+    private fun propositionCiting(entry: ProvenanceEntry): Proposition =
+        Proposition(
+            contextId = ContextId("bounds"),
+            text = "a bounded fact",
+            mentions = emptyList(),
+            confidence = 0.9,
+            provenanceEntries = listOf(entry),
+        )
+
+    @Test
+    fun `a source key at the limit is accepted`() {
+        val locator = locatorWithKeyLength(SourceIdentityBounds.MAX_SOURCE_KEY_LENGTH)
+        assertEquals(SourceIdentityBounds.MAX_SOURCE_KEY_LENGTH, locator.key().length)
+
+        val entry = ProvenanceEntry(locator = locator)
+        assertEquals(locator.key(), entry.locator.key())
+        assertEquals(locator.key(), SourceRevisionRef(locator.key(), "r1").sourceKey)
+    }
+
+    @Test
+    fun `a source key one over the limit is refused before the store is touched`() {
+        val store = InteractionCountingStore()
+        val locator = locatorWithKeyLength(SourceIdentityBounds.MAX_SOURCE_KEY_LENGTH + 1)
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            store.save(propositionCiting(ProvenanceEntry(locator = locator)))
+        }
+
+        assertTrue(
+            failure.message!!.contains("MAX_SOURCE_KEY_LENGTH") &&
+                failure.message!!.contains("${SourceIdentityBounds.MAX_SOURCE_KEY_LENGTH}"),
+            "the refusal must name the limit it enforced: ${failure.message}",
+        )
+        assertEquals(0, store.interactions, "an over-long source key must never reach the store")
+    }
+
+    @Test
+    fun `a source revision at the limit is accepted`() {
+        val revision = "r".repeat(SourceIdentityBounds.MAX_SOURCE_REVISION_LENGTH)
+        val locator = UriLocator("https://example.com/at-limit-revision")
+
+        assertEquals(revision, ProvenanceEntry(locator = locator, sourceRevision = revision).sourceRevision)
+        assertEquals(revision, SourceRevisionRef(locator.key(), revision).sourceRevision)
+    }
+
+    @Test
+    fun `a source revision one over the limit is refused before the store is touched`() {
+        val store = InteractionCountingStore()
+        val locator = UriLocator("https://example.com/over-limit-revision")
+        val revision = "r".repeat(SourceIdentityBounds.MAX_SOURCE_REVISION_LENGTH + 1)
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            store.save(propositionCiting(ProvenanceEntry(locator = locator, sourceRevision = revision)))
+        }
+
+        assertTrue(
+            failure.message!!.contains("MAX_SOURCE_REVISION_LENGTH") &&
+                failure.message!!.contains("${SourceIdentityBounds.MAX_SOURCE_REVISION_LENGTH}"),
+            "the refusal must name the limit it enforced: ${failure.message}",
+        )
+        assertEquals(0, store.interactions, "an over-long revision must never reach the store")
+    }
+
+    /**
+     * The query-side value object is bounded too. A caller that hands a runaway key or revision to
+     * an exact-revision query is refused at the same ceiling the write path uses.
+     */
+    @Test
+    fun `SourceRevisionRef refuses an over-long key or revision`() {
+        val overLongKey = "uri:" + "a".repeat(SourceIdentityBounds.MAX_SOURCE_KEY_LENGTH)
+        val keyFailure = assertThrows(IllegalArgumentException::class.java) {
+            SourceRevisionRef(overLongKey, "r1")
+        }
+        assertTrue(
+            keyFailure.message!!.contains("MAX_SOURCE_KEY_LENGTH"),
+            "the refusal must name the limit it enforced: ${keyFailure.message}",
+        )
+
+        val revisionFailure = assertThrows(IllegalArgumentException::class.java) {
+            SourceRevisionRef("uri:https://example.com/ok", "r".repeat(SourceIdentityBounds.MAX_SOURCE_REVISION_LENGTH + 1))
+        }
+        assertTrue(
+            revisionFailure.message!!.contains("MAX_SOURCE_REVISION_LENGTH"),
+            "the refusal must name the limit it enforced: ${revisionFailure.message}",
+        )
+    }
+
+    /**
+     * The bound sits ahead of the evidence-key encoding, so nothing over the limit can ever be
+     * folded into a stored provenance ref.
+     */
+    @Test
+    fun `an over-long value cannot reach the evidence key encoding`() {
+        val locator = locatorWithKeyLength(SourceIdentityBounds.MAX_SOURCE_KEY_LENGTH)
+        val entry = ProvenanceEntry(
+            locator = locator,
+            sourceRevision = "r".repeat(SourceIdentityBounds.MAX_SOURCE_REVISION_LENGTH),
+        )
+        val encoded = ProvenanceEvidenceKey.encode(entry)
+
+        assertTrue(ProvenanceEvidenceKey.matches(entry, encoded))
+        assertThrows(IllegalArgumentException::class.java) {
+            ProvenanceEvidenceKey.encode(
+                ProvenanceEntry(
+                    locator = locatorWithKeyLength(SourceIdentityBounds.MAX_SOURCE_KEY_LENGTH + 1),
+                ),
+            )
+        }
+    }
+}

--- a/dice/src/test/kotlin/com/embabel/dice/provenance/SourceIdentityBoundsTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/provenance/SourceIdentityBoundsTest.kt
@@ -159,6 +159,58 @@ class SourceIdentityBoundsTest {
         assertEquals(0, store.interactions, "an over-long revision must never reach the store")
     }
 
+    @Test
+    fun `a chunk id at the limit is accepted`() {
+        val chunkId = "c".repeat(SourceIdentityBounds.MAX_CHUNK_ID_LENGTH)
+        val locator = UriLocator("https://example.com/at-limit-chunk-id")
+
+        assertEquals(chunkId, ProvenanceEntry(locator = locator, chunkId = chunkId).chunkId)
+    }
+
+    @Test
+    fun `a chunk id one over the limit is refused before the store is touched`() {
+        val store = InteractionCountingStore()
+        val locator = UriLocator("https://example.com/over-limit-chunk-id")
+        val chunkId = "c".repeat(SourceIdentityBounds.MAX_CHUNK_ID_LENGTH + 1)
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            store.save(propositionCiting(ProvenanceEntry(locator = locator, chunkId = chunkId)))
+        }
+
+        assertTrue(
+            failure.message!!.contains("MAX_CHUNK_ID_LENGTH") &&
+                failure.message!!.contains("${SourceIdentityBounds.MAX_CHUNK_ID_LENGTH}"),
+            "the refusal must name the limit it enforced: ${failure.message}",
+        )
+        assertEquals(0, store.interactions, "an over-long chunk id must never reach the store")
+    }
+
+    @Test
+    fun `a content hash at the limit is accepted`() {
+        val contentHash = "h".repeat(SourceIdentityBounds.MAX_CONTENT_HASH_LENGTH)
+        val locator = UriLocator("https://example.com/at-limit-content-hash")
+
+        assertEquals(contentHash, ProvenanceEntry(locator = locator, contentHash = contentHash).contentHash)
+    }
+
+    @Test
+    fun `a content hash one over the limit is refused before the store is touched`() {
+        val store = InteractionCountingStore()
+        val locator = UriLocator("https://example.com/over-limit-content-hash")
+        val contentHash = "h".repeat(SourceIdentityBounds.MAX_CONTENT_HASH_LENGTH + 1)
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            store.save(propositionCiting(ProvenanceEntry(locator = locator, contentHash = contentHash)))
+        }
+
+        assertTrue(
+            failure.message!!.contains("MAX_CONTENT_HASH_LENGTH") &&
+                failure.message!!.contains("${SourceIdentityBounds.MAX_CONTENT_HASH_LENGTH}"),
+            "the refusal must name the limit it enforced: ${failure.message}",
+        )
+        assertEquals(0, store.interactions, "an over-long content hash must never reach the store")
+    }
+
     /**
      * The query-side value object is bounded too. A caller that hands a runaway key or revision to
      * an exact-revision query is refused at the same ceiling the write path uses.

--- a/dice/src/test/kotlin/com/embabel/dice/provenance/SourceRevisionContractTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/provenance/SourceRevisionContractTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.provenance
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.junit.jupiter.api.Test
+
+class SourceRevisionContractTest {
+
+    private val objectMapper = jacksonObjectMapper()
+    private val locator = UriLocator("https://example.com/source")
+
+    @Test
+    fun `source revision ref preserves opaque values`() {
+        val ref = SourceRevisionRef(
+            sourceKey = locator.key(),
+            sourceRevision = "null",
+        )
+
+        assertThat(ref.sourceKey).isEqualTo(locator.key())
+        assertThat(ref.sourceRevision).isEqualTo("null")
+        assertThat(objectMapper.readValue<SourceRevisionRef>(objectMapper.writeValueAsString(ref)))
+            .isEqualTo(ref)
+    }
+
+    @Test
+    fun `source revision ref rejects blank components`() {
+        assertThatIllegalArgumentException()
+            .isThrownBy { SourceRevisionRef(" ", "r1") }
+        assertThatIllegalArgumentException()
+            .isThrownBy { SourceRevisionRef(locator.key(), "\t") }
+    }
+
+    @Test
+    fun `provenance revision participates in equality and deduplication`() {
+        val revisionless = ProvenanceEntry(locator = locator)
+        val sameRevisionless = ProvenanceEntry(locator = locator)
+        val revisionOne = ProvenanceEntry(locator = locator, sourceRevision = "r1")
+        val duplicateRevisionOne = ProvenanceEntry(locator = locator, sourceRevision = "r1")
+        val revisionTwo = ProvenanceEntry(locator = locator, sourceRevision = "r2")
+
+        assertThat(revisionless).isEqualTo(sameRevisionless)
+        assertThat(revisionOne).isNotEqualTo(revisionTwo)
+        assertThat(listOf(revisionOne, duplicateRevisionOne, revisionTwo).distinct())
+            .containsExactly(revisionOne, revisionTwo)
+    }
+
+    @Test
+    fun `provenance rejects a blank present revision`() {
+        assertThatIllegalArgumentException()
+            .isThrownBy { ProvenanceEntry(locator = locator, sourceRevision = " ") }
+    }
+
+    @Test
+    fun `old and new provenance json preserve revision absence and value`() {
+        val revisionless = ProvenanceEntry(locator = locator)
+        val oldJson = objectMapper.valueToTree<com.fasterxml.jackson.databind.node.ObjectNode>(
+            revisionless
+        ).apply {
+            remove("sourceRevision")
+        }
+        val fromOldJson = objectMapper.treeToValue(oldJson, ProvenanceEntry::class.java)
+
+        val revised = ProvenanceEntry(locator = locator, sourceRevision = "null")
+        val fromNewJson = objectMapper.readValue<ProvenanceEntry>(
+            objectMapper.writeValueAsString(revised)
+        )
+
+        assertThat(fromOldJson).isEqualTo(revisionless)
+        assertThat(fromOldJson.sourceRevision).isNull()
+        assertThat(fromNewJson).isEqualTo(revised)
+        assertThat(fromNewJson.sourceRevision).isEqualTo("null")
+        assertThat(fromNewJson).isNotEqualTo(fromOldJson)
+    }
+}

--- a/dice/src/test/resources/provenance/proposition-revisioned.json
+++ b/dice/src/test/resources/provenance/proposition-revisioned.json
@@ -1,0 +1,49 @@
+{
+  "id": "revisioned",
+  "contextId": "ctx-json",
+  "text": "A revisioned proposition",
+  "mentions": [],
+  "confidence": 0.8,
+  "decay": 0.0,
+  "importance": 0.5,
+  "reasoning": null,
+  "grounding": [],
+  "created": "2026-01-02T00:00:00Z",
+  "contentRevised": "2026-01-02T00:00:00Z",
+  "metadataRevised": "2026-01-02T00:00:00Z",
+  "pinned": false,
+  "lastAccessed": "2026-01-02T00:00:00Z",
+  "status": "ACTIVE",
+  "level": 0,
+  "sourceIds": [],
+  "reinforceCount": 0,
+  "metadata": {},
+  "uri": null,
+  "temporal": null,
+  "provenanceEntries": [
+    {
+      "locator": {
+        "kind": "uri",
+        "uri": "https://example.com/revisioned",
+        "display": "Revisioned source"
+      },
+      "chunkId": "chunk-r1",
+      "startOffset": 2,
+      "endOffset": 12,
+      "contentHash": "hash-r1",
+      "sourceRevision": "r1"
+    },
+    {
+      "locator": {
+        "kind": "uri",
+        "uri": "https://example.com/revisioned",
+        "display": "Revisioned source"
+      },
+      "chunkId": "chunk-literal-null",
+      "startOffset": 13,
+      "endOffset": 25,
+      "contentHash": "hash-null",
+      "sourceRevision": "null"
+    }
+  ]
+}

--- a/dice/src/test/resources/provenance/proposition-revisionless.json
+++ b/dice/src/test/resources/provenance/proposition-revisionless.json
@@ -1,0 +1,36 @@
+{
+  "id": "revisionless",
+  "contextId": "ctx-json",
+  "text": "A revisionless proposition",
+  "mentions": [],
+  "confidence": 0.75,
+  "decay": 0.0,
+  "importance": 0.5,
+  "reasoning": null,
+  "grounding": [],
+  "created": "2026-01-01T00:00:00Z",
+  "contentRevised": "2026-01-01T00:00:00Z",
+  "metadataRevised": "2026-01-01T00:00:00Z",
+  "pinned": false,
+  "lastAccessed": "2026-01-01T00:00:00Z",
+  "status": "ACTIVE",
+  "level": 0,
+  "sourceIds": [],
+  "reinforceCount": 0,
+  "metadata": {},
+  "uri": null,
+  "temporal": null,
+  "provenanceEntries": [
+    {
+      "locator": {
+        "kind": "uri",
+        "uri": "https://example.com/legacy",
+        "display": "Legacy source"
+      },
+      "chunkId": "chunk-legacy",
+      "startOffset": 0,
+      "endOffset": 10,
+      "contentHash": "hash-legacy"
+    }
+  ]
+}

--- a/docs/design/INDEX.md
+++ b/docs/design/INDEX.md
@@ -29,6 +29,10 @@ you need.
 - [grounding-and-conflicts.md](grounding-and-conflicts.md) — how propositions stay anchored to
   source material (grounding) and how the conflict/policy SPI resolves disagreements between
   propositions.
+- [source-revisions.md](source-revisions.md) — carrying an opaque source version beside a stable
+  locator: where the revision sits on the evidence, what it does to equality and dedup, the
+  evidence-key codec that makes a fold precisely undoable, and what stays true for evidence that
+  carries no revision.
 
 ## Projections
 

--- a/docs/design/events.md
+++ b/docs/design/events.md
@@ -145,11 +145,15 @@ hand a listener to the pipeline, and combine several listeners with `CompositeDi
 Every event is set up for polymorphic JSON, so a listener can forward them out of process.
 
 ```kotlin
-val repo = EventEmittingPropositionRepository(
+val repo = EventEmittingPropositionRepository.wrapping(
     delegate = inMemoryRepository,
     listener = SafeDiceEventListener(myListener),
 )
 ```
+
+`wrapping` answers source-revision queries when the store it wraps does: it picks a wrapper that
+carries `SourceRevisionQueryCapable` when `delegate` implements it, and a plain wrapper otherwise, so
+a caller's `as?` probe on the wrapper sees the same answer it would on the delegate.
 
 A listener is a one-method fun interface, so a lambda or a class both work:
 

--- a/docs/design/source-revisions.md
+++ b/docs/design/source-revisions.md
@@ -106,7 +106,9 @@ classDiagram
         +encode(ProvenanceEntry) String
         +matches(ProvenanceEntry, String) Boolean
     }
-    class PropositionRepository {
+    class SourceRevisionQueryCapable {
+        <<opt-in capability>>
+        +supportsSourceRevisionQueries Boolean
         +findBySourceKey(contextId, sourceKey)
         +findBySourceRevision(contextId, ref)
         +findRevisionlessBySourceLocator(contextId, locator)
@@ -116,8 +118,8 @@ classDiagram
     ProvenanceEntry --> SourceLocator : locator
     SourceRevisionRef ..> SourceLocator : sourceKey is a locator key
     ProvenanceEvidenceKey ..> ProvenanceEntry : encodes and matches
-    PropositionRepository ..> SourceRevisionRef : exact-version query
-    PropositionRepository ..> Proposition : returns
+    SourceRevisionQueryCapable ..> SourceRevisionRef : exact-version query
+    SourceRevisionQueryCapable ..> Proposition : returns
 ```
 
 `sourceRevision` is the sixth field of `ProvenanceEntry`, defaulted to null and validated non-blank
@@ -212,7 +214,7 @@ properties hold for those, and slice 1's tests pin each one:
 
 ## Querying by source
 
-Three finders land on `PropositionRepository`, all context-scoped:
+Three finders land on `SourceRevisionQueryCapable`, all context-scoped:
 
 | Method | Matches |
 | --- | --- |
@@ -220,25 +222,60 @@ Three finders land on `PropositionRepository`, all context-scoped:
 | `findBySourceRevision(contextId, ref)` | exactly that source key and that revision |
 | `findRevisionlessBySourceLocator(contextId, locator)` | that source key with no revision |
 
-Each exists twice: the `ContextId`-typed form above, and a plain-String form that holds the default
-body. The typed one forwards to the String one, following `findByContextId` →
-`findByContextIdValue` in `PropositionStore`. The direction is load-bearing. `ContextId` is a Kotlin
-value class, so the typed method's JVM name is mangled and a Java class cannot override it; an
-override placed there would be unreachable from Java, and if the delegation ran the other way a
-Java backend's override would be unreachable from Kotlin. With the String form as the single
-override point, every call from either language passes through it.
-`PropositionRepositoryDelegationTest` calls the typed entry points against a backend that overrode
-only the String forms and counts the dispatches, so the test fails if a typed call ever skips the
-override.
+### Why this is a capability the base repository leaves out
 
-The default bodies read the context and filter loaded provenance in memory, which is correct for any
-backend whose context read carries provenance — the in-memory and JSON-file repositories get it for
-free. A backend whose context read is lean must override all three, and `DrivinePropositionRepository`
-does: its context read loads a view with no provenance at all, so the defaults would return nothing.
-Its overrides push each predicate into Cypher instead, scoping to the tenant first and then testing
-for a matching `DERIVED_FROM` edge, with the revision compared as an edge property (`IS NULL` for
-the revisionless query). `DrivinePropositionStoreIntegrationTest` runs all three against a real
-Neo4j through both the typed and the String entry points.
+An earlier draft put these three finders on `PropositionRepository` with default bodies that read
+the context and filtered loaded provenance in memory. That is safe only for a backend whose context
+read carries provenance. On a backend that stores evidence and never projects it through an ordinary
+read — which describes the graph store — the default returns an empty list, and an empty list here
+already means something: nothing in this context cites that source. An unsupported operation would
+have been indistinguishable from a genuine negative answer, which is the worst shape a query contract
+can take.
+
+So the surface lives on its own opt-in interface, following the house pattern of `GraphQueryCapable`
+and `VectorSearchCapable`. The three plain-String finders are **abstract**: implementing
+`SourceRevisionQueryCapable` is a promise to answer correctly for your own storage, and there is no
+body to inherit that could quietly answer wrongly. A backend that cannot answer does not implement
+it, and is therefore absent from the type. A caller asks for the capability and treats its absence as
+its own case:
+
+```kotlin
+val revisionQueries = repository as? SourceRevisionQueryCapable
+    ?: error("this backend cannot answer source-revision queries")
+```
+
+`supportsSourceRevisionQueries` is the runtime half of the same signal, mirroring
+`VectorSearchCapable.supportsVector`. A type can promise what a particular instance cannot deliver:
+`EventEmittingPropositionRepository` decorates a plain `PropositionRepository`, so whether it can
+answer depends on the delegate it was handed. It carries the capability type, reports `false` from
+the flag when its delegate lacks the capability, and throws an `UnsupportedOperationException` naming
+that delegate if a call gets through anyway. Two ways to find out, no empty list.
+
+`ProvenanceScanningSourceRevisionQueries` carries the in-memory scan as default bodies, for the
+stores whose reads genuinely do hold every entry — `InMemoryPropositionRepository` and
+`JsonFilePropositionRepository` implement that, and get all three for free. Naming the condition
+keeps it visible: a store may only mix that in when its context read carries provenance.
+
+### The typed and String forms
+
+Each finder exists twice: the `ContextId`-typed form above, and a plain-String form that carries the
+work. The typed one forwards to the String one, following `findByContextId` →
+`findByContextIdValue` in `PropositionStore`. The direction is load-bearing. `ContextId` is a Kotlin
+value class, so the typed method's JVM name is mangled and a Java class cannot implement it; an
+implementation placed there would be unreachable from Java, and if the delegation ran the other way a
+Java backend's implementation would be unreachable from Kotlin. With the String form as the single
+implementation point, every call from either language passes through it.
+`PropositionRepositoryDelegationTest` calls the typed entry points against a backend that implemented
+only the String forms and counts the dispatches, so the test fails if a typed call ever skips them.
+The same test pins the split itself: a store implementing only `PropositionRepository` yields null
+from the `as?` probe, while a capability-declaring store does not.
+
+`DrivinePropositionRepository` implements `SourceRevisionQueryCapable` directly, because its context
+read loads a view with no provenance at all. Each finder pushes its predicate into Cypher, scoping to
+the tenant first and then testing for a matching `DERIVED_FROM` edge, with the revision compared as
+an edge property (`IS NULL` for the revisionless query).
+`DrivinePropositionStoreIntegrationTest` runs all three against a real Neo4j through both the typed
+and the String entry points.
 
 Inside the `dice` module a shared fixture, `PortableSourceQueryFixture` with
 `assertPortableSourceQueries`, states what the three finders mean once; the in-memory and JSON-file
@@ -295,6 +332,45 @@ for the second revision.
 depend on the capability directly, without probing for a repository type at runtime.
 `PropositionRepository` keeps its declarations as overrides that delegate to the store defaults, so
 existing implementors see no behaviour change.
+
+### A shared `:Source` node needs an unshared label
+
+`:Source` is deliberately global: one locator key is one node, whichever context cites it. That is
+what makes "everything from this document" a single graph question. Presentation was following the
+same rule by accident. `display` was refreshed on every write, so a second context citing the same
+document repainted the label the first context reads — one tenant's wording leaking into everybody
+else's UI, with no way to tell where it came from.
+
+Identity and presentation now part company. The key stays global, and `display` becomes write-once:
+it is set in the `ON CREATE SET` block alongside the identity fields and left alone thereafter. Each
+writer's own evidence still lands on its own `DERIVED_FROM` edge, so nothing about what a context can
+see or query changes. `display` has never participated in `SourceLocator.key()`, so identity is
+untouched either way. `DrivinePropositionStoreIntegrationTest` writes the same locator from two
+contexts with different labels and asserts the first label survives while both writers' evidence
+arrives; reverting the write-once change turns it red.
+
+### Bounding what comes in from outside
+
+Two strings reaching this model come from outside DICE and end up inside stored identity: the
+canonical source key, and the provider-defined revision. Both get hashed into an evidence key and
+written to indexed graph properties, so an unbounded value inflates every index entry mentioning it
+and can trip a graph store's own ceiling deep inside a write, where it surfaces as an opaque database
+error.
+
+`SourceIdentityBounds` states the two limits as public constants — `MAX_SOURCE_KEY_LENGTH` at 2048
+and `MAX_SOURCE_REVISION_LENGTH` at 1024 — and both are enforced while the value object is being
+built, in `ProvenanceEntry`'s and `SourceRevisionRef`'s `init` blocks. That placement is the point:
+construction happens before anything is hashed and before any store call, so an over-long value is
+refused with an `IllegalArgumentException` naming the limit it broke while the store is still
+untouched. `SourceIdentityBoundsTest` pins all of it — a value exactly at each limit is accepted, a
+value one character over is refused, the message names the limit, and a counting store records zero
+interactions across the rejected write.
+
+The numbers are generous by design. 2048 is the practical ceiling browsers and proxies settled on for
+a URL, which is the longest thing a locator wraps. 1024 is the longest real revision token we know
+of, an S3 object version id; a git SHA is 40 or 64 characters, an HTTP ETag a few dozen, a Slack or
+Notion timestamp about 20. Nothing a real connector emits comes near either limit; they exist to stop
+a runaway or hostile value.
 
 ## Compatibility boundary
 

--- a/docs/design/source-revisions.md
+++ b/docs/design/source-revisions.md
@@ -1,0 +1,341 @@
+# Source revisions: an opaque version beside a stable locator
+
+A source revision is an opaque, provider-defined string carried on each piece of evidence, beside
+the locator that identifies the source. It records which version of a source a claim was read
+from — the note edited between Monday and Friday, the Notion page with a new `last_edited_time`,
+the S3 object with a new version id. DICE already records *where* a claim came from, a
+`SourceLocator` and the span within it; the revision says *when in that source's life*.
+
+The locator keeps its current identity. `SourceLocator.key()` is unchanged, so a document read at
+`r1` and the same document read at `r7` are still one source, cited by one graph node, reachable by
+one query.
+
+This note covers the whole of Wave A at overview level and the core contract — the types in the
+`dice` module — in depth. The storage mapping, collector hardening, and entry-point carriage each
+have their own slice; see [Wave A map](#wave-a-map) at the end.
+
+## What the model could not say
+
+`ProvenanceEntry` on `main` is five fields:
+
+```kotlin
+data class ProvenanceEntry @JvmOverloads constructor(
+    val locator: SourceLocator,
+    val chunkId: String? = null,
+    val startOffset: Int? = null,
+    val endOffset: Int? = null,
+    val contentHash: String? = null,
+)
+```
+
+`contentHash` gets close. If you hash the source content and store it, a later mismatch tells you
+the source changed. What it cannot tell you is *which* version you read, in the vocabulary the
+source system itself uses. A hash is DICE's own summary of the bytes; a revision is the provider's
+identifier, the one you can hand back to that provider to fetch exactly what was extracted. Two
+extractions of one document at two revisions were, before this change, indistinguishable evidence
+pointing at the same locator.
+
+## Stable key, opaque version
+
+S3 and W3C PROV both split identity this way. S3 names an object by bucket and key; enabling
+versioning leaves the key alone and adds a version id per PUT, and a GET without one resolves to
+the current version. W3C PROV keeps a general entity referable while a specialization of it — the
+entity as it stood at some point — is a distinct thing linked back by `prov:specializationOf`, so a statement
+about the general entity survives the arrival of new specializations. Both keep the *name* of the
+thing stable and put the version somewhere the name does not reach.
+
+DICE follows that split with a scalar rather than a second entity, because DICE's evidence already
+lives on a relationship: a proposition cites a source through a `ProvenanceEntry`, and the entry is
+the natural place for a per-citation qualifier. Adding a revision-bearing `SourceLocator` subtype
+would have forked source identity, so `uri:https://example.com/doc` at `r1` and at `r7` would
+MERGE as two `:Source` nodes, "all propositions from this document" would need a prefix scan, and
+every consumer that persisted a locator key would see its keys change meaning. Two constraints
+follow from that, and both are load-bearing:
+
+- **`SourceLocator.key()` never contains the revision.** `UriLocator.key()` stays `"uri:$uri"`,
+  `FileLocator.key()` stays `"file:$path"`, `ContentAddressedLocator.key()` stays
+  `"content:$contentHash"`, `ConnectorRef.key()` stays `"connector:$connectorId:$externalId"`.
+  Nothing in this train touches those.
+- **The revision is opaque to DICE.** It is a non-blank string that DICE stores, compares for exact
+  equality, and hands back. No ordering, no parsing, no "latest" inference. `"r1"` and `"r10"` have
+  no relationship DICE knows about, and the literal string `"null"` is a perfectly good revision
+  value — the tests pin that, because a codec that confused it with absence would be a silent
+  evidence-deletion bug.
+
+`SourceRevisionRef` pairs the two halves for callers who need to name one version of one source:
+
+```kotlin
+data class SourceRevisionRef(
+    val sourceKey: String,
+    val sourceRevision: String,
+)
+```
+
+Both components are required and non-blank. It is the query and carriage value; stored evidence
+keeps only the scalar beside its existing locator, so nothing on the write path has to keep a
+denormalized copy of the key in step.
+
+## The types
+
+```mermaid
+classDiagram
+    class Proposition {
+        +List~ProvenanceEntry~ provenanceEntries
+        +withProvenanceEntries(entries) Proposition
+        +absorbEvidence(other) Proposition
+        +withoutFoldedEvidence(grounding, refs, sourceIds) Proposition
+    }
+    class ProvenanceEntry {
+        +SourceLocator locator
+        +String? chunkId
+        +Int? startOffset
+        +Int? endOffset
+        +String? contentHash
+        +String? sourceRevision
+    }
+    class SourceLocator {
+        <<sealed interface>>
+        +key() String
+    }
+    class SourceRevisionRef {
+        +String sourceKey
+        +String sourceRevision
+    }
+    class ProvenanceEvidenceKey {
+        <<internal object>>
+        +encode(ProvenanceEntry) String
+        +matches(ProvenanceEntry, String) Boolean
+    }
+    class PropositionRepository {
+        +findBySourceKey(contextId, sourceKey)
+        +findBySourceRevision(contextId, ref)
+        +findRevisionlessBySourceLocator(contextId, locator)
+    }
+
+    Proposition "1" o-- "*" ProvenanceEntry : provenanceEntries
+    ProvenanceEntry --> SourceLocator : locator
+    SourceRevisionRef ..> SourceLocator : sourceKey is a locator key
+    ProvenanceEvidenceKey ..> ProvenanceEntry : encodes and matches
+    PropositionRepository ..> SourceRevisionRef : exact-version query
+    PropositionRepository ..> Proposition : returns
+```
+
+`sourceRevision` is the sixth field of `ProvenanceEntry`, defaulted to null and validated non-blank
+when present. `@JvmOverloads` already sat on the constructor, so every concrete Java constructor
+descriptor a caller could have compiled against survives and the revision arrives as one more
+descriptor on the end.
+
+## Two identities: equality and dedup
+
+The change touches identity in two places, and they answer different questions.
+
+**Data-class equality** answers "are these the same piece of evidence?" `ProvenanceEntry` is a
+Kotlin `data class` with no custom `equals`, so adding `sourceRevision` puts it into structural
+equality with the other five fields. That is the whole mechanism behind in-memory dedup:
+`withProvenanceEntries` and `withProvenance` both end in `.distinct()`, and `absorbEvidence` folds
+a collapsed proposition's evidence the same way. So evidence at `r1` and evidence at `r2` over the
+same span of the same document are two entries, and both survive a fold. Before this change they
+collapsed into one and the second revision's reading was lost.
+
+**The evidence-key codec** answers "which stored entry does this recorded reference name?" A
+collapse writes down what it folded so an undo can subtract exactly that contribution later. On
+`main` those references were locator keys, which stopped being precise the moment one locator could
+appear on several entries at different revisions. `ProvenanceEvidenceKey` owns the replacement:
+
+```kotlin
+internal object ProvenanceEvidenceKey {
+    fun encode(entry: ProvenanceEntry): String
+    fun matches(entry: ProvenanceEntry, encoded: String): Boolean
+}
+```
+
+The encoding is length-framed — each field is written as `<length>:<value>`, in the fixed order
+locator key, revision, chunk id, start offset, end offset, content hash, behind a
+`dice-provenance:v1:` prefix. Framing by length means no value needs escaping however many colons
+it contains, and a length of `-1` stands for null, so absence stays distinct from every string
+value including `"null"`. An entry over `https://a` at revision `r1`, chunk `c`, offsets 1–2, hash
+`h` encodes as:
+
+```
+dice-provenance:v1:13:uri:https://a2:r11:c1:11:21:h
+```
+
+`matches` runs one way only: it walks the candidate entry's fields against the string and compares
+regions in place, so there is no decode step that could produce a half-trusted entry. A reference
+that is truncated, has a bad length, carries a non-ASCII digit, or has trailing bytes matches
+nothing at all, so an undo driven by a corrupt reference removes no evidence.
+
+```mermaid
+flowchart TD
+    E["ProvenanceEntry"]
+    E -->|"structural equality, all six fields"| DD["list dedup:<br/>withProvenanceEntries, withProvenance,<br/>absorbEvidence"]
+    E -->|"ProvenanceEvidenceKey.encode"| K["opaque ref string<br/>dice-provenance:v1:..."]
+    K --> T["recorded with the fold<br/>(collector trace, slice 3)"]
+    T -->|"undo passes refs to<br/>Proposition.withoutFoldedEvidence"| M["ProvenanceEvidenceKey.matches"]
+    M --> Q{"carries the<br/>dice-provenance: prefix?"}
+    Q -->|"yes, and it parses"| R1["remove the single entry<br/>whose six fields match"]
+    Q -->|"yes, and it does not parse"| R2["match nothing;<br/>evidence is left alone"]
+    Q -->|"no: a legacy locator key"| R3["remove only revisionless entries<br/>with that locator key"]
+```
+
+### The interim gap, until the collector slice lands
+
+`encode` has no production caller yet. Until slice 3 rewires `MultiSignalCollectorStrategy`, a
+collapse still records fold refs as plain locator keys, so undoing a collapse that folded revisioned
+evidence takes the legacy path and leaves those entries on the survivor. The direction of the gap is
+safe — evidence is retained, never wrongly deleted — and it closes when slice 3 starts recording
+encoded refs.
+
+### Legacy evidence is unchanged, by construction
+
+A revisionless entry is one whose `sourceRevision` is null, which is every entry written before
+this change and every entry written after it by a caller that supplies no revision. Three
+properties hold for those, and slice 1's tests pin each one:
+
+- **Equality is unchanged.** Two revisionless entries over the same locator and span are equal, and
+  a list of them dedups to the same result as before. `SourceRevisionContractTest` asserts the
+  equality and `.distinct()` behaviour side by side with the revisioned case.
+- **Stored JSON still loads.** Old JSON with no `sourceRevision` key deserializes to a null
+  revision and compares equal to a freshly built revisionless entry. New writes carry
+  `"sourceRevision": null` for those entries, which reads back to the same value.
+  `ProvenanceJsonCompatibilityTest` reads a checked-in revisionless fixture and a revisioned one
+  and asserts a full round trip through both; `JsonFilePropositionRepositoryTest` strips the field
+  back out of a written store file, reloads it, and reruns the source queries against the result.
+- **Legacy refs still work, conservatively.** A reference with no `dice-provenance:` prefix is read
+  as a plain locator key and matches revisionless evidence only. So an undo recorded before
+  revisions existed removes exactly what it used to remove, and can never reach evidence from a
+  revision it never saw. `PropositionFoldEvidenceTest` and `ProvenanceEvidenceKeyTest` both pin
+  this. A locator key cannot be mistaken for a codec ref in either direction: the sealed hierarchy
+  makes every key kind-prefixed (`uri:`, `file:`, `content:`, `connector:`), so none can begin with
+  `dice-provenance:`, and a ref that does carry the prefix but names an unknown version — the
+  `dice-provenance:v2:` case in `ProvenanceEvidenceKeyTest` — fails closed and matches nothing.
+
+## Querying by source
+
+Three finders land on `PropositionRepository`, all context-scoped:
+
+| Method | Matches |
+| --- | --- |
+| `findBySourceKey(contextId, sourceKey)` | any revision of that source, including revisionless |
+| `findBySourceRevision(contextId, ref)` | exactly that source key and that revision |
+| `findRevisionlessBySourceLocator(contextId, locator)` | that source key with no revision |
+
+Each exists twice: the `ContextId`-typed form above, and a plain-String form that holds the default
+body. The typed one forwards to the String one, following `findByContextId` →
+`findByContextIdValue` in `PropositionStore`. The direction is load-bearing. `ContextId` is a Kotlin
+value class, so the typed method's JVM name is mangled and a Java class cannot override it; an
+override placed there would be unreachable from Java, and if the delegation ran the other way a
+Java backend's override would be unreachable from Kotlin. With the String form as the single
+override point, every call from either language passes through it.
+`PropositionRepositoryDelegationTest` calls the typed entry points against a backend that overrode
+only the String forms and counts the dispatches, so the test fails if a typed call ever skips the
+override.
+
+The default bodies read the context and filter loaded provenance in memory, which is correct for any
+backend whose context read carries provenance — the in-memory and JSON-file repositories get it for
+free. A backend whose context read is lean must override all three, and `DrivinePropositionRepository`
+does: its context read loads a view with no provenance at all, so the defaults would return nothing.
+Its overrides push each predicate into Cypher instead, scoping to the tenant first and then testing
+for a matching `DERIVED_FROM` edge, with the revision compared as an edge property (`IS NULL` for
+the revisionless query). `DrivinePropositionStoreIntegrationTest` runs all three against a real
+Neo4j through both the typed and the String entry points.
+
+Inside the `dice` module a shared fixture, `PortableSourceQueryFixture` with
+`assertPortableSourceQueries`, states what the three finders mean once; the in-memory and JSON-file
+repository tests both run it, so "all versions", "exact version", and "revisionless only" cannot
+drift apart between the two portable backends — including across a write, reload, and re-query cycle
+on the JSON one.
+
+### Why the graph write had to change too
+
+Making the finders correct on Neo4j forced two changes to how evidence is stored, because both
+defects lose a revision before any query runs.
+
+**One proposition, two revisions of one source.** Relationship-fragment mapping identifies a
+`DERIVED_FROM` edge by its endpoints, so a proposition citing one source at `r1` and `r2` stored a
+single row and the second revision vanished. Every edge now carries `entryKey`, a length-framed
+encoding of the whole evidence tuple, and writes `MERGE` on it, so parallel revisions are separate
+rows that stay idempotent under replay. Edges written before `entryKey` existed have none; an exactly
+matching revisionless entry adopts one on first touch, and revisioned evidence never adopts a legacy
+edge, because nothing records which revision that edge was read from.
+
+The collapse is a write-side fact, and only that. Reverting the write path to relationship-fragment
+mapping drops the stored edge count from two to one; the same test passed with reads still going
+through the object view, so the read side was never shown to lose parallel edges. Provenance is read
+as raw Cypher rows anyway, so that every provenance read — `findById`, `provenanceOf`,
+`query(withProvenance = true)`, `findAll(withProvenance = true)`, and the three finders — goes
+through one path with one set of guarantees.
+
+**A second revision of an already-extracted fact.** Exact-text dedup answers a save with the
+existing proposition when the text matches. It used to return that proposition and drop the incoming
+evidence, so re-extracting one sentence from a newer revision of its source left the new revision
+unqueryable. Both dedup paths — the in-process one and the cross-instance uniqueness-race recovery —
+now union incoming evidence into the winner. An exact replay finds nothing novel and stays a no-op,
+issuing no write statements at all.
+
+Two details make that union safe. **Structural source identity is validated before the no-op check,
+not after.** A locator's equality is its key, and `ConnectorRef` builds its key by joining on colons,
+so `("a:b", "c")` and `("a", "b:c")` produce one key and their entries compare equal. An entry can
+therefore look like one the winner already holds while naming a different connector. Validating
+first — with a read, so the replay stays write-free — rejects that instead of filing the evidence
+under the wrong source. **Recovery from a uniqueness race runs in its own transaction.** A losing
+writer learns it lost by having the database reject its insert, which leaves that transaction dead;
+any union attempted inside it cannot commit. When the repository owns the transaction it starts a
+fresh one for the recovery. When a caller owns it, the violation propagates untouched and recovery
+is the caller's to retry, because opening a nested transaction to force a write out would break the
+atomicity the caller asked for.
+
+Both are pinned by integration tests that were confirmed to fail against the previous write path:
+the parallel-revision one saw one edge where it needed two, and the dedup one saw an empty result
+for the second revision.
+
+`PropositionStore` also grows the provenance-management operations — `provenanceOf`,
+`addProvenance`, `setProvenance`, `clearProvenance` — which previously sat only on the richer
+`PropositionRepository`. They move down so evidence-sensitive callers such as collector undo can
+depend on the capability directly, without probing for a repository type at runtime.
+`PropositionRepository` keeps its declarations as overrides that delegate to the store defaults, so
+existing implementors see no behaviour change.
+
+## Compatibility boundary
+
+Stated with the same scope on every Wave A slice:
+
+- **Source compatibility: claimed.** Existing Kotlin and Java call sites compile unchanged.
+- **JSON compatibility: claimed.** Stored propositions written before this change load, and
+  round-trip, with a null revision.
+- **Java constructor-descriptor compatibility: claimed.** `@JvmOverloads` preserves every concrete
+  `ProvenanceEntry` constructor descriptor; the revision adds one.
+- **Full Kotlin synthetic constructor and `copy` ABI: not claimed.** Adding a field to a data class
+  changes the synthetic `$default` constructor and the `copy`/`componentN` descriptors. Kotlin code
+  compiled against the previous jar and run against this one without recompiling can fail to link.
+  `SourceRevisionCompatibilityTest` asserts the old descriptors are gone, so the boundary is
+  pinned by a test.
+
+## Wave A map
+
+Four slices, each green on its own, together equal to the reviewed
+`feat/source-revision-provenance` branch:
+
+1. **Source revision contract** (this note's subject) — the `dice` core model: `SourceRevisionRef`,
+   `ProvenanceEvidenceKey`, `ProvenanceEntry.sourceRevision`, the `Proposition`,
+   `PropositionStore`, and `PropositionRepository` additions, their unit tests, and the JSON
+   fixtures. It reaches into `dice-storage` for everything the three finders need to be correct on
+   the default production backend: the revision and `entryKey` on the `DERIVED_FROM` edge, the
+   raw-Cypher write and read paths that keep parallel revisions apart, evidence union on both dedup
+   paths, and the three Cypher push-down overrides with integration tests.
+2. **Storage** — what remains on the `dice-storage` proposition side: the query-plan assertions that
+   couple each statement to the plan Neo4j actually runs, the DERIVED_FROM edge-count proofs for
+   repeated and concurrent writes of one revision, and the connector-collision and legacy-adoption
+   cases around `:Source` identity.
+3. **Collector hardening** — the trace and undo half: `CollectorSignals` carrying evidence keys,
+   undo routed through the store SPI, `DrivineCollectorTraceStore`, and
+   `MultiSignalCollectorStrategy`.
+4. **Entry points** — `IncrementalPropositionExtraction`, pipeline wiring, the REST surface, and
+   the executed binary-compatibility fixture. The async `SourceAnalysisRequestEvent` path carries a
+   revision the same way `rememberText` does, since both build `SourceAnalysisContext` through
+   `buildContext`.
+
+Two things stay out of this train. Bundle round-trips for source revision depend on external issue
+#46, so DICE issue #64 stays open after Wave A lands and its follow-up is separate work. Extraction
+run lineage — which *execution* produced a claim — is a different axis, delivered by Waves B and C;
+`SourceRevisionRef` names one version of one source and never identifies a run.


### PR DESCRIPTION
PR 1 of the source-revision series (refs #64). Successive versions of one logical source become queryable without changing locator identity: stable key plus opaque revision, the S3/W3C-PROV pattern. `ProvenanceEntry` gains `sourceRevision`, an opaque provider-defined string participating in data-class equality, so evidence at two revisions over the same span survives a fold as two entries. `SourceLocator.key()` is untouched and revision-free — one document read at two revisions is still one source identity. `SourceRevisionRef(sourceKey, sourceRevision)` names one version of one source for queries. In `dice-storage`, `DERIVED_FROM` edges carry an `entryKey` identity and merge on it, so parallel revisions of one source persist as parallel edges; exact-text dedup unions novel evidence into the winner behind a structural source-identity guard; exact replays issue zero writes. Length ceilings on source key (2048) and revision (1024) are checked at construction, upstream of every hash and indexed write.

**Changed in this review round:**

- **Revision queries moved onto a capability.** `SourceRevisionQueryCapable` carries the three context-scoped finders (`findBySourceKey`, `findBySourceRevision`, `findRevisionlessBySourceLocator`); `PropositionRepository` carries none of them. A shared default body over an ordinary context read would have answered an empty list on backends that store evidence without projecting it, and an empty list already means "nothing cites this source" — so a backend that cannot answer is absent from the type, and a caller probes with `as?`. `DrivinePropositionRepository` implements the capability with all three predicates pushed into Cypher; the in-memory and JSON stores answer through a provenance scan.
- **Source identity is bounded** via `SourceIdentityBounds`, with a rejection naming the limit it broke.

**Breaking changes: none** for source, JSON, or Java constructor descriptors — legacy revisionless callers keep byte-identical behavior, pinned by compat fixtures and, in the final PR of the series, an executed legacy-client jar. The stated boundary: Kotlin data-class synthetics (`copy`/`componentN`) on `ProvenanceEntry` move; Kotlin callers recompile. Stored graphs need no migration — an edge with no `sourceRevision` reads back as a revisionless entry.

**Opt-in and status:** **EXPERIMENTAL** (shape may change before 1.0). The trigger is a store implementing `SourceRevisionQueryCapable`; everything else is inert carriage.

**The identity rule the series rests on:**

```mermaid
flowchart LR
    L[SourceLocator] --> K["key(), revision-free and untouched"]
    K --> S[SourceRevisionRef.sourceKey]
    V[opaque sourceRevision] --> S
    S --> Q[exact revision queries via SourceRevisionQueryCapable]
    L --> P[ProvenanceEntry]
    V --> P
    P --> E[ProvenanceEvidenceKey, length-framed and injective]
    E --> D[DERIVED_FROM edges, one per evidence identity]
    D --> R[parallel revisions of one source persist as parallel edges]
```

**Series:** #91 storage proofs → #92 collector fold/undo → #93 entry points and REST. #64 stays open after the series lands; its bundle round-trip criterion gates on #46.
