### PR TITLE
Source-revision provenance: proven storage semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -685,9 +685,8 @@ and the consumer PRs that deliver it).
   [docs/design/source-revisions.md](docs/design/source-revisions.md).
   **Interim limitation.** Collapse records fold references as plain locator keys until the collector
   slice lands, so undoing a collapse that folded revisioned evidence leaves those entries on the
-  survivor; evidence is retained, never wrongly deleted. Internally, `ProvenanceEvidenceKey` is the
-  codec that will make those references exact — it is `internal` to the `dice` module, machinery
-  behind fold and undo rather than API a consumer can call.
+  survivor; evidence is retained, never wrongly deleted. `ProvenanceEvidenceKey` is the codec that
+  will make those references exact.
   **Compatibility: additive, with a scoped ABI boundary.** Source, JSON, and Java
   constructor-descriptor compatibility are claimed: existing Kotlin and Java call sites compile
   unchanged, provenance JSON written before this change loads and round-trips with a null revision,
@@ -738,3 +737,33 @@ and the consumer PRs that deliver it).
   each writer's evidence still lands on its own `DERIVED_FROM` edge.
   **Compatibility: behavioral, `dice-storage` only.** An existing `:Source` node keeps the label it
   currently has, and a later write leaves that label alone.
+
+- One evidence-key codec across the `dice` core and the graph, plus the storage proofs that go with
+  it (second slice of DICE #64). `com.embabel.dice.provenance.ProvenanceEvidenceKey` is now public:
+  `dice-storage` keys each `DERIVED_FROM` edge by the string it mints, so a stored graph row and a
+  recorded fold reference are the same string for the same piece of evidence. Storage previously
+  carried its own copy of the encoding; the two framed the same fields in the same order and differed
+  only in the version prefix, and each being `internal` to its own module meant nothing could catch a
+  drift between them. A golden-literal test now pins the `v1` bytes, so the format cannot move under
+  its own version label. Source-identity collisions are rejected in two places: under the `MERGE` that
+  upserts the shared `:Source` node, which is what separates two writers introducing one colliding key
+  at the same time, and in a preflight over the whole batch before the first write, which keeps a
+  rejected write from changing anything and also rejects a single write carrying two structurally
+  different locators under one key. Evidence for behavior that was previously asserted only in prose:
+  the source finders are EXPLAINed as the repository binds them, and seek the `contextId` range index
+  before expanding provenance where that index exists, falling back to a label scan and still
+  answering where it does not; `delete` takes every edge of a proposition citing one source at
+  several revisions and prunes only the sources left with no citations; a repeated or concurrent
+  write of one revision stays one relationship; a pre-`entryKey` edge is claimed only by an exactly
+  matching revisionless entry; and a colliding connector locator is rejected on the plain save,
+  in-process dedup, and race-recovery paths alike. Design note:
+  [docs/design/source-revisions.md](docs/design/source-revisions.md).
+  **Compatibility: additive.** `ProvenanceEvidenceKey` widens from `internal` to public, which adds
+  API rather than removing it; the format it encodes is unchanged and already carried a `v1` version
+  prefix, and a reader meeting a version it does not know matches nothing rather than guessing. A
+  stored `entryKey` now carries that prefix, where the storage-local copy of the encoding omitted it.
+  Released graphs are unaffected — the `entryKey` property itself is part of this same unreleased
+  block, so no released DICE ever wrote one, and an edge with no `entryKey` is still adopted in place
+  by an exactly matching revisionless entry. A graph written by a build of the previous entry in this
+  block holds prefix-less keys that this build does not recognise, and re-saving that evidence adds a
+  second edge for it; clearing such a development store is the whole of the fix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -755,8 +755,16 @@ and the consumer PRs that deliver it).
   answering where it does not; `delete` takes every edge of a proposition citing one source at
   several revisions and prunes only the sources left with no citations; a repeated or concurrent
   write of one revision stays one relationship; a pre-`entryKey` edge is claimed only by an exactly
-  matching revisionless entry; and a colliding connector locator is rejected on the plain save,
-  in-process dedup, and race-recovery paths alike. Design note:
+  matching revisionless entry; and the source-identity guard rejects two structurally different
+  locators sharing one key, checked two ways — a preflight over one write's own batch, and a check of
+  whatever the `:Source` node already holds. `ConnectorRef` escaping its connector id
+  (`fix(provenance): escape connector ids so ConnectorRef keys are injective`, main) closed the
+  *batch-internal* half's trigger: the pair of tuples `dice-storage`'s tests used to exercise it with
+  now render distinct keys, so that half's coverage now pins distinct sources and coexisting evidence
+  instead of a rejection. The *stored-vs-incoming* half is not dead: a store that predates that fix
+  can still hold a `:Source` node keyed the old, ambiguous way, and a current write naming a
+  structurally different locator that renders the same key is rejected against it —
+  `dice-storage`'s coverage now seeds exactly that legacy shape and pins the rejection. Design note:
   [docs/design/source-revisions.md](docs/design/source-revisions.md).
   **Compatibility: additive.** `ProvenanceEvidenceKey` widens from `internal` to public, which adds
   API rather than removing it; the format it encodes is unchanged and already carried a `v1` version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,7 +745,8 @@ and the consumer PRs that deliver it).
   carried its own copy of the encoding; the two framed the same fields in the same order and differed
   only in the version prefix, and each being `internal` to its own module meant nothing could catch a
   drift between them. A golden-literal test now pins the `v1` bytes, so the format cannot move under
-  its own version label. Source-identity collisions are rejected in two places: under the `MERGE` that
+  its own version label; each frame's length counts the value's UTF-8 bytes, and a non-ASCII golden
+  literal pins that too. Source-identity collisions are rejected in two places: under the `MERGE` that
   upserts the shared `:Source` node, which is what separates two writers introducing one colliding key
   at the same time, and in a preflight over the whole batch before the first write, which keeps a
   rejected write from changing anything and also rejects a single write carrying two structurally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -705,6 +705,8 @@ and the consumer PRs that deliver it).
   Contexts sharing one `:Source` node no longer share a label: each writer's `DERIVED_FROM` edge
   carries the label it supplied, and a provenance read takes `display` from the edge it belongs to.
   Rows written before this change have no edge-level `display` and fall back to the node's label.
+  The `DerivedFrom` relationship fragment now carries `display` as a field, so the mapper can build
+  and read that per-edge label directly, not only by way of raw Cypher.
 - Length ceilings on the externally supplied strings that become stored identity, in
   `SourceIdentityBounds`: `MAX_SOURCE_KEY_LENGTH` (2048), `MAX_SOURCE_REVISION_LENGTH` (1024),
   `MAX_CHUNK_ID_LENGTH` (512), and `MAX_CONTENT_HASH_LENGTH` (256).

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
@@ -464,7 +464,7 @@ class DrivinePropositionRepository(
                         r.startOffset = ${'$'}startOffset,
                         r.endOffset = ${'$'}endOffset,
                         r.contentHash = ${'$'}contentHash,
-                        r.display = ${'$'}sourceDisplay
+                        r.display = ${'$'}display
                     """.trimIndent()
                 ).bind(params),
             )
@@ -536,7 +536,7 @@ class DrivinePropositionRepository(
                   AND ((r.contentHash IS NULL AND ${'$'}contentHash IS NULL) OR r.contentHash = ${'$'}contentHash)
                 WITH r LIMIT 1
                 SET r.entryKey = ${'$'}entryKey,
-                    r.display = ${'$'}sourceDisplay
+                    r.display = ${'$'}display
                 RETURN count(r) AS adopted
                 """.trimIndent()
             ).bind(params).transform(Long::class.java)
@@ -593,6 +593,7 @@ class DrivinePropositionRepository(
         "sourceKey" to edge.source.key,
         "sourceKind" to edge.source.kind,
         "sourceDisplay" to edge.source.display,
+        "display" to edge.display,
         "sourceUri" to edge.source.uri,
         "sourcePath" to edge.source.path,
         "sourceContentHash" to edge.source.contentHash,
@@ -836,7 +837,8 @@ class DrivinePropositionRepository(
                     sourceRevision: r.sourceRevision,
                     sourceKey: s.key,
                     sourceKind: s.kind,
-                    sourceDisplay: coalesce(r.display, s.display),
+                    sourceDisplay: s.display,
+                    display: r.display,
                     sourceUri: s.uri,
                     sourcePath: s.path,
                     sourceContentHash: s.contentHash,
@@ -870,6 +872,7 @@ class DrivinePropositionRepository(
                 endOffset = (row["endOffset"] as? Number)?.toInt(),
                 contentHash = row["contentHash"] as? String,
                 sourceRevision = row["sourceRevision"] as? String,
+                display = row["display"] as? String,
             ),
         )
 

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
@@ -56,15 +56,21 @@ import java.time.Instant
 /**
  * The three source-provenance queries, kept together so they stay in step with each other.
  *
- * Each scopes to the tenant first and then checks for a matching `DERIVED_FROM` edge, so provenance
- * is only expanded for one tenant's propositions.
+ * Each names the tenant first and then checks for a matching `DERIVED_FROM` edge. On a store with an
+ * index on `Proposition.contextId` — the range index `dice-storage-autoconfigure` ships — that is
+ * also how they run: the plan seeks that index to produce `p`, and only that tenant's propositions
+ * reach the relationship expansion. With no such index the leaf becomes a label scan and the tenant
+ * predicate is applied as a filter, so the expansion sees every proposition in the store. The
+ * `(contextId, text)` dedup constraint does not stand in for the range index, because Neo4j will not
+ * use a composite index for a predicate on only its first property.
  *
  * There is deliberately no `USING INDEX` hint. Neo4j resolves hints at planning time and fails the
- * whole query when the named index is absent, and `dice-storage`'s schema is adopter-supplied — the
- * `(contextId, text)` constraint ships in `dice-storage-autoconfigure`'s catalog, so a host wiring
- * this repository by hand may not have it. A hint would turn an optional dedup backstop into a hard
- * runtime dependency for every source query. Without one, the planner still seeks on `contextId`
- * where an index exists and falls back to a label scan where it does not.
+ * whole query when the named index is absent, and `dice-storage`'s schema is adopter-supplied, so a
+ * host wiring this repository by hand may have neither index. A hint would turn a missing index from
+ * a slower plan into a hard runtime failure for every source query.
+ *
+ * `DrivinePropositionStoreIntegrationTest` EXPLAINs each of these statements as the repository binds
+ * it and asserts both plan shapes, so the paragraph above is a measurement rather than a claim.
  */
 internal object SourceProvenanceQueryStatements {
 
@@ -296,36 +302,59 @@ class DrivinePropositionRepository(
         winner: Proposition,
         incomingEntries: List<ProvenanceEntry>,
     ): Proposition {
-        // Validate every incoming entry, including ones the winner appears to already hold. "Appears"
-        // is the operative word: a locator's equality is its key, and a key can be ambiguous — a
-        // connector id containing a colon can produce the same key as a different (connectorId,
-        // externalId) split — so an entry can compare equal to a stored one while naming a
-        // structurally different source. Validating first stops that evidence being filed under the
-        // wrong source by the no-op path below. These are reads, so an exact replay still writes
-        // nothing.
-        incomingEntries.forEach(::validateSourceIdentity)
+        // Every incoming entry, whatever the novelty check goes on to say about it. "Already held"
+        // means data-class equality, a locator's equality is its key, and a key can be ambiguous — a
+        // connector id containing a colon produces the same key as a different (connectorId,
+        // externalId) split. So an entry can compare equal to a stored one while naming a
+        // structurally different source, and the novelty check is exactly what would drop it. Nothing
+        // downstream sees such an entry either: it is filtered out of the write. Reads only, and once
+        // per distinct source key, so an exact replay still writes nothing.
+        validateSourceIdentities(incomingEntries)
         val knownEntries = winner.provenanceEntries.toHashSet()
         val novelEntries = incomingEntries.filterNot(knownEntries::contains)
         if (novelEntries.isEmpty()) return winner
         val revisedWinner = winner.withProvenanceEntries(novelEntries)
-        doPersist(revisedWinner)
+        // Straight to the write: everything incoming was checked above, and the winner's own entries
+        // riding along in `revisedWinner` came out of the graph, so they have nothing left to
+        // disagree with. Going through doPersist would re-read every source key this batch names.
+        persistValidated(revisedWinner)
         return findById(winner.id) ?: revisedWinner
     }
 
     /**
-     * Read-only check that an incoming entry's locator agrees with the `:Source` already stored under
-     * its key. Nothing stored yet means nothing to disagree with.
+     * Preflight for a batch of incoming evidence: no two entries may claim one source key with
+     * different structure, and none may disagree with the `:Source` already stored under its key.
      *
-     * Separate from the upsert in [upsertSource] so it can run on the exact-replay path, which must
-     * not write.
+     * This is an ordering guarantee, not the guarantee. It runs before the first write of the
+     * operation it guards, so an ordinary rejected batch leaves the graph exactly as it found it, and
+     * so the dedup no-op path — which writes nothing and would otherwise reach no check at all — has
+     * something to reject a colliding locator with. What makes the check *sound* is the identity
+     * comparison inside [upsertSource], which happens under the `MERGE` rather than before it: two
+     * writers introducing the same key with different structure can both read an empty store here.
      */
-    private fun validateSourceIdentity(entry: ProvenanceEntry) {
-        val source = PropositionGraphMapper.toDerivedFrom(entry).source
-        val stored = storedSourceIdentity(source.key) ?: return
-        require(sourceIdentityMatches(stored, source)) {
-            "Source key collision for '${source.key}': stored source identity differs from incoming locator"
-        }
+    private fun validateSourceIdentities(entries: List<ProvenanceEntry>) {
+        entries.map { PropositionGraphMapper.toDerivedFrom(it).source }
+            .groupBy(SourceNode::key)
+            .forEach { (key, sources) ->
+                val first = sources.first()
+                require(sources.all { sourceIdentitiesAgree(it, first) }) {
+                    "Source key collision for '$key': this write carries two structurally different " +
+                        "locators under one source key"
+                }
+                val stored = storedSourceIdentity(key) ?: return@forEach
+                require(sourceIdentityMatches(stored, first)) {
+                    "Source key collision for '$key': stored source identity differs from incoming locator"
+                }
+            }
     }
+
+    private fun sourceIdentitiesAgree(a: SourceNode, b: SourceNode): Boolean =
+        a.kind == b.kind &&
+            a.uri == b.uri &&
+            a.path == b.path &&
+            a.contentHash == b.contentHash &&
+            a.connectorId == b.connectorId &&
+            a.externalId == b.externalId
 
     @Suppress("UNCHECKED_CAST")
     private fun storedSourceIdentity(sourceKey: String): Map<String, Any?>? =
@@ -354,7 +383,20 @@ class DrivinePropositionRepository(
             stored["externalId"] == source.externalId
 
     /**
-     * Persist node, mentions, and (append-only) provenance.
+     * Preflight the proposition's evidence for source-identity conflicts, then write it. A rejected
+     * write changes nothing.
+     */
+    private fun doPersist(proposition: Proposition): Proposition {
+        validateSourceIdentities(proposition.provenanceEntries)
+        return persistValidated(proposition)
+    }
+
+    /**
+     * The write half of [doPersist], for a caller that has already preflighted the evidence it is
+     * introducing. The dedup merge is the one such caller: it validates its whole incoming batch
+     * before the novelty check, so what arrives here is that batch's novel entries plus the winner's
+     * own, which came out of the graph and have nothing left to disagree with. Going back through
+     * [doPersist] would re-read every source key the batch names, a second time, for nothing.
      *
      * Two writes with different ownership:
      * - **Node + mentions** via the lean [PropositionView] with `DELETE_ORPHAN`: authoritative, so a
@@ -365,7 +407,7 @@ class DrivinePropositionRepository(
      *   two endpoints, so one proposition citing one source at two revisions would store a single
      *   row and lose a revision. Authoritative replacement is the job of [setProvenance].
      */
-    private fun doPersist(proposition: Proposition): Proposition {
+    private fun persistValidated(proposition: Proposition): Proposition {
         val embedding = embeddingFor(proposition)
         graphObjectManager.save(PropositionGraphMapper.toView(proposition, embedding), CascadeType.DELETE_ORPHAN)
         dropMetadataKeysNotIn(proposition)
@@ -401,9 +443,7 @@ class DrivinePropositionRepository(
     private fun embeddingFor(proposition: Proposition): List<Float>? =
         proposition.text.takeIf { it.isNotBlank() }?.let { embeddingService.embed(it).toList() }
 
-    /**
-     * Append evidence, one MERGE per entry keyed by its storage identity.
-     */
+    /** Append evidence, one MERGE per entry keyed by its storage identity. */
     private fun appendProvenance(propositionId: String, entries: List<ProvenanceEntry>) {
         entries.map(PropositionGraphMapper::toDerivedFrom).forEach { edge ->
             val entryKey = requireNotNull(edge.entryKey) { "Provenance entryKey must be computed before persistence" }
@@ -429,11 +469,15 @@ class DrivinePropositionRepository(
     }
 
     /**
-     * Upsert the shared `:Source` node and reject a key collision.
+     * Upsert the shared `:Source` node and reject a key collision — the check that actually makes
+     * source identity safe, because it reads the node the `MERGE` settled on rather than the store as
+     * it looked beforehand.
      *
-     * Two structurally different locators that produce one key would otherwise take turns rewriting
-     * each other's node, so the incoming identity is compared against what is stored and a mismatch
-     * fails the write and leaves the shared node alone.
+     * The preflight in [validateSourceIdentities] cannot stand alone: two writers introducing one key
+     * with different structure, or one batch carrying both, can each see no stored `:Source` and both
+     * pass. Here the `MERGE` serialises on the `:Source(key)` uniqueness constraint, `ON CREATE SET`
+     * leaves an existing node's identity alone, and the returned row is therefore whichever identity
+     * won — so the loser compares against the winner's and fails.
      *
      * Every property here is set once, on create, `display` included, so a reader of the bare node
      * still sees a label. The `:Source` node is global: one locator key is one node across every
@@ -505,6 +549,7 @@ class DrivinePropositionRepository(
     @Transactional
     override fun setProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? {
         val updated = (findById(propositionId) ?: return null).withProvenance(entries)
+        validateSourceIdentities(entries)
         graphObjectManager.save(PropositionGraphMapper.toView(updated, embeddingFor(updated)), CascadeType.DELETE_ORPHAN)
         replaceProvenance(propositionId, entries)
         return updated
@@ -988,7 +1033,16 @@ class DrivinePropositionRepository(
      */
     private fun toEngineScore(rawCosineThreshold: Double): Double = (1.0 + rawCosineThreshold) / 2.0
 
-    /** DELETE_ORPHAN (not DELETE_ALL) so shared `:Source` nodes survive unless this was their last reference. */
+    /**
+     * DELETE_ORPHAN (not DELETE_ALL) so shared `:Source` nodes survive unless this was their last
+     * reference.
+     *
+     * The last provenance path still going through the object view. It handles parallel revisions:
+     * deleting a proposition that cites one source at two revisions takes both edges and leaves that
+     * source standing while anything else cites it. `deleting a proposition takes its parallel
+     * revision edges and only its own orphaned source` pins that against a real Neo4j, which is why
+     * the raw-Cypher rewrite the write and read paths needed is not needed here.
+     */
     @Transactional
     override fun delete(id: String): Boolean =
         graphObjectManager.delete<PropositionWithProvenanceView>(id, CascadeType.DELETE_ORPHAN) > 0

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
@@ -336,6 +336,9 @@ class DrivinePropositionRepository(
         entries.map { PropositionGraphMapper.toDerivedFrom(it).source }
             .groupBy(SourceNode::key)
             .forEach { (key, sources) ->
+                // Every entry grouped under this key claims to describe the same source, so any one
+                // of them can stand for the whole group: the first is checked against the rest, then
+                // against whatever the graph already holds under the key.
                 val first = sources.first()
                 require(sources.all { sourceIdentitiesAgree(it, first) }) {
                     "Source key collision for '$key': this write carries two structurally different " +

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/PropositionGraphMapper.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/PropositionGraphMapper.kt
@@ -24,6 +24,7 @@ import com.embabel.dice.provenance.ConnectorRef
 import com.embabel.dice.provenance.ContentAddressedLocator
 import com.embabel.dice.provenance.FileLocator
 import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import com.embabel.dice.provenance.SourceLocator
 import com.embabel.dice.provenance.UriLocator
 import com.embabel.dice.storage.model.DerivedFrom
@@ -44,9 +45,11 @@ import com.embabel.dice.temporal.TemporalMetadata
  *   of every path. [toProposition] from it returns a [Proposition] with **empty**
  *   `provenanceEntries` (provenance isn't projected).
  * - [PropositionWithProvenanceView] — adds `DERIVED_FROM` → shared [SourceNode]. Sources are MERGEd
- *   by `SourceLocator.key()`, so a source cited by many propositions is one node. Its only remaining
- *   use is the cascade in `DrivinePropositionRepository.delete`: provenance writes and reads both
- *   moved to raw Cypher so parallel source revisions keep their own edges.
+ *   by `SourceLocator.key()`, so a source cited by many propositions is one node. Provenance writes
+ *   and reads moved to raw Cypher, keyed by evidence identity, so parallel source revisions keep
+ *   their own edges; what still runs through this view is the `DELETE_ORPHAN` cascade in
+ *   `DrivinePropositionRepository.delete`, which takes every edge a proposition has and prunes only
+ *   the sources left with no citations.
  *
  * The graph carries an `embedding` that is *not* part of [Proposition]; the repository owns it and
  * passes it in. `EntityMention.hints` is not yet persisted.
@@ -60,9 +63,10 @@ object PropositionGraphMapper {
     /**
      * Full view: mentions + provenance (`DERIVED_FROM` → shared [SourceNode]).
      *
-     * No production caller left once provenance writes moved to raw Cypher. Kept for now because
-     * `delete` still cascades through the view it builds; slice 2 of the source-revision work decides
-     * whether both go.
+     * Nothing in the repository builds one any more — provenance is written and read as raw Cypher.
+     * This is the public way to construct the view type `delete` cascades through, and the shape it
+     * produces is what `PropositionGraphMapperRevisionTest` pins: one shared source node however many
+     * revisions cite it, one edge per revision, each carrying its own evidence key.
      */
     fun toProvenanceView(p: Proposition, embedding: List<Float>? = null): PropositionWithProvenanceView =
         PropositionWithProvenanceView(
@@ -241,22 +245,20 @@ object PropositionGraphMapper {
 }
 
 /**
- * The storage identity of one `DERIVED_FROM` edge: every field of the evidence tuple, length-framed
- * so a `-1` stands for null and no value needs escaping.
+ * The storage identity of one `DERIVED_FROM` edge: the evidence key [ProvenanceEvidenceKey] mints,
+ * with no storage-specific encoding of its own.
  *
- * This is deliberately a separate encoding from the domain's `ProvenanceEvidenceKey`, which is
- * `internal` to the `dice` module and is the format collector traces record. Graph rows and fold
- * records have different lifetimes, and pinning one to the other would make a change to either a
- * migration of both.
+ * A graph row and a recorded fold reference name the same thing — one piece of evidence — so they use
+ * one string. Storage had its own copy of the encoding at first. The two framed the same six fields
+ * in the same order and differed only in that the storage copy omitted the `dice-provenance:v1:`
+ * prefix, which made them one format maintained in two places with nothing able to catch a drift,
+ * since each was `internal` to its own module.
+ *
+ * Adopting the prefix **changed the bytes stored on an edge**. That is safe here and nowhere else:
+ * `entryKey` itself is unreleased, arriving in the same train as this, so no released DICE ever wrote
+ * one. A graph written by an intermediate build of this train holds prefix-less keys that no longer
+ * match, and re-saving that evidence adds a second edge — the CHANGELOG says so. Once released, a
+ * format change means a new version prefix and a migration for the keys already written.
  */
 internal fun provenanceStorageEntryKey(entry: ProvenanceEntry): String =
-    listOf(
-        entry.locator.key(),
-        entry.sourceRevision,
-        entry.chunkId,
-        entry.startOffset?.toString(),
-        entry.endOffset?.toString(),
-        entry.contentHash,
-    ).joinToString(separator = "") { value ->
-        if (value == null) "-1:" else "${value.length}:$value"
-    }
+    ProvenanceEvidenceKey.encode(entry)

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/PropositionGraphMapper.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/PropositionGraphMapper.kt
@@ -189,11 +189,12 @@ object PropositionGraphMapper {
             source = toSourceNode(e.locator),
             sourceRevision = e.sourceRevision,
             entryKey = provenanceStorageEntryKey(e),
+            display = e.locator.display,
         )
 
     internal fun toProvenanceEntry(df: DerivedFrom): ProvenanceEntry =
         ProvenanceEntry(
-            locator = toLocator(df.source),
+            locator = toLocator(df.source, df.display ?: df.source.display),
             chunkId = df.chunkId,
             startOffset = df.startOffset,
             endOffset = df.endOffset,
@@ -220,11 +221,11 @@ object PropositionGraphMapper {
         is ConnectorRef -> "connector"
     }
 
-    private fun toLocator(s: SourceNode): SourceLocator = when (s.kind) {
-        "uri" -> UriLocator(s.uri!!, s.display)
-        "file" -> FileLocator(s.path!!, s.display)
-        "content" -> ContentAddressedLocator(s.contentHash!!, s.display)
-        "connector" -> ConnectorRef(s.connectorId!!, s.externalId!!, s.display)
+    private fun toLocator(s: SourceNode, display: String? = s.display): SourceLocator = when (s.kind) {
+        "uri" -> UriLocator(s.uri!!, display)
+        "file" -> FileLocator(s.path!!, display)
+        "content" -> ContentAddressedLocator(s.contentHash!!, display)
+        "connector" -> ConnectorRef(s.connectorId!!, s.externalId!!, display)
         else -> error("Unknown source locator kind: ${s.kind}")
     }
 

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/DerivedFrom.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/DerivedFrom.kt
@@ -26,11 +26,12 @@ import org.drivine.annotation.RelationshipFragment
  * claim was read from is a fact about this citation, and the `:Source` node stays shared across
  * every revision of it.
  *
- * `entryKey` is the edge's own identity, a length-framed encoding of the whole evidence tuple. The
- * relationship needs one because a proposition can cite one source at several revisions, and an
- * edge identified only by its two endpoints would collapse those into a single row. Writes MERGE on
- * it. Edges written before revisions existed have no `entryKey`; they are adopted on first touch by
- * an exactly matching revisionless entry.
+ * `entryKey` is the edge's own identity: the string `ProvenanceEvidenceKey` mints for the entry, the
+ * same one a collapse records when it folds that evidence away. The relationship needs an identity
+ * because a proposition can cite one source at several revisions, and an edge identified only by its
+ * two endpoints would collapse those into a single row. Writes MERGE on it. Edges written before
+ * revisions existed have no `entryKey`; they are adopted on first touch by an exactly matching
+ * revisionless entry.
  */
 @RelationshipFragment
 data class DerivedFrom @JvmOverloads constructor(

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/DerivedFrom.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/DerivedFrom.kt
@@ -32,6 +32,10 @@ import org.drivine.annotation.RelationshipFragment
  * two endpoints would collapse those into a single row. Writes MERGE on it. Edges written before
  * revisions existed have no `entryKey`; they are adopted on first touch by an exactly matching
  * revisionless entry.
+ *
+ * `display` is the label the writer of this citation supplied. The shared `:Source` node only keeps
+ * the first writer's label, so a read prefers the edge's own `display` and falls back to the node's
+ * for edges written before this field existed.
  */
 @RelationshipFragment
 data class DerivedFrom @JvmOverloads constructor(
@@ -42,4 +46,5 @@ data class DerivedFrom @JvmOverloads constructor(
     val source: SourceNode,
     val sourceRevision: String? = null,
     val entryKey: String? = null,
+    val display: String? = null,
 )

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/PropositionWithProvenanceView.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/model/PropositionWithProvenanceView.kt
@@ -25,8 +25,10 @@ import org.drivine.annotation.Root
  *
  * A second view over the same `:Proposition` node, distinct from the lean [PropositionView] (root +
  * mentions). Provenance is heavy and rarely needed on bulk/query/vector paths, so this view is used
- * only where completeness matters — `save` (persist everything) and `findById` (the canonical full
- * fetch).
+ * only where completeness matters. Reads and writes of provenance are raw Cypher keyed by evidence
+ * identity, which leaves this view one job: the `DELETE_ORPHAN` cascade behind
+ * `DrivinePropositionRepository.delete`, where naming the shape is enough to take a proposition's
+ * edges with it and prune the sources nothing cites any more.
  */
 @GraphView
 data class PropositionWithProvenanceView(

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -41,10 +41,15 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.drivine.connection.DataSourceMap
 import org.drivine.manager.CascadeType
 import org.drivine.manager.GraphObjectManager
 import org.drivine.manager.PersistenceManager
 import org.drivine.query.QuerySpecification
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.GraphDatabase
+import org.neo4j.driver.SessionConfig
+import org.neo4j.driver.summary.Plan
 import org.springframework.aop.framework.ProxyFactory
 import org.springframework.aop.support.AopUtils
 import org.springframework.beans.factory.annotation.Autowired
@@ -54,6 +59,7 @@ import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource
 import org.springframework.transaction.interceptor.TransactionInterceptor
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.CopyOnWriteArrayList
@@ -98,6 +104,9 @@ class DrivinePropositionStoreIntegrationTest {
 
     @Autowired
     private lateinit var transactionManager: PlatformTransactionManager
+
+    @Autowired
+    private lateinit var dataSourceMap: DataSourceMap
 
     @AfterEach
     fun cleanUp() {
@@ -1016,8 +1025,715 @@ class DrivinePropositionStoreIntegrationTest {
         assertEquals("r2", repository.provenanceOf(second.id).single().sourceRevision)
     }
 
+    /**
+     * A colliding locator arriving in the same batch as genuinely new evidence. The colliding entry
+     * compares equal to one the winner already holds, so the novelty check drops it — and it is then
+     * neither written nor, if only novel entries are checked, ever looked at. The save would report
+     * success while the second connector's evidence had been quietly counted as the first's.
+     */
+    @Test
+    fun `dedup rejects a colliding connector source arriving alongside novel evidence`() {
+        val original = ConnectorRef("a:b", "c")
+        val colliding = ConnectorRef("a", "b:c")
+        val newSource = UriLocator("https://example.com/mixed-batch")
+        assertEquals(original.key(), colliding.key(), "the fixture depends on these keys colliding")
+        val winner = repository.save(
+            prop("mixed batch fact", context = "ctx-mixed", provenance = listOf(ProvenanceEntry(original))),
+        )
+        assertTrue(
+            winner.provenanceEntries.contains(ProvenanceEntry(colliding)),
+            "and on the colliding entry counting as already held, which is what drops it from the novelty check",
+        )
+
+        val thrown = assertThrows<Exception> {
+            repository.save(
+                prop(
+                    "mixed batch fact",
+                    context = "ctx-mixed",
+                    provenance = listOf(ProvenanceEntry(colliding), evidence(newSource, "r1")),
+                ),
+            )
+        }
+        assertTrue(
+            generateSequence(thrown as Throwable?) { it.cause }.any {
+                it is IllegalArgumentException && it.message?.contains("Source key collision") == true
+            },
+            "the batch must be rejected as a source key collision; got: $thrown",
+        )
+
+        assertEquals(1, repository.count())
+        assertEquals(
+            listOf(ProvenanceEntry(original)),
+            repository.findById(winner.id)!!.provenanceEntries,
+            "the winner must be exactly as it was",
+        )
+        assertEquals(1L, edgeCount(winner.id))
+        assertEquals(
+            setOf(original.key()),
+            storedSourceKeys(),
+            "the batch's novel source must not survive a rejected write either",
+        )
+    }
+
+    /**
+     * Both colliding locators in one write, naming a source that does not exist yet. Nothing is
+     * stored to compare against, so a check that only reads the store beforehand sees two clean
+     * entries and lets the second silently attach to the source the first creates.
+     */
+    @Test
+    fun `one write carrying two colliding connector locators is rejected`() {
+        val original = ConnectorRef("a:b", "c")
+        val colliding = ConnectorRef("a", "b:c")
+        assertEquals(original.key(), colliding.key(), "the fixture depends on these keys colliding")
+
+        val thrown = assertThrows<Exception> {
+            repository.save(
+                prop(
+                    "two colliding locators in one write",
+                    context = "ctx-batch-collide",
+                    provenance = listOf(ProvenanceEntry(original), ProvenanceEntry(colliding)),
+                ),
+            )
+        }
+        assertTrue(
+            generateSequence(thrown as Throwable?) { it.cause }.any {
+                it is IllegalArgumentException && it.message?.contains("Source key collision") == true
+            },
+            "the batch must be rejected as a source key collision; got: $thrown",
+        )
+
+        assertEquals(0, repository.count(), "the rejected write must leave no proposition behind")
+        assertEquals(emptySet<String>(), storedSourceKeys(), "and no half-created source")
+    }
+
+    /**
+     * Two writers introducing the same colliding source key at once, with neither able to see the
+     * other's work: the barrier holds both until each has finished reading the store and found
+     * nothing there. Only a check that runs under the `MERGE` can separate them, so this is the case a
+     * read-then-write preflight cannot cover on its own.
+     *
+     * Which writer wins is the database's business. What must hold is that one is rejected, one
+     * succeeds, and the stored source carries the winner's identity rather than a mixture.
+     */
+    @Test
+    fun `concurrent writers introducing one colliding source key cannot corrupt it`() {
+        val original = ConnectorRef("a:b", "c")
+        val colliding = ConnectorRef("a", "b:c")
+        assertEquals(original.key(), colliding.key(), "the fixture depends on these keys colliding")
+        val barrier = CountDownLatch(2)
+        val firstRepository = newTransactionProxiedRepository(
+            SourcePreflightBarrierPersistenceManager(persistenceManager, barrier),
+        )
+        val secondRepository = newTransactionProxiedRepository(
+            SourcePreflightBarrierPersistenceManager(persistenceManager, barrier),
+        )
+
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val outcomes = listOf(
+                executor.submit<Proposition> {
+                    firstRepository.save(
+                        prop("first new-source fact", context = "ctx-new-collide", provenance = listOf(ProvenanceEntry(original))),
+                    )
+                },
+                executor.submit<Proposition> {
+                    secondRepository.save(
+                        prop("second new-source fact", context = "ctx-new-collide", provenance = listOf(ProvenanceEntry(colliding))),
+                    )
+                },
+            ).map { future -> runCatching { future.get(30, TimeUnit.SECONDS) } }
+
+            assertEquals(1, outcomes.count { it.isSuccess }, "exactly one writer may create the shared source")
+            val failure = outcomes.single { it.isFailure }.exceptionOrNull()!!
+            assertTrue(
+                generateSequence(failure as Throwable?) { it.cause }.any {
+                    it is IllegalArgumentException && it.message?.contains("Source key collision") == true
+                },
+                "the losing writer must report the structural Source key collision; got: $failure",
+            )
+
+            val winner = outcomes.single { it.isSuccess }.getOrThrow()
+            val storedLocator = repository.findById(winner.id)!!.provenanceEntries.single().locator
+            assertEquals(
+                winner.provenanceEntries.single().locator,
+                storedLocator,
+                "the stored source must carry the identity of whoever created it",
+            )
+            assertEquals(setOf(original.key()), storedSourceKeys())
+            assertEquals(1, repository.count(), "the rejected writer must leave no proposition behind")
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    /**
+     * A cross-instance race on the *recovery* path. Both writers pass the dedup lookup, one loses on
+     * the uniqueness constraint, and its recovery tries to union evidence whose locator collides with
+     * the winner's. Recovery must reject it and leave the winner as it found it.
+     */
+    @Test
+    fun `cross-instance recovery rejects a colliding connector source and preserves its winner`() {
+        val original = ConnectorRef("a:b", "c")
+        val colliding = ConnectorRef("a", "b:c")
+        assertEquals(original.key(), colliding.key(), "the fixture depends on these keys colliding")
+        val first = prop(
+            "cross-instance collision-prone fact",
+            context = "ctx-recover-collide",
+            provenance = listOf(ProvenanceEntry(original)),
+        )
+        val second = prop(
+            "cross-instance collision-prone fact",
+            context = "ctx-recover-collide",
+            provenance = listOf(ProvenanceEntry(colliding)),
+        )
+        val barrier = CountDownLatch(2)
+        val firstRepository = newTransactionProxiedRepository(
+            DedupLookupBarrierPersistenceManager(persistenceManager, barrier),
+        )
+        val secondRepository = newTransactionProxiedRepository(
+            DedupLookupBarrierPersistenceManager(persistenceManager, barrier),
+        )
+
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val outcomes = listOf(
+                executor.submit<Proposition> { firstRepository.save(first) },
+                executor.submit<Proposition> { secondRepository.save(second) },
+            ).map { future -> runCatching { future.get(30, TimeUnit.SECONDS) } }
+
+            assertEquals(1, outcomes.count { it.isSuccess }, "exactly one writer may win the race")
+            val failure = outcomes.single { it.isFailure }.exceptionOrNull()!!
+            assertTrue(
+                generateSequence(failure as Throwable?) { it.cause }.any {
+                    it is IllegalArgumentException && it.message?.contains("Source key collision") == true
+                },
+                "the losing recovery must report the structural Source key collision; got: $failure",
+            )
+
+            val winner = outcomes.single { it.isSuccess }.getOrThrow()
+            assertEquals(1, repository.count())
+            assertEquals(
+                winner.provenanceEntries,
+                repository.findById(winner.id)!!.provenanceEntries,
+                "a rejected recovery must leave the stored winner unchanged",
+            )
+            assertEquals(1L, edgeCount(winner.id))
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    /**
+     * One revision, written over and over — sequentially, then by two repository instances at once.
+     * The edge MERGE is keyed by evidence identity, so every one of those writes has to land on the
+     * same relationship.
+     */
+    @Test
+    fun `repeated and concurrent writes of one revision remain one relationship`() {
+        val locator = UriLocator("https://example.com/idempotent")
+        val revisionOne = evidence(locator, "r1", chunkId = "chunk", startOffset = 1, endOffset = 4, contentHash = "hash")
+        val saved = repository.save(
+            prop("idempotent evidence", context = "ctx-idempotent", provenance = listOf(revisionOne)),
+        )
+        repository.save(saved)
+
+        val firstRepository = DrivinePropositionRepository(
+            graphObjectManager, persistenceManager, embeddingService, transactionManager,
+        )
+        val secondRepository = DrivinePropositionRepository(
+            graphObjectManager, persistenceManager, embeddingService, transactionManager,
+        )
+        val start = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val writes = listOf(firstRepository, secondRepository).map { candidate ->
+                executor.submit {
+                    assertTrue(start.await(10, TimeUnit.SECONDS), "both writers must start together")
+                    candidate.save(saved)
+                }
+            }
+            start.countDown()
+            writes.forEach { it.get(30, TimeUnit.SECONDS) }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertEquals(1L, edgeCount(saved.id), "replaying one revision must not accumulate edges")
+        assertEquals(listOf(revisionOne), repository.findById(saved.id)!!.provenanceEntries)
+    }
+
+    /**
+     * An edge written before `entryKey` existed carries none. Exactly one entry may claim it — a
+     * revisionless one whose span matches it field for field. A revisioned entry cannot, because
+     * nothing records which revision the legacy edge was read from, and neither can a revisionless
+     * entry over a different span.
+     */
+    @Test
+    fun `legacy unkeyed revisionless evidence is adopted exactly while revisioned writes stay separate`() {
+        val locator = UriLocator("https://example.com/legacy")
+        val revisionless = evidence(locator, null, chunkId = "chunk", startOffset = 1, endOffset = 4, contentHash = "hash")
+        val revisionOne = revisionless.copy(sourceRevision = "r1")
+
+        val adoptTarget = repository.save(prop("adopt legacy", context = "ctx-legacy-adopt"))
+        seedLegacyEdge(adoptTarget.id, revisionless)
+        assertEquals(listOf(revisionless), repository.findById(adoptTarget.id)!!.provenanceEntries)
+
+        repository.save(adoptTarget.withProvenanceEntries(listOf(revisionless)))
+
+        assertEquals(1L, edgeCount(adoptTarget.id), "the exact revisionless legacy edge is claimed in place")
+        assertEquals(
+            1L,
+            persistenceManager.getOne(
+                QuerySpecification
+                    .withStatement("MATCH (s:Source {key: \$sourceKey}) RETURN count(s) AS c")
+                    .bind(mapOf("sourceKey" to firstWriter.key()))
+                    .transform(Long::class.java),
+            ),
+            "both writers still share one Source node",
+        )
+
+        assertEquals(
+            listOf(first.id),
+            repository.findBySourceRevision(ContextId("ctx-display-a"), SourceRevisionRef(firstWriter.key(), "r1"))
+                .map { it.id },
+            "the first writer's evidence is queryable",
+        )
+        assertEquals(
+            listOf(second.id),
+            repository.findBySourceRevision(ContextId("ctx-display-b"), SourceRevisionRef(secondWriter.key(), "r2"))
+                .map { it.id },
+            "the second writer's evidence landed in full",
+        )
+        assertEquals("r2", repository.provenanceOf(second.id).single().sourceRevision)
+    }
+
+
     private fun evidence(locator: UriLocator, revision: String?): ProvenanceEntry =
         ProvenanceEntry(locator = locator, sourceRevision = revision)
+                    .withStatement(
+                        "MATCH (:Proposition {id: \$id})-[r:DERIVED_FROM]->() RETURN count(r.entryKey) AS c",
+                    )
+                    .bind(mapOf("id" to adoptTarget.id))
+                    .transform(Long::class.java),
+            ),
+            "and comes away carrying an entryKey",
+        )
+
+        val revisionedTarget = repository.save(prop("keep legacy separate", context = "ctx-legacy-adopt"))
+        seedLegacyEdge(revisionedTarget.id, revisionless)
+        repository.save(revisionedTarget.withProvenanceEntries(listOf(revisionOne)))
+
+        assertEquals(2L, edgeCount(revisionedTarget.id), "a revisioned write must not claim an unkeyed edge")
+        assertEquals(
+            setOf(revisionless, revisionOne),
+            repository.findById(revisionedTarget.id)!!.provenanceEntries.toSet(),
+        )
+
+        val nonExactTarget = repository.save(prop("keep non-exact legacy separate", context = "ctx-legacy-adopt"))
+        val differentSpan = revisionless.copy(chunkId = "different-chunk")
+        seedLegacyEdge(nonExactTarget.id, revisionless)
+        repository.save(nonExactTarget.withProvenanceEntries(listOf(differentSpan)))
+
+        assertEquals(2L, edgeCount(nonExactTarget.id), "a revisionless write over another span must not claim it")
+        assertEquals(
+            setOf(revisionless, differentSpan),
+            repository.findById(nonExactTarget.id)!!.provenanceEntries.toSet(),
+        )
+    }
+
+    /**
+     * `setProvenance` is the authoritative path: what it is given is what the proposition ends up
+     * with. It has to drop a parallel revision of a source it keeps, leave another proposition's edge
+     * to that same source alone, and prune only the source nothing cites any more.
+     */
+    @Test
+    fun `authoritative provenance replace removes omitted edges and only globally orphaned sources`() {
+        val shared = UriLocator("https://example.com/shared-replace")
+        val exclusive = UriLocator("https://example.com/exclusive-replace")
+        val keep = evidence(shared, "r1", chunkId = "keep")
+        val omittedParallel = evidence(shared, "r2", chunkId = "omit-parallel")
+        val omittedExclusive = evidence(exclusive, "r1", chunkId = "omit-exclusive")
+        val subject = repository.save(
+            prop(
+                "replace subject",
+                context = "ctx-replace",
+                provenance = listOf(keep, omittedParallel, omittedExclusive),
+            ),
+        )
+        val other = repository.save(
+            prop(
+                "shared source remains",
+                context = "ctx-replace",
+                provenance = listOf(evidence(shared, "other")),
+            ),
+        )
+        assertEquals(3L, edgeCount(subject.id))
+
+        repository.setProvenance(subject.id, listOf(keep))
+
+        assertEquals(listOf(keep), repository.findById(subject.id)!!.provenanceEntries)
+        assertEquals(1L, edgeCount(subject.id), "the omitted parallel revision loses its edge")
+        assertEquals(1L, edgeCount(other.id), "replace must not disturb another proposition's edge")
+        assertEquals(
+            setOf(shared.key()),
+            storedSourceKeys(),
+            "only the source nothing cites any more is pruned",
+        )
+    }
+
+    /**
+     * `save` participates in a caller's transaction. Rolling that transaction back has to undo the
+     * whole save — node, mentions, and evidence.
+     */
+    @Test
+    fun `caller rollback undoes a completed save`() {
+        val proposition = prop(
+            "transactional save",
+            context = "ctx-rollback",
+            provenance = listOf(evidence(UriLocator("https://example.com/rollback"), "r1")),
+        )
+
+        TransactionTemplate(transactionManager).executeWithoutResult { status ->
+            repository.save(proposition)
+            assertNotNull(repository.findById(proposition.id), "the save must be visible inside the caller transaction")
+            status.setRollbackOnly()
+        }
+
+        assertNull(repository.findById(proposition.id), "caller rollback must remove the saved proposition")
+        assertEquals(emptySet<String>(), storedSourceKeys(), "and the source it created with it")
+    }
+
+    /**
+     * `delete` is the last provenance path still going through the Drivine object view, so this is
+     * where a proposition holding parallel revisions of one source meets `DELETE_ORPHAN`. The subject
+     * cites one source at two revisions and a second source exclusively; a bystander cites the first
+     * source as well. Deleting the subject must take all three of its edges, prune only the source
+     * left with no citations, and leave the bystander whole.
+     */
+    @Test
+    fun `deleting a proposition takes its parallel revision edges and only its own orphaned source`() {
+        val shared = UriLocator("https://example.com/delete-shared")
+        val exclusive = UriLocator("https://example.com/delete-exclusive")
+        val context = ContextId("ctx-delete")
+        val subject = repository.save(
+            prop(
+                "delete subject",
+                context = "ctx-delete",
+                provenance = listOf(evidence(shared, "r1"), evidence(shared, "r2"), evidence(exclusive, null)),
+            ),
+        )
+        val bystander = repository.save(
+            prop("shared source survives", context = "ctx-delete", provenance = listOf(evidence(shared, "r3"))),
+        )
+        assertEquals(3L, edgeCount(subject.id), "the subject starts with two parallel revisions and one more source")
+
+        assertTrue(repository.delete(subject.id))
+
+        assertNull(repository.findById(subject.id))
+        assertEquals(0L, edgeCount(subject.id), "no DERIVED_FROM edge may outlive its proposition")
+        assertEquals(
+            setOf(shared.key()),
+            storedSourceKeys(),
+            "the exclusively cited source is pruned; the one the bystander still cites is not",
+        )
+        assertEquals(
+            listOf(bystander.id),
+            repository.findBySourceKey(context, shared.key()).map { it.id },
+            "the bystander's own evidence is untouched",
+        )
+        assertEquals(listOf(evidence(shared, "r3")), repository.findById(bystander.id)!!.provenanceEntries)
+    }
+
+    /**
+     * Ties each public finder to the statement it actually sends and the plan Neo4j actually builds
+     * for it. The capture wrapper records the statement and parameters the repository binds, asserts
+     * they are the production ones, then EXPLAINs that exact text with those exact parameters — so a
+     * statement edited without a matching plan change is caught here, and nothing under assertion is
+     * retyped from the production constants.
+     *
+     * Tenant-first is the property being pinned, and it is visible in the plan: the operator that
+     * produces `p` is an index seek on `contextId`, so only that tenant's propositions ever reach the
+     * `DERIVED_FROM` expansion, and no `Filter` on `p.contextId` survives anywhere above it. That
+     * holds on the `contextId` range index `dice-storage-autoconfigure` ships; the `(contextId, text)`
+     * dedup constraint cannot supply it, because Neo4j will not use a composite index for a predicate
+     * on only its first property.
+     */
+    @Test
+    fun `public source queries execute their production statements on tenant-first plans`() {
+        val locator = UriLocator("https://example.com/explain-source")
+        seedExplainFixture(locator)
+        val plans = explainAllSourceQueries(locator)
+
+        plans.forEach { (name, plan) ->
+            val outerInput = semiApplyOuterInput(plan)
+            assertTrue(
+                outerInput.text.contains("IndexSeek") && outerInput.text.contains("contextId"),
+                "$name must drive the provenance check from a tenant index seek, not $outerInput:\n$plan",
+            )
+            val expand = planLine(plan, "DERIVED_FROM")
+            assertTrue(
+                expand.depth > outerInput.depth - 1,
+                "$name must expand DERIVED_FROM inside the SemiApply the seek drives:\n$plan",
+            )
+            assertFalse(
+                plan.contains("p.contextId ="),
+                "$name must not re-filter on the tenant after seeking it:\n$plan",
+            )
+        }
+    }
+
+    /**
+     * The same three statements against a store with no index on `contextId` at all — neither the
+     * range index nor the optional dedup constraint. Neo4j resolves an index hint at planning time and
+     * fails the whole query when the named index is absent, so a hinted statement would not survive
+     * this; these carry none, and instead degrade to a label scan with the tenant applied as a filter.
+     * Every finder still plans and still answers, which is the whole cost of dropping the hints.
+     */
+    @Test
+    fun `source queries plan and answer with no index on contextId`() {
+        val locator = UriLocator("https://example.com/explain-bare")
+        withoutContextIdIndexes {
+            seedExplainFixture(locator)
+            val plans = explainAllSourceQueries(locator)
+
+            plans.forEach { (name, plan) ->
+                val outerInput = semiApplyOuterInput(plan)
+                assertTrue(
+                    outerInput.text.contains("NodeByLabelScan") && outerInput.text.contains("p:Proposition"),
+                    "$name has no index to seek and must drive the check from a label scan:\n$plan",
+                )
+                assertFalse(
+                    plan.lineSequence().any { it.contains("IndexSeek") && it.contains("contextId") },
+                    "$name cannot seek an index that is not there:\n$plan",
+                )
+                // The cost of the fallback, stated as an assertion: the tenant filter sits *above* the
+                // SemiApply, so provenance is expanded for every proposition in the store and only
+                // then narrowed to this tenant.
+                val tenantFilter = planLine(plan, "p.contextId =")
+                assertTrue(
+                    tenantFilter.depth < semiApplyDepth(plan),
+                    "$name applies the tenant after expanding provenance for the whole store:\n$plan",
+                )
+            }
+        }
+    }
+
+    /**
+     * Two propositions in the tenant under test, and enough in other tenants that `contextId` is a
+     * selective predicate.
+     *
+     * The noise is load-bearing. Against a handful of rows the planner has nothing to choose between
+     * seeking the index and scanning it, and it will do either — which showed up as an intermittent
+     * `NodeIndexScan … WHERE contextId IS NOT NULL` where the seek was expected. A scan reads every
+     * proposition's `contextId`, so it is not the tenant-first plan the test means to pin, and
+     * accepting it would have hollowed out the assertion. Statistics are resampled afterwards because
+     * a freshly created index carries none, and the fallback test drops and recreates this one.
+     */
+    private fun seedExplainFixture(locator: UriLocator) {
+        repository.save(
+            prop("explain revisionless", context = "ctx-explain", provenance = listOf(evidence(locator, null))),
+        )
+        repository.save(
+            prop("explain r1", context = "ctx-explain", provenance = listOf(evidence(locator, "r1"))),
+        )
+        (1..8).forEach { tenant ->
+            (1..5).forEach { row ->
+                repository.save(prop("other tenant $tenant fact $row", context = "ctx-other-$tenant"))
+            }
+        }
+        persistenceManager.execute(QuerySpecification.withStatement("CALL db.resampleOutdatedIndexes()"))
+        persistenceManager.execute(QuerySpecification.withStatement("CALL db.awaitIndexes(60)"))
+    }
+
+    /** Every source finder, run through the capture harness, keyed by name for the assertions. */
+    private fun explainAllSourceQueries(locator: UriLocator): Map<String, String> {
+        val context = ContextId("ctx-explain")
+        val common = mapOf<String, Any>("contextId" to "ctx-explain", "sourceKey" to locator.key())
+        return mapOf(
+            "source-key" to captureAndExplainSourceQuery(
+                "source-key",
+                SourceProvenanceQueryStatements.bySourceKey,
+                common,
+            ) { it.findBySourceKey(context, locator.key()) },
+            "source-revision" to captureAndExplainSourceQuery(
+                "source-revision",
+                SourceProvenanceQueryStatements.bySourceRevision,
+                common + ("sourceRevision" to "r1"),
+            ) { it.findBySourceRevision(context, SourceRevisionRef(locator.key(), "r1")) },
+            "revisionless-source" to captureAndExplainSourceQuery(
+                "revisionless-source",
+                SourceProvenanceQueryStatements.revisionlessBySourceKey,
+                common,
+            ) { it.findRevisionlessBySourceLocator(context, locator) },
+        )
+    }
+
+    /**
+     * Run one finder against a repository whose persistence manager records the source statement it
+     * executes, check that statement and its parameters are the production ones, then EXPLAIN exactly
+     * what was recorded. Nothing here is retyped from the production constants, so the plan under
+     * assertion is the plan the repository runs.
+     */
+    private fun captureAndExplainSourceQuery(
+        name: String,
+        expectedStatement: String,
+        expectedParameters: Map<String, Any>,
+        invocation: (DrivinePropositionRepository) -> List<Proposition>,
+    ): String {
+        val capturing = SourceQueryCapturingPersistenceManager(persistenceManager)
+        val results = invocation(newTransactionProxiedRepository(capturing))
+        assertTrue(results.isNotEmpty(), "$name must return the seeded evidence")
+        assertEquals(1, capturing.captured.size, "$name must execute exactly one source query")
+        val captured = capturing.captured.single()
+        assertEquals(expectedStatement, captured.statement, "$name must execute its production statement")
+        assertEquals(expectedParameters, captured.parameters, "$name must bind its production parameters")
+        return explainStatement(name, captured.statement, captured.parameters)
+    }
+
+    /**
+     * EXPLAIN through a plain driver session on the same testcontainer. Drivine hands back rows, and
+     * a plan lives on the result summary rather than in them, so this reaches past it to the driver.
+     */
+    private fun explainStatement(name: String, statement: String, parameters: Map<String, Any>): String {
+        val dataSource = dataSourceMap.dataSources.getValue("neo")
+        val uri = "${dataSource.protocol ?: "bolt"}://${dataSource.host}:${dataSource.port ?: 7687}"
+        val auth = dataSource.userName?.let { AuthTokens.basic(it, dataSource.password.orEmpty()) }
+            ?: AuthTokens.none()
+        return GraphDatabase.driver(uri, auth).use { driver ->
+            val sessionConfig = dataSource.databaseName?.let(SessionConfig::forDatabase)
+                ?: SessionConfig.defaultConfig()
+            driver.session(sessionConfig).use { session ->
+                val plan = session.run("EXPLAIN\n$statement", parameters).consume().plan()
+                renderPlan(plan).also { println("SOURCE_QUERY_EXPLAIN[$name]\n$it") }
+            }
+        }
+    }
+
+    /**
+     * Flatten a plan tree to one line per operator, two spaces of indent per level, children in the
+     * order the planner feeds them — so the outer input of an `Apply`-family operator is the first
+     * child listed and the ordering assertions can read structure off the text.
+     *
+     * Only `Details` is rendered. The other arguments include a `string-representation` holding the
+     * whole plan again as a multi-line ASCII table, which would put unindented text into the middle
+     * of the output and make depth meaningless.
+     */
+    private fun renderPlan(plan: Plan): String = renderPlanLines(plan, 0).trimEnd()
+
+    // Trims once, at the top. Trimming inside the recursion strips a childless operator's own line
+    // ending and glues its next sibling onto it, which silently flattens the tree the depth-based
+    // ordering assertions read.
+    private fun renderPlanLines(plan: Plan, depth: Int): String = buildString {
+        append("  ".repeat(depth))
+        append(plan.operatorType())
+        plan.arguments()["Details"]?.let { append(" | ").append(it.toString().replace('\n', ' ')) }
+        appendLine()
+        plan.children().forEach { append(renderPlanLines(it, depth + 1)) }
+    }
+
+    private data class PlanLine(val depth: Int, val text: String)
+
+    private fun planLines(plan: String): List<PlanLine> =
+        plan.lines().filter { it.isNotBlank() }.map { line ->
+            PlanLine(line.takeWhile { it == ' ' }.length / 2, line.trim())
+        }
+
+    /**
+     * The operator whose rows the `SemiApply` drives — its outer input, and so the thing that decides
+     * how many propositions the provenance expansion is evaluated for.
+     */
+    private fun semiApplyOuterInput(plan: String): PlanLine {
+        val lines = planLines(plan)
+        val semiApply = lines.indexOfFirst { it.text.startsWith("SemiApply") }
+        assertTrue(semiApply >= 0, "expected a SemiApply in:\n$plan")
+        return lines[semiApply + 1].also {
+            assertEquals(lines[semiApply].depth + 1, it.depth, "expected the outer input directly under SemiApply")
+        }
+    }
+
+    private fun semiApplyDepth(plan: String): Int =
+        planLines(plan).first { it.text.startsWith("SemiApply") }.depth
+
+    private fun planLine(plan: String, matching: String): PlanLine {
+        val line = planLines(plan).firstOrNull { it.text.contains(matching) }
+        assertNotNull(line, "expected an operator matching '$matching' in:\n$plan")
+        return line!!
+    }
+
+    private data class CapturedSourceQuery(val statement: String, val parameters: Map<String, Any>)
+
+    /** Records the source-provenance statements a repository runs, identified by their parameters. */
+    private class SourceQueryCapturingPersistenceManager(
+        private val delegate: PersistenceManager,
+    ) : PersistenceManager by delegate {
+
+        val captured = mutableListOf<CapturedSourceQuery>()
+
+        override fun <T : Any> query(spec: QuerySpecification<T>): List<T> {
+            if (spec.parameters.keys.containsAll(setOf("contextId", "sourceKey"))) {
+                @Suppress("UNCHECKED_CAST")
+                captured += CapturedSourceQuery(
+                    requireNotNull(spec.statement).text,
+                    spec.parameters.toMap() as Map<String, Any>,
+                )
+            }
+            return delegate.query(spec)
+        }
+    }
+
+    /** Write a `DERIVED_FROM` edge the way a pre-revision DICE wrote one: no `entryKey`, no revision. */
+    private fun seedLegacyEdge(propositionId: String, entry: ProvenanceEntry) {
+        val locator = entry.locator as UriLocator
+        persistenceManager.execute(
+            QuerySpecification
+                .withStatement(
+                    """
+                    MATCH (p:Proposition {id: ${'$'}propositionId})
+                    MERGE (s:Source {key: ${'$'}sourceKey})
+                    SET s.kind = 'uri', s.uri = ${'$'}sourceUri, s.display = ${'$'}sourceDisplay
+                    CREATE (p)-[r:DERIVED_FROM]->(s)
+                    SET r.chunkId = ${'$'}chunkId,
+                        r.startOffset = ${'$'}startOffset,
+                        r.endOffset = ${'$'}endOffset,
+                        r.contentHash = ${'$'}contentHash
+                    """.trimIndent(),
+                )
+                .bind(
+                    mapOf(
+                        "propositionId" to propositionId,
+                        "sourceKey" to locator.key(),
+                        "sourceUri" to locator.uri,
+                        "sourceDisplay" to locator.display,
+                        "chunkId" to entry.chunkId,
+                        "startOffset" to entry.startOffset,
+                        "endOffset" to entry.endOffset,
+                        "contentHash" to entry.contentHash,
+                    ),
+                ),
+        )
+    }
+
+    private fun storedSourceKeys(): Set<String> =
+        persistenceManager.query(
+            QuerySpecification.withStatement("MATCH (s:Source) RETURN s.key AS key").transform(String::class.java),
+        ).toSet()
+
+    private fun evidence(
+        locator: UriLocator,
+        revision: String?,
+        chunkId: String? = null,
+        startOffset: Int? = null,
+        endOffset: Int? = null,
+        contentHash: String? = null,
+    ): ProvenanceEntry =
+        ProvenanceEntry(
+            locator = locator,
+            chunkId = chunkId,
+            startOffset = startOffset,
+            endOffset = endOffset,
+            contentHash = contentHash,
+            sourceRevision = revision,
+        )
 
     private fun edgeCount(propositionId: String): Long =
         persistenceManager.getOne(
@@ -1055,6 +1771,25 @@ class DrivinePropositionStoreIntegrationTest {
             TransactionInterceptor(transactionManager, AnnotationTransactionAttributeSource()),
         )
         return proxyFactory.proxy as DrivinePropositionRepository
+    }
+
+    /**
+     * Holds both writers at the source-identity preflight until each has read the store and found
+     * nothing there, so neither can see the other's `:Source` and the preflight cannot separate them.
+     */
+    private class SourcePreflightBarrierPersistenceManager(
+        private val delegate: PersistenceManager,
+        private val barrier: CountDownLatch,
+    ) : PersistenceManager by delegate {
+
+        override fun <T : Any> query(spec: QuerySpecification<T>): List<T> {
+            val result = delegate.query(spec)
+            if (spec.parameters.keys == setOf("sourceKey")) {
+                barrier.countDown()
+                assertTrue(barrier.await(10, TimeUnit.SECONDS), "both writers must preflight against an empty store")
+            }
+            return result
+        }
     }
 
     /** Holds both writers at the dedup lookup until each has seen no duplicate, forcing the race. */
@@ -1296,6 +2031,38 @@ class DrivinePropositionStoreIntegrationTest {
         val orthogonal = normalize(raw.indices.map { (raw[it] - projection * u[it]).toFloat() })
         val sinTheta = kotlin.math.sqrt(1.0 - cosTheta * cosTheta)
         return u.indices.map { (cosTheta * u[it] + sinTheta * orthogonal[it]).toFloat() }
+    }
+
+    /**
+     * Run [body] on a store with nothing indexing `Proposition.contextId` — the range index goes as
+     * well as the dedup constraint — then put both back.
+     */
+    private fun withoutContextIdIndexes(body: () -> Unit) {
+        val rangeIndex = persistenceManager.maybeGetOne(
+            QuerySpecification
+                .withStatement(
+                    "SHOW INDEXES YIELD name, labelsOrTypes, properties, type " +
+                        "WHERE type = 'RANGE' AND 'Proposition' IN labelsOrTypes AND properties = ['contextId'] " +
+                        "RETURN name",
+                )
+                .transform(String::class.java),
+        )
+        rangeIndex?.let { persistenceManager.execute(QuerySpecification.withStatement("DROP INDEX $it IF EXISTS")) }
+        try {
+            withoutContextTextConstraint(body)
+        } finally {
+            rangeIndex?.let {
+                persistenceManager.execute(
+                    QuerySpecification.withStatement(
+                        "CREATE INDEX $it IF NOT EXISTS FOR (p:Proposition) ON (p.contextId)",
+                    ),
+                )
+            }
+            // CREATE INDEX returns before the index is online, and the planner will not seek one that
+            // is still POPULATING. Without this wait, whether the tenant-first plan test sees a seek
+            // depends on whether it happened to run after this one.
+            persistenceManager.execute(QuerySpecification.withStatement("CALL db.awaitIndexes(60)"))
+        }
     }
 
     /** Run [body] with the (contextId, text) uniqueness constraint dropped, then restore it. */

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -1515,8 +1515,11 @@ class DrivinePropositionStoreIntegrationTest {
      * seeking the index and scanning it, and it will do either — which showed up as an intermittent
      * `NodeIndexScan … WHERE contextId IS NOT NULL` where the seek was expected. A scan reads every
      * proposition's `contextId`, so it is not the tenant-first plan the test means to pin, and
-     * accepting it would have hollowed out the assertion. Statistics are resampled afterwards because
-     * a freshly created index carries none, and the fallback test drops and recreates this one.
+     * accepting it would have hollowed out the assertion. The fixture resamples every index and
+     * clears the query cache afterwards, because a freshly created index carries no statistics and
+     * because earlier tests in the class run these same statements against two rows and leave a
+     * cached plan Neo4j would otherwise reuse until its replan interval passes. The fallback test
+     * drops and recreates the index.
      */
     private fun seedExplainFixture(locator: UriLocator) {
         repository.save(
@@ -1530,7 +1533,7 @@ class DrivinePropositionStoreIntegrationTest {
                 repository.save(prop("other tenant $tenant fact $row", context = "ctx-other-$tenant"))
             }
         }
-        persistenceManager.execute(QuerySpecification.withStatement("CALL db.resampleOutdatedIndexes()"))
+        persistenceManager.execute(QuerySpecification.withStatement("CALL db.prepareForReplanning()"))
         persistenceManager.execute(QuerySpecification.withStatement("CALL db.awaitIndexes(60)"))
     }
 

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -976,150 +976,132 @@ class DrivinePropositionStoreIntegrationTest {
     }
 
     /**
-     * A `:Source` node is global: one locator key is one node, shared by every context that cites it.
-     * Its `display` label used to be refreshed on every write, so whichever writer ran last owned the
-     * label everybody else read, one context's presentation leaking into all the others. `display`
-     * now travels on each writer's own `DERIVED_FROM` edge, so provenance reads take it from there.
-     *
-     * Two writers, same locator key, different labels. Each context must read back its own label,
-     * and the two writers still share one `:Source` node.
+     * `ConnectorRef` used to join its two ids on a bare colon, so `("a:b", "c")` and `("a", "b:c")`
+     * rendered the same key. Without the store's source-identity guard, the second tenant's write
+     * would have silently squatted on the first's `:Source` node instead of getting its own —
+     * pre-escaping, the guard caught that mismatch and rejected the write instead. `SourceLocator.kt`
+     * now escapes the connector id, so this same tuple pair is the sharpest regression probe
+     * available: if the escaping ever breaks, a plain two-tenant save is where it would show up
+     * first, not just `SourceLocatorTest`.
      */
     @Test
-    fun `each context reads back its own Source display`() {
-        val uri = "https://example.com/shared-display"
-        val firstWriter = UriLocator(uri, display = "First writer label")
-        val secondWriter = UriLocator(uri, display = "Second writer label")
-        assertEquals(firstWriter.key(), secondWriter.key(), "the two writers name one shared Source")
-
-        val first = repository.save(
-            prop("first writer fact", context = "ctx-display-a", provenance = listOf(evidence(firstWriter, "r1"))),
+    fun `structurally distinct connector tuples that used to collide keep separate sources`() {
+        val original = ConnectorRef("a:b", "c")
+        val formerlyColliding = ConnectorRef("a", "b:c")
+        assertNotEquals(
+            original.key(),
+            formerlyColliding.key(),
+            "these two tuples rendered one key before ConnectorRef escaped colons in the connector id " +
+                "— a regression here means the escaping broke",
+        )
+        val stored = repository.save(
+            prop("original connector fact", context = "ctx-a", provenance = listOf(ProvenanceEntry(original))),
         )
         val second = repository.save(
-            prop("second writer fact", context = "ctx-display-b", provenance = listOf(evidence(secondWriter, "r2"))),
-        )
-
-        assertEquals(
-            "First writer label",
-            repository.findBySourceRevision(ContextId("ctx-display-a"), SourceRevisionRef(firstWriter.key(), "r1"))
-                .single().provenanceEntries.single().locator.display,
-            "ctx-display-a reads back its own writer's label",
-        )
-        assertEquals(
-            "Second writer label",
-            repository.findBySourceRevision(ContextId("ctx-display-b"), SourceRevisionRef(secondWriter.key(), "r2"))
-                .single().provenanceEntries.single().locator.display,
-            "ctx-display-b reads back its own writer's label, not ctx-display-a's",
-        )
-        assertEquals(
-            1L,
-            persistenceManager.getOne(
-                QuerySpecification
-                    .withStatement("MATCH (s:Source {key: \$sourceKey}) RETURN count(s) AS c")
-                    .bind(mapOf("sourceKey" to firstWriter.key()))
-                    .transform(Long::class.java),
+            prop(
+                "colliding connector fact",
+                context = "ctx-b",
+                provenance = listOf(ProvenanceEntry(formerlyColliding)),
             ),
-            "both writers still share one Source node",
         )
 
-        assertEquals("r1", repository.provenanceOf(first.id).single().sourceRevision)
-        assertEquals("r2", repository.provenanceOf(second.id).single().sourceRevision)
+        assertEquals(
+            original,
+            repository.findById(stored.id)?.provenanceEntries?.single()?.locator,
+            "the first tenant's source keeps its own identity",
+        )
+        assertEquals(
+            formerlyColliding,
+            repository.findById(second.id)?.provenanceEntries?.single()?.locator,
+            "the second tenant gets its own source rather than inheriting the first's",
+        )
+        assertEquals(2, repository.count(), "both writes must land as their own proposition")
+        assertEquals(setOf(original.key(), formerlyColliding.key()), storedSourceKeys())
     }
 
     /**
-     * A colliding locator arriving in the same batch as genuinely new evidence. The colliding entry
-     * compares equal to one the winner already holds, so the novelty check drops it — and it is then
-     * neither written nor, if only novel entries are checked, ever looked at. The save would report
-     * success while the second connector's evidence had been quietly counted as the first's.
+     * A tuple that used to collide, arriving in the same batch as genuinely new evidence. Before the
+     * escaping fix the once-colliding entry compared equal to one the winner already held, so —
+     * without the stored-vs-incoming check catching the mismatch first — the novelty check would have
+     * dropped it and the second connector's evidence would have been quietly counted as the first's.
+     * With the keys distinct, both the once-colliding entry and the plain novel one are recognised as
+     * new and both land on the winner.
      */
     @Test
-    fun `dedup rejects a colliding connector source arriving alongside novel evidence`() {
+    fun `dedup treats a source that used to collide as novel evidence alongside other novel evidence`() {
         val original = ConnectorRef("a:b", "c")
-        val colliding = ConnectorRef("a", "b:c")
+        val formerlyColliding = ConnectorRef("a", "b:c")
         val newSource = UriLocator("https://example.com/mixed-batch")
-        assertEquals(original.key(), colliding.key(), "the fixture depends on these keys colliding")
+        assertNotEquals(original.key(), formerlyColliding.key(), "the fixture used to depend on these keys colliding")
         val winner = repository.save(
             prop("mixed batch fact", context = "ctx-mixed", provenance = listOf(ProvenanceEntry(original))),
         )
-        assertTrue(
-            winner.provenanceEntries.contains(ProvenanceEntry(colliding)),
-            "and on the colliding entry counting as already held, which is what drops it from the novelty check",
+        assertFalse(
+            winner.provenanceEntries.contains(ProvenanceEntry(formerlyColliding)),
+            "the two tuples no longer compare equal, so the winner does not already hold this evidence",
         )
 
-        val thrown = assertThrows<Exception> {
-            repository.save(
-                prop(
-                    "mixed batch fact",
-                    context = "ctx-mixed",
-                    provenance = listOf(ProvenanceEntry(colliding), evidence(newSource, "r1")),
-                ),
-            )
-        }
-        assertTrue(
-            generateSequence(thrown as Throwable?) { it.cause }.any {
-                it is IllegalArgumentException && it.message?.contains("Source key collision") == true
-            },
-            "the batch must be rejected as a source key collision; got: $thrown",
+        val second = repository.save(
+            prop(
+                "mixed batch fact",
+                context = "ctx-mixed",
+                provenance = listOf(ProvenanceEntry(formerlyColliding), evidence(newSource, "r1")),
+            ),
+        )
+
+        assertEquals(1, repository.count(), "dedup still collapses onto one proposition")
+        assertEquals(winner.id, second.id)
+        val stored = repository.findById(winner.id)!!
+        assertEquals(
+            setOf(original.key(), formerlyColliding.key(), newSource.key()),
+            stored.provenanceEntries.map { it.locator.key() }.toSet(),
+            "the once-colliding connector locator and its uri sibling both land as novel evidence",
+        )
+        assertEquals(3L, edgeCount(winner.id))
+    }
+
+    /**
+     * Both tuples that used to collide in one write, naming sources that don't exist yet. Before the
+     * escaping fix nothing was stored to compare against, so a check that only reads the store
+     * beforehand would have seen two clean entries and let the second attach silently to the source
+     * the first created; the batch-internal preflight caught that by comparing entries against each
+     * other. With the keys distinct there is no batch-internal collision left to catch — the write
+     * creates two sources and keeps both.
+     */
+    @Test
+    fun `one write carrying two connector locators that used to collide keeps both`() {
+        val original = ConnectorRef("a:b", "c")
+        val formerlyColliding = ConnectorRef("a", "b:c")
+        assertNotEquals(original.key(), formerlyColliding.key(), "the fixture used to depend on these keys colliding")
+
+        val saved = repository.save(
+            prop(
+                "two once-colliding locators in one write",
+                context = "ctx-batch-collide",
+                provenance = listOf(ProvenanceEntry(original), ProvenanceEntry(formerlyColliding)),
+            ),
         )
 
         assertEquals(1, repository.count())
+        assertEquals(setOf(original.key(), formerlyColliding.key()), storedSourceKeys())
+        assertEquals(2L, edgeCount(saved.id))
         assertEquals(
-            listOf(ProvenanceEntry(original)),
-            repository.findById(winner.id)!!.provenanceEntries,
-            "the winner must be exactly as it was",
-        )
-        assertEquals(1L, edgeCount(winner.id))
-        assertEquals(
-            setOf(original.key()),
-            storedSourceKeys(),
-            "the batch's novel source must not survive a rejected write either",
+            setOf(original.key(), formerlyColliding.key()),
+            repository.findById(saved.id)!!.provenanceEntries.map { it.locator.key() }.toSet(),
         )
     }
 
     /**
-     * Both colliding locators in one write, naming a source that does not exist yet. Nothing is
-     * stored to compare against, so a check that only reads the store beforehand sees two clean
-     * entries and lets the second silently attach to the source the first creates.
+     * Two writers, each introducing one of the two tuples that used to collide, held at the
+     * source-identity preflight until both have read an empty store — the interleaving that used to
+     * matter because only the `MERGE` itself could tell the two apart. With the keys distinct there
+     * is nothing left for the `MERGE` to arbitrate: both writers get their own `:Source` node.
      */
     @Test
-    fun `one write carrying two colliding connector locators is rejected`() {
+    fun `concurrent writers introducing tuples that used to collide land on two distinct sources`() {
         val original = ConnectorRef("a:b", "c")
-        val colliding = ConnectorRef("a", "b:c")
-        assertEquals(original.key(), colliding.key(), "the fixture depends on these keys colliding")
-
-        val thrown = assertThrows<Exception> {
-            repository.save(
-                prop(
-                    "two colliding locators in one write",
-                    context = "ctx-batch-collide",
-                    provenance = listOf(ProvenanceEntry(original), ProvenanceEntry(colliding)),
-                ),
-            )
-        }
-        assertTrue(
-            generateSequence(thrown as Throwable?) { it.cause }.any {
-                it is IllegalArgumentException && it.message?.contains("Source key collision") == true
-            },
-            "the batch must be rejected as a source key collision; got: $thrown",
-        )
-
-        assertEquals(0, repository.count(), "the rejected write must leave no proposition behind")
-        assertEquals(emptySet<String>(), storedSourceKeys(), "and no half-created source")
-    }
-
-    /**
-     * Two writers introducing the same colliding source key at once, with neither able to see the
-     * other's work: the barrier holds both until each has finished reading the store and found
-     * nothing there. Only a check that runs under the `MERGE` can separate them, so this is the case a
-     * read-then-write preflight cannot cover on its own.
-     *
-     * Which writer wins is the database's business. What must hold is that one is rejected, one
-     * succeeds, and the stored source carries the winner's identity rather than a mixture.
-     */
-    @Test
-    fun `concurrent writers introducing one colliding source key cannot corrupt it`() {
-        val original = ConnectorRef("a:b", "c")
-        val colliding = ConnectorRef("a", "b:c")
-        assertEquals(original.key(), colliding.key(), "the fixture depends on these keys colliding")
+        val formerlyColliding = ConnectorRef("a", "b:c")
+        assertNotEquals(original.key(), formerlyColliding.key(), "the fixture used to depend on these keys colliding")
         val barrier = CountDownLatch(2)
         val firstRepository = newTransactionProxiedRepository(
             SourcePreflightBarrierPersistenceManager(persistenceManager, barrier),
@@ -1138,44 +1120,32 @@ class DrivinePropositionStoreIntegrationTest {
                 },
                 executor.submit<Proposition> {
                     secondRepository.save(
-                        prop("second new-source fact", context = "ctx-new-collide", provenance = listOf(ProvenanceEntry(colliding))),
+                        prop("second new-source fact", context = "ctx-new-collide", provenance = listOf(ProvenanceEntry(formerlyColliding))),
                     )
                 },
             ).map { future -> runCatching { future.get(30, TimeUnit.SECONDS) } }
 
-            assertEquals(1, outcomes.count { it.isSuccess }, "exactly one writer may create the shared source")
-            val failure = outcomes.single { it.isFailure }.exceptionOrNull()!!
-            assertTrue(
-                generateSequence(failure as Throwable?) { it.cause }.any {
-                    it is IllegalArgumentException && it.message?.contains("Source key collision") == true
-                },
-                "the losing writer must report the structural Source key collision; got: $failure",
-            )
-
-            val winner = outcomes.single { it.isSuccess }.getOrThrow()
-            val storedLocator = repository.findById(winner.id)!!.provenanceEntries.single().locator
-            assertEquals(
-                winner.provenanceEntries.single().locator,
-                storedLocator,
-                "the stored source must carry the identity of whoever created it",
-            )
-            assertEquals(setOf(original.key()), storedSourceKeys())
-            assertEquals(1, repository.count(), "the rejected writer must leave no proposition behind")
+            assertEquals(2, outcomes.count { it.isSuccess }, "neither key collides any more, so both writers must succeed")
+            val ids = outcomes.map { it.getOrThrow().id }
+            assertEquals(2, ids.toSet().size, "each writer must get its own proposition")
+            assertEquals(setOf(original.key(), formerlyColliding.key()), storedSourceKeys())
+            assertEquals(2, repository.count())
         } finally {
             executor.shutdownNow()
         }
     }
 
     /**
-     * A cross-instance race on the *recovery* path. Both writers pass the dedup lookup, one loses on
-     * the uniqueness constraint, and its recovery tries to union evidence whose locator collides with
-     * the winner's. Recovery must reject it and leave the winner as it found it.
+     * A cross-instance race on the *recovery* path, with each writer bringing one of the two tuples
+     * that used to collide. Before the escaping fix the loser's recovery would try to union evidence
+     * whose locator collided with the winner's and get rejected. With the keys distinct there is
+     * nothing to reject: recovery unions the loser's evidence onto the winner like any other race.
      */
     @Test
-    fun `cross-instance recovery rejects a colliding connector source and preserves its winner`() {
+    fun `cross-instance recovery unions tuples that used to collide onto the winner`() {
         val original = ConnectorRef("a:b", "c")
-        val colliding = ConnectorRef("a", "b:c")
-        assertEquals(original.key(), colliding.key(), "the fixture depends on these keys colliding")
+        val formerlyColliding = ConnectorRef("a", "b:c")
+        assertNotEquals(original.key(), formerlyColliding.key(), "the fixture used to depend on these keys colliding")
         val first = prop(
             "cross-instance collision-prone fact",
             context = "ctx-recover-collide",
@@ -1184,7 +1154,7 @@ class DrivinePropositionStoreIntegrationTest {
         val second = prop(
             "cross-instance collision-prone fact",
             context = "ctx-recover-collide",
-            provenance = listOf(ProvenanceEntry(colliding)),
+            provenance = listOf(ProvenanceEntry(formerlyColliding)),
         )
         val barrier = CountDownLatch(2)
         val firstRepository = newTransactionProxiedRepository(
@@ -1201,26 +1171,70 @@ class DrivinePropositionStoreIntegrationTest {
                 executor.submit<Proposition> { secondRepository.save(second) },
             ).map { future -> runCatching { future.get(30, TimeUnit.SECONDS) } }
 
-            assertEquals(1, outcomes.count { it.isSuccess }, "exactly one writer may win the race")
-            val failure = outcomes.single { it.isFailure }.exceptionOrNull()!!
-            assertTrue(
-                generateSequence(failure as Throwable?) { it.cause }.any {
-                    it is IllegalArgumentException && it.message?.contains("Source key collision") == true
-                },
-                "the losing recovery must report the structural Source key collision; got: $failure",
-            )
+            assertEquals(2, outcomes.count { it.isSuccess }, "recovery unions rather than rejects a now-distinct source")
+            val winners = outcomes.map { it.getOrThrow() }
+            assertEquals(1, winners.map { it.id }.toSet().size, "both writers must return the database winner")
+            val winnerId = winners.first().id
 
-            val winner = outcomes.single { it.isSuccess }.getOrThrow()
-            assertEquals(1, repository.count())
+            assertEquals(1, repository.count(), "the race still collapses onto one proposition")
+            val stored = repository.findById(winnerId)!!
             assertEquals(
-                winner.provenanceEntries,
-                repository.findById(winner.id)!!.provenanceEntries,
-                "a rejected recovery must leave the stored winner unchanged",
+                setOf(original.key(), formerlyColliding.key()),
+                stored.provenanceEntries.map { it.locator.key() }.toSet(),
+                "the loser's once-colliding evidence is unioned onto the winner rather than rejected",
             )
-            assertEquals(1L, edgeCount(winner.id))
+            assertEquals(2L, edgeCount(winnerId))
         } finally {
             executor.shutdownNow()
         }
+    }
+
+    /**
+     * `ConnectorRef` escaping only stops a *current* write from minting an ambiguous key — it does
+     * nothing for a `:Source` node a pre-escaping store already wrote. Before the fix, `("a:b", "c")`
+     * and `("a", "b:c")` both rendered `connector:a:b:c` (`SourceLocator.kt`'s KDoc documents this:
+     * such a key "was ambiguous when written and cannot be re-keyed from the key alone"), so an
+     * upgraded store can still hold a node under that key with `("a:b", "c")`'s identity. This seeds
+     * that legacy node directly, by raw Cypher rather than through the repository — the only way to
+     * get it into the graph without the escaping fix, since nothing on the current write path can
+     * mint an ambiguous key any more — then saves the *other* half of the old pair, which now renders
+     * the identical key. The batch-internal preflight has nothing to compare here (one entry, one
+     * write); it's the stored-vs-incoming check that has to catch this, and it does.
+     */
+    @Test
+    fun `a legacy ambiguous source key still rejects a structurally different connector write`() {
+        val legacyKey = "connector:a:b:c"
+        persistenceManager.execute(
+            QuerySpecification
+                .withStatement(
+                    "MERGE (s:Source {key: \$sourceKey}) " +
+                        "SET s.kind = 'connector', s.connectorId = \$connectorId, s.externalId = \$externalId",
+                )
+                .bind(mapOf("sourceKey" to legacyKey, "connectorId" to "a:b", "externalId" to "c")),
+        )
+        val formerlyColliding = ConnectorRef("a", "b:c")
+        assertEquals(
+            legacyKey,
+            formerlyColliding.key(),
+            "this write must land on exactly the legacy node's key for the guard to have anything to compare",
+        )
+
+        val thrown = assertThrows<Exception> {
+            repository.save(
+                prop(
+                    "structurally different from the legacy node",
+                    context = "ctx-legacy-collide",
+                    provenance = listOf(ProvenanceEntry(formerlyColliding)),
+                ),
+            )
+        }
+        assertTrue(
+            generateSequence(thrown as Throwable?) { it.cause }.any {
+                it is IllegalArgumentException && it.message?.contains("Source key collision") == true
+            },
+            "the write must report the structural Source key collision against the legacy node; got: $thrown",
+        )
+        assertEquals(0, repository.count(), "the rejected write must leave no proposition behind")
     }
 
     /**
@@ -1285,31 +1299,6 @@ class DrivinePropositionStoreIntegrationTest {
             1L,
             persistenceManager.getOne(
                 QuerySpecification
-                    .withStatement("MATCH (s:Source {key: \$sourceKey}) RETURN count(s) AS c")
-                    .bind(mapOf("sourceKey" to firstWriter.key()))
-                    .transform(Long::class.java),
-            ),
-            "both writers still share one Source node",
-        )
-
-        assertEquals(
-            listOf(first.id),
-            repository.findBySourceRevision(ContextId("ctx-display-a"), SourceRevisionRef(firstWriter.key(), "r1"))
-                .map { it.id },
-            "the first writer's evidence is queryable",
-        )
-        assertEquals(
-            listOf(second.id),
-            repository.findBySourceRevision(ContextId("ctx-display-b"), SourceRevisionRef(secondWriter.key(), "r2"))
-                .map { it.id },
-            "the second writer's evidence landed in full",
-        )
-        assertEquals("r2", repository.provenanceOf(second.id).single().sourceRevision)
-    }
-
-
-    private fun evidence(locator: UriLocator, revision: String?): ProvenanceEntry =
-        ProvenanceEntry(locator = locator, sourceRevision = revision)
                     .withStatement(
                         "MATCH (:Proposition {id: \$id})-[r:DERIVED_FROM]->() RETURN count(r.entryKey) AS c",
                     )
@@ -2274,4 +2263,56 @@ class DrivinePropositionStoreIntegrationTest {
 
         assertEquals(old, repository.findById(saved.id)!!.lastAccessed)
     }
+    /**
+     * A `:Source` node is global: one locator key is one node, shared by every context that cites it.
+     * Its `display` label used to be refreshed on every write, so whichever writer ran last owned the
+     * label everybody else read, one context's presentation leaking into all the others. `display`
+     * now travels on each writer's own `DERIVED_FROM` edge, so provenance reads take it from there.
+     *
+     * Two writers, same locator key, different labels. Each context must read back its own label,
+     * and the two writers still share one `:Source` node.
+     */
+    @Test
+    fun `each context reads back its own Source display`() {
+        val uri = "https://example.com/shared-display"
+        val firstWriter = UriLocator(uri, display = "First writer label")
+        val secondWriter = UriLocator(uri, display = "Second writer label")
+        assertEquals(firstWriter.key(), secondWriter.key(), "the two writers name one shared Source")
+
+        val first = repository.save(
+            prop("first writer fact", context = "ctx-display-a", provenance = listOf(evidence(firstWriter, "r1"))),
+        )
+        val second = repository.save(
+            prop("second writer fact", context = "ctx-display-b", provenance = listOf(evidence(secondWriter, "r2"))),
+        )
+
+        assertEquals(
+            "First writer label",
+            repository.findBySourceRevision(ContextId("ctx-display-a"), SourceRevisionRef(firstWriter.key(), "r1"))
+                .single().provenanceEntries.single().locator.display,
+            "ctx-display-a reads back its own writer's label",
+        )
+        assertEquals(
+            "Second writer label",
+            repository.findBySourceRevision(ContextId("ctx-display-b"), SourceRevisionRef(secondWriter.key(), "r2"))
+                .single().provenanceEntries.single().locator.display,
+            "ctx-display-b reads back its own writer's label, not ctx-display-a's",
+        )
+        assertEquals(
+            1L,
+            persistenceManager.getOne(
+                QuerySpecification
+                    .withStatement("MATCH (s:Source {key: \$sourceKey}) RETURN count(s) AS c")
+                    .bind(mapOf("sourceKey" to firstWriter.key()))
+                    .transform(Long::class.java),
+            ),
+            "both writers still share one Source node",
+        )
+
+        assertEquals("r1", repository.provenanceOf(first.id).single().sourceRevision)
+        assertEquals("r2", repository.provenanceOf(second.id).single().sourceRevision)
+    }
+
+
+
 }

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/PropositionGraphMapperRevisionTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/PropositionGraphMapperRevisionTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.storage
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
+import com.embabel.dice.provenance.UriLocator
+import com.embabel.dice.storage.model.DerivedFrom
+import com.embabel.dice.storage.model.SourceNode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * What the graph mapper does with revisions: several revisions of one source share one `:Source`
+ * node and get one `DERIVED_FROM` row each, the row's identity is the domain evidence key, and an
+ * edge written before that identity existed still maps back to the entry it always meant.
+ */
+class PropositionGraphMapperRevisionTest {
+
+    @Test
+    fun `DerivedFrom retains its legacy Java constructor descriptor`() {
+        DerivedFrom::class.java.getConstructor(
+            String::class.java,
+            Integer::class.java,
+            Integer::class.java,
+            String::class.java,
+            SourceNode::class.java,
+        )
+    }
+
+    @Test
+    fun `revisionless and revisioned evidence round trips without duplicating source identity`() {
+        val locator = UriLocator("https://example.com/source")
+        val entries = listOf(
+            evidence(sourceRevision = null),
+            evidence(sourceRevision = "r1"),
+            evidence(sourceRevision = "r2"),
+        )
+
+        val view = PropositionGraphMapper.toProvenanceView(proposition(entries))
+
+        assertEquals(listOf(null, "r1", "r2"), view.provenance.map { it.sourceRevision })
+        assertEquals(setOf(locator.key()), view.provenance.map { it.source.key }.toSet())
+        assertFalse(
+            DerivedFrom::class.java.declaredFields.any { it.name == "sourceKey" },
+            "the source key belongs to the shared node, not to every edge that points at it",
+        )
+        assertEquals(entries, PropositionGraphMapper.toProposition(view).provenanceEntries)
+    }
+
+    /**
+     * The edge identity is not a storage-local encoding: it is exactly what `ProvenanceEvidenceKey`
+     * mints for the same entry, so a stored row and a recorded fold reference are the same string.
+     */
+    @Test
+    fun `the stored edge key is the domain evidence key`() {
+        val entry = evidence(sourceRevision = "r1")
+
+        val stored = entryKey(entry)
+
+        assertEquals(ProvenanceEvidenceKey.encode(entry), stored)
+        assertTrue(
+            ProvenanceEvidenceKey.matches(entry, stored),
+            "an edge's own key must name the evidence it was written from",
+        )
+        assertFalse(
+            ProvenanceEvidenceKey.matches(entry.copy(sourceRevision = "r2"), stored),
+            "and must not name a different revision of it",
+        )
+    }
+
+    @Test
+    fun `entry key is stable and includes every evidence component`() {
+        val base = evidence(sourceRevision = "r1")
+        val stableKey = entryKey(base)
+
+        assertEquals(stableKey, entryKey(base.copy()))
+        listOf(
+            base.copy(locator = UriLocator("https://example.com/other")),
+            base.copy(sourceRevision = "r2"),
+            base.copy(chunkId = "other-chunk"),
+            base.copy(startOffset = 2),
+            base.copy(endOffset = 4),
+            base.copy(contentHash = "other-hash"),
+        ).forEach { changed ->
+            assertNotEquals(stableKey, entryKey(changed))
+        }
+    }
+
+    @Test
+    fun `an edge with no stored identity still maps back to its entry`() {
+        val original = evidence(sourceRevision = null)
+        val mapped = PropositionGraphMapper.toProvenanceView(proposition(listOf(original)))
+        val legacy = mapped.copy(provenance = mapped.provenance.map { it.copy(entryKey = null) })
+
+        assertNull(legacy.provenance.single().entryKey)
+        assertEquals(original, PropositionGraphMapper.toProposition(legacy).provenanceEntries.single())
+    }
+
+    private fun entryKey(entry: ProvenanceEntry): String =
+        requireNotNull(
+            PropositionGraphMapper.toProvenanceView(proposition(listOf(entry))).provenance.single().entryKey,
+        ) { "the mapper must give every edge an identity" }
+
+    private fun proposition(entries: List<ProvenanceEntry>): Proposition =
+        Proposition(
+            contextId = ContextId("context-1"),
+            text = "Mapped evidence",
+            mentions = emptyList(),
+            confidence = 1.0,
+            provenanceEntries = entries,
+        )
+
+    private fun evidence(
+        locator: UriLocator = UriLocator("https://example.com/source"),
+        sourceRevision: String? = "r1",
+    ): ProvenanceEntry =
+        ProvenanceEntry(
+            locator = locator,
+            chunkId = "chunk-1",
+            startOffset = 1,
+            endOffset = 3,
+            contentHash = "content-hash",
+            sourceRevision = sourceRevision,
+        )
+}

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/PropositionGraphMapperRevisionTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/PropositionGraphMapperRevisionTest.kt
@@ -107,6 +107,27 @@ class PropositionGraphMapperRevisionTest {
     }
 
     @Test
+    fun `the writer's label rides on the edge and wins over the shared node's`() {
+        val withDisplay = evidence(locator = UriLocator("https://example.com/source", display = "My Source"))
+        val view = PropositionGraphMapper.toProvenanceView(proposition(listOf(withDisplay)))
+        val edge = view.provenance.single()
+
+        assertEquals("My Source", edge.display)
+
+        val edgeWinsOverNode = edge.copy(source = edge.source.copy(display = "Node Label"))
+        assertEquals(
+            "My Source",
+            PropositionGraphMapper.toProvenanceEntry(edgeWinsOverNode).locator.display,
+        )
+
+        val noEdgeLabel = edge.copy(display = null, source = edge.source.copy(display = "Node Label"))
+        assertEquals(
+            "Node Label",
+            PropositionGraphMapper.toProvenanceEntry(noEdgeLabel).locator.display,
+        )
+    }
+
+    @Test
     fun `an edge with no stored identity still maps back to its entry`() {
         val original = evidence(sourceRevision = null)
         val mapped = PropositionGraphMapper.toProvenanceView(proposition(listOf(original)))

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/TestApplication.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/TestApplication.kt
@@ -23,6 +23,7 @@ import org.drivine.manager.GraphObjectManager
 import org.drivine.manager.GraphObjectManagerFactory
 import org.drivine.manager.PersistenceManager
 import org.drivine.manager.PersistenceManagerFactory
+import org.drivine.schema.RangeIndexSpec
 import org.drivine.schema.SchemaCatalog
 import org.drivine.schema.SchemaItemSpec
 import org.drivine.schema.SimilarityFunction
@@ -112,6 +113,11 @@ open class TestApplication {
         // Cross-instance dedup backstop: the same fact minted by parallel writers as distinct ids
         // collapses to one node; save() catches the violation and reuses the existing node.
         UniquenessConstraintSpec(label = "Proposition", properties = listOf("contextId", "text")),
+        // What every tenant-scoped read seeks. The composite constraint above cannot stand in for it:
+        // Neo4j will not use a composite index for a predicate on only its first property, so without
+        // this the tenant predicate becomes a label scan. `dice-storage-autoconfigure` ships it, and
+        // the source-query plan assertions read the plans a real store gets.
+        RangeIndexSpec("Proposition", "contextId"),
     )
 
     @Bean

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKey.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKey.kt
@@ -26,8 +26,14 @@ package com.embabel.dice.provenance
  * A ref that lacks the `dice-provenance:` prefix is a legacy locator key, written before revisions
  * existed. Those match revisionless evidence only, so an old trace can never remove evidence from a
  * revision it never saw. Anything that carries the prefix and then fails to parse matches nothing.
+ *
+ * This is the only evidence-key codec in DICE. `dice-storage` keys each `DERIVED_FROM` edge by the
+ * string [encode] returns, so one piece of evidence has one identity whether it is being recorded by
+ * a collapse or stored as a graph row. The format is public because it outlives the process that
+ * wrote it: a version prefix leads every string, and a reader that meets a version it does not know
+ * matches nothing rather than guessing.
  */
-internal object ProvenanceEvidenceKey {
+object ProvenanceEvidenceKey {
 
     private const val MAGIC_PREFIX = "dice-provenance:"
     private const val VERSION_PREFIX = "${MAGIC_PREFIX}v1:"

--- a/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKey.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKey.kt
@@ -32,6 +32,13 @@ package com.embabel.dice.provenance
  * a collapse or stored as a graph row. The format is public because it outlives the process that
  * wrote it: a version prefix leads every string, and a reader that meets a version it does not know
  * matches nothing rather than guessing.
+ *
+ * The length in each frame counts the value's UTF-8 bytes, not its Kotlin/Java `String.length`
+ * (UTF-16 code units) or its count of Unicode code points. Those three counts agree for plain ASCII
+ * but diverge for anything outside it, and the length has to mean the same thing wherever this
+ * format is read or written, in any language, so it's pinned to the one count every language can
+ * compute the same way from the same bytes. The value itself is still carried as the string it
+ * always was; only the number in front of it changes.
  */
 object ProvenanceEvidenceKey {
 
@@ -71,11 +78,13 @@ object ProvenanceEvidenceKey {
         if (value == null) {
             append("-1:")
         } else {
-            append(value.length)
+            append(utf8Length(value))
             append(':')
             append(value)
         }
     }
+
+    private fun utf8Length(value: String): Int = value.toByteArray(Charsets.UTF_8).size
 
     private class FrameMatcher(
         private val encoded: String,
@@ -92,13 +101,13 @@ object ProvenanceEvidenceKey {
             if (length == -1) {
                 return value == null
             }
-            if (value == null || length != value.length || length > encoded.length - offset) {
+            if (value == null || length != utf8Length(value) || value.length > encoded.length - offset) {
                 return false
             }
-            if (!encoded.regionMatches(offset, value, 0, length)) {
+            if (!encoded.regionMatches(offset, value, 0, value.length)) {
                 return false
             }
-            offset += length
+            offset += value.length
             return true
         }
 

--- a/dice/src/test/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKeyTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKeyTest.kt
@@ -22,6 +22,30 @@ class ProvenanceEvidenceKeyTest {
 
     private val locator = UriLocator("https://example.com/source")
 
+    /**
+     * The exact bytes of `v1`, written out. Every other test here checks `encode` against `matches`
+     * from the same build, so a coordinated edit to both would keep them all green while orphaning
+     * every `entryKey` already stored on a `DERIVED_FROM` edge and every reference already recorded
+     * with a fold. This is the only assertion that fails when the format moves under a `v1` label.
+     *
+     * Changing the format means a new version prefix and a story for the keys already written, not an
+     * edit to this string. The same worked example appears in `docs/design/source-revisions.md`.
+     */
+    @Test
+    fun `v1 encodes to exactly these bytes`() {
+        val entry = ProvenanceEntry(
+            locator = UriLocator("https://a"),
+            sourceRevision = "r1",
+            chunkId = "c",
+            startOffset = 1,
+            endOffset = 2,
+            contentHash = "h",
+        )
+
+        assertThat(ProvenanceEvidenceKey.encode(entry))
+            .isEqualTo("dice-provenance:v1:13:uri:https://a2:r11:c1:11:21:h")
+    }
+
     @Test
     fun `full evidence identity participates in encoding`() {
         val entry = ProvenanceEntry(

--- a/dice/src/test/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKeyTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/provenance/ProvenanceEvidenceKeyTest.kt
@@ -46,6 +46,26 @@ class ProvenanceEvidenceKeyTest {
             .isEqualTo("dice-provenance:v1:13:uri:https://a2:r11:c1:11:21:h")
     }
 
+    /**
+     * The frame length counts UTF-8 bytes, not `String.length` (UTF-16 code units) or code points.
+     * The key `uri:https://a/💾` is 14 ASCII bytes plus 4 bytes for the floppy disk symbol, so its
+     * frame is `18:`, not the 16 `String.length` would give or the 15 a code-point count would give.
+     */
+    @Test
+    fun `a non-ASCII value is framed by its UTF-8 byte count`() {
+        val entry = ProvenanceEntry(locator = UriLocator("https://a/💾"))
+        val encoded = ProvenanceEvidenceKey.encode(entry)
+
+        assertThat(encoded).isEqualTo("dice-provenance:v1:18:uri:https://a/💾-1:-1:-1:-1:-1:")
+        assertThat(ProvenanceEvidenceKey.matches(entry, encoded)).isTrue()
+        assertThat(
+            ProvenanceEvidenceKey.matches(entry, encoded.replaceFirst("18:", "16:"))
+        ).isFalse()
+        assertThat(
+            ProvenanceEvidenceKey.matches(entry, encoded.replaceFirst("18:", "15:"))
+        ).isFalse()
+    }
+
     @Test
     fun `full evidence identity participates in encoding`() {
         val entry = ProvenanceEntry(

--- a/docs/design/source-revisions.md
+++ b/docs/design/source-revisions.md
@@ -145,7 +145,7 @@ collapse writes down what it folded so an undo can subtract exactly that contrib
 appear on several entries at different revisions. `ProvenanceEvidenceKey` owns the replacement:
 
 ```kotlin
-internal object ProvenanceEvidenceKey {
+object ProvenanceEvidenceKey {
     fun encode(entry: ProvenanceEntry): String
     fun matches(entry: ProvenanceEntry, encoded: String): Boolean
 }
@@ -167,6 +167,47 @@ regions in place, so there is no decode step that could produce a half-trusted e
 that is truncated, has a bad length, carries a non-ASCII digit, or has trailing bytes matches
 nothing at all, so an undo driven by a corrupt reference removes no evidence.
 
+### One codec, and why it is public
+
+This is the only evidence-key codec in DICE, and the graph uses it too: a `DERIVED_FROM` edge is
+keyed by the string `encode` returns for the entry it was written from, so a stored row and a
+recorded fold reference are the same string for the same piece of evidence.
+
+They started out as two. Storage had a `provenanceStorageEntryKey` of its own, on the argument that a
+graph row and a fold record have different lifetimes and pinning one to the other would make a change
+to either a migration of both. The two encodings turned out to frame the same six components in the
+same order with the same `-1` for null, differing only in that the storage copy omitted the
+`dice-provenance:v1:` prefix — one format maintained in two places. Worse, neither module could see
+the other's copy: each was `internal` to itself, so even a conformance test tying them together was
+impossible to write without widening one of them. The escape hatch cost the same visibility change as
+the fix.
+
+So the fix. `ProvenanceEvidenceKey` is public, `dice-storage` calls `encode`, and
+`PropositionGraphMapperRevisionTest` asserts that a stored edge key both equals `encode` for its
+entry and satisfies `matches` against it — and fails `matches` against a different revision of the
+same evidence.
+
+**Adopting the prefix changed the bytes stored on an edge**, and that is worth stating plainly rather
+than leaving as an implication of "one codec". It is safe only because of when it happened:
+`entryKey` is itself unreleased, arriving in this same train, so no released DICE ever wrote one. A
+graph written by an intermediate build of this train holds prefix-less keys that this build does not
+recognise, and re-saving that evidence adds a second edge; clearing such a development store is the
+whole of the fix, and the CHANGELOG says so. After release the same change would be a migration.
+
+The reason a released format change would be expensive is the reason `v1` is now pinned by a literal.
+Every other test compares `encode` against `matches` from the same build, so a coordinated edit to
+both would stay green while orphaning every stored key and every recorded fold reference.
+`ProvenanceEvidenceKeyTest.v1 encodes to exactly these bytes` asserts the worked example above
+character for character, so moving the format under a `v1` label fails the build.
+
+Public is the honest declaration rather than a new commitment. The format was already durable in two
+places before this: recorded in collector traces and stored on every edge. What being public adds is
+a stated contract — a version prefix leads every string, a reader that meets a version it does not
+know matches nothing rather than guessing, and the format is the thing that must not change under
+either reader, not an implementation detail either module owns. The lifetime argument survives as a
+constraint on future versions: a `v2` would have to be introduced the way this note describes for
+legacy locator keys, since `entryKey` values already stored cannot be rewritten by a redeploy.
+
 ```mermaid
 flowchart TD
     E["ProvenanceEntry"]
@@ -182,11 +223,11 @@ flowchart TD
 
 ### The interim gap, until the collector slice lands
 
-`encode` has no production caller yet. Until slice 3 rewires `MultiSignalCollectorStrategy`, a
-collapse still records fold refs as plain locator keys, so undoing a collapse that folded revisioned
-evidence takes the legacy path and leaves those entries on the survivor. The direction of the gap is
-safe — evidence is retained, never wrongly deleted — and it closes when slice 3 starts recording
-encoded refs.
+Storage keys its edges by `encode`, but no *collapse* records an encoded ref yet. Until slice 3
+rewires `MultiSignalCollectorStrategy`, a collapse still writes down plain locator keys, so undoing
+one that folded revisioned evidence takes the legacy path and leaves those entries on the survivor.
+The direction of the gap is safe — evidence is retained, never wrongly deleted — and it closes when
+slice 3 starts recording encoded refs.
 
 ### Legacy evidence is unchanged, by construction
 
@@ -326,6 +367,73 @@ Both are pinned by integration tests that were confirmed to fail against the pre
 the parallel-revision one saw one edge where it needed two, and the dedup one saw an empty result
 for the second revision.
 
+Source identity is guarded in two places, and they do different jobs.
+
+The **check under the `MERGE`** is the one that makes it sound. `upsertSource` merges the `:Source`
+node, returns the identity fields of whatever node it settled on, and compares. `ON CREATE SET`
+leaves an existing node's identity alone, so the row that comes back is whichever identity won, and a
+writer holding a different one fails. The `MERGE` serialises on the `:Source(key)` uniqueness
+constraint, so this is the only check that can separate two writers introducing the same key at once.
+
+The **preflight before the first write** is an ordering guarantee. It reads the store for each
+distinct source key the batch names, and additionally rejects a batch that carries two structurally
+different locators under one key. It buys two things: an ordinary rejected write leaves the graph
+exactly as it found it, and the dedup no-op path — which writes nothing, and so would reach no check
+at all — has something to reject a colliding locator with.
+
+Relying on the preflight alone does not work, and the reason is worth recording because the obvious
+tidy-up is to delete one of the two. A read-then-write check has a window: two writers introducing a
+colliding key can both read an empty store and both pass, and one batch carrying both locators has no
+stored node to disagree with either. `one write carrying two colliding connector locators is
+rejected` and `concurrent writers introducing one colliding source key cannot corrupt it` pin those
+two cases — the second holds both writers at the preflight until each has read nothing, so only the
+`MERGE`-time comparison can tell them apart. `colliding connector tuples cannot overwrite a shared
+source`, `dedup rejects a colliding connector source even when the entry looks already known`, and
+`cross-instance recovery rejects a colliding connector source and preserves its winner` cover the
+three ways a collision with an *already stored* source arrives.
+
+On the dedup path only the novel entries are preflighted. The winner's own entries came out of the
+graph, so there is nothing about them left to disagree with, and reading them back would cost one
+query per stored entry per merge.
+
+### Deleting a proposition that cites one source at several revisions
+
+`delete` is the last provenance path still going through the Drivine object view: it cascades
+`PropositionWithProvenanceView` with `DELETE_ORPHAN`. The write and read paths had to leave that
+mapping because it identifies an edge by its endpoints, which raised the obvious question for delete
+— does a proposition holding two revisions of one source lose an edge, or strand one?
+
+Neither. `deleting a proposition takes its parallel revision edges and only its own orphaned source`
+puts a subject with two revisions of a shared source plus one exclusive source, and a bystander citing
+the shared source, against a real Neo4j. Deleting the subject removes all three of its edges, prunes
+the exclusive source, leaves the shared one standing, and leaves the bystander's own evidence intact.
+Delete asks a different question from a write: it wants every edge gone rather than one particular
+row, so endpoint-level identity is enough. The view and the two mapper functions that build and read
+it stay, with documentation that says what each is for.
+
+### The plans the finders actually run
+
+`public source queries execute their production statements on tenant-first plans` couples each finder
+to the Cypher it sends: a recording persistence manager captures the statement and parameters the
+repository binds, asserts they are the production constants, and EXPLAINs exactly what it captured.
+Nothing under assertion is retyped, so a statement edited without a matching plan change fails here.
+
+The statements carry no `USING INDEX` hint. Neo4j resolves a hint at planning time and fails the whole
+query when the named index is absent, and `dice-storage`'s schema is adopter-supplied. What the plans
+show:
+
+- With an index on `Proposition.contextId` — the range index `dice-storage-autoconfigure` ships — the
+  plan seeks it to produce `p`, and the `DERIVED_FROM` expansion runs under a `SemiApply` above that
+  seek. No `Filter` on `p.contextId` survives, so only that tenant's propositions are ever expanded.
+  Tenant-first is a measured property, not a reading of the Cypher.
+- With no index on `contextId` at all, the leaf is a label scan and the tenant becomes a filter. The
+  finders still plan and still answer, which a hinted statement would not.
+
+The `(contextId, text)` uniqueness constraint does not stand in for the range index: Neo4j will not
+use a composite index for a predicate on only its first property, so a store carrying the dedup
+constraint alone scans. `source queries plan and answer with no index on contextId` pins the second
+plan shape by dropping both.
+
 `PropositionStore` also grows the provenance-management operations — `provenanceOf`,
 `addProvenance`, `setProvenance`, `clearProvenance` — which previously sat only on the richer
 `PropositionRepository`. They move down so evidence-sensitive callers such as collector undo can
@@ -399,10 +507,11 @@ Four slices, each green on its own, together equal to the reviewed
    the default production backend: the revision and `entryKey` on the `DERIVED_FROM` edge, the
    raw-Cypher write and read paths that keep parallel revisions apart, evidence union on both dedup
    paths, and the three Cypher push-down overrides with integration tests.
-2. **Storage** — what remains on the `dice-storage` proposition side: the query-plan assertions that
-   couple each statement to the plan Neo4j actually runs, the DERIVED_FROM edge-count proofs for
-   repeated and concurrent writes of one revision, and the connector-collision and legacy-adoption
-   cases around `:Source` identity.
+2. **Storage** — what remains on the `dice-storage` proposition side: one evidence-key codec shared
+   by the domain and the graph, the query-plan assertions that couple each statement to the plan
+   Neo4j actually runs, the DERIVED_FROM edge-count proofs for repeated and concurrent writes of one
+   revision, the delete cascade over parallel revisions, and the connector-collision and
+   legacy-adoption cases around `:Source` identity.
 3. **Collector hardening** — the trace and undo half: `CollectorSignals` carrying evidence keys,
    undo routed through the store SPI, `DrivineCollectorTraceStore`, and
    `MultiSignalCollectorStrategy`.

--- a/docs/design/source-revisions.md
+++ b/docs/design/source-revisions.md
@@ -153,10 +153,11 @@ object ProvenanceEvidenceKey {
 
 The encoding is length-framed — each field is written as `<length>:<value>`, in the fixed order
 locator key, revision, chunk id, start offset, end offset, content hash, behind a
-`dice-provenance:v1:` prefix. Framing by length means no value needs escaping however many colons
-it contains, and a length of `-1` stands for null, so absence stays distinct from every string
-value including `"null"`. An entry over `https://a` at revision `r1`, chunk `c`, offsets 1–2, hash
-`h` encodes as:
+`dice-provenance:v1:` prefix. The length counts the value's UTF-8 bytes, so any implementation in
+any language arrives at the same string for the same value. Framing by length means no value needs
+escaping however many colons it contains, and a length of `-1` stands for null, so absence stays
+distinct from every string value including `"null"`. An entry over `https://a` at revision `r1`,
+chunk `c`, offsets 1–2, hash `h` encodes as:
 
 ```
 dice-provenance:v1:13:uri:https://a2:r11:c1:11:21:h


### PR DESCRIPTION
**Breaking changes: none.** Additive tests, one public visibility widening (`ProvenanceEvidenceKey`), and query-plan work; no API signature changed.

PR 2 of the source-revision series (refs #64). This slice proves and pins what PR 1 built:
- **Query plans, captured and EXPLAINed**: the tenant-first finder path pins a `NodeIndexSeek` off the `contextId` range index (added to the test catalog; production already ships one), and a paired test proves the hint-free statements still plan and answer with no index at all — the old branch's `USING INDEX` hints are gone because they fail queries outright on adopter schemas without the constraint.
- **One codec**: the storage entry-key encoding delegates to the now-public domain `ProvenanceEvidenceKey`, with a golden literal locking the v1 wire format so a coordinated format edit can't ship green while orphaning stored keys. The unification changed stored bytes (the storage copy lacked the version prefix) — safe only because `entryKey` is unreleased within this same series, disclosed in the CHANGELOG.
- **Delete probed**: removing a proposition holding parallel revision edges of one source behaves correctly through the existing view cascade, with a bystander-safety test.
- **Validation topology**: one read-only preflight per distinct source key for fail-before-mutate ordering, with the atomic post-MERGE identity check inside `upsertSource` as the actual guarantee (TOCTOU closed; barrier-tested with two racing writers on Neo4j).

Tests: `dice` 1213, `dice-storage` 114. Review: three rounds; the TOCTOU, a mixed-batch validation bypass, and a plan-test flake (planner statistics) all caught, reproduced, fixed.

