### PR TITLE
Source-revision provenance: authoritative collector fold and undo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -782,13 +782,13 @@ and the consumer PRs that deliver it).
   survivor already cited at `r1` shares that survivor's locator key, so the fold recorded nothing and
   `r2` stayed on the survivor after an undo; and a bare locator key matches revisionless evidence
   only, so a recorded ref could not reach a revisioned entry either. `undoSingleCollapse` now
-  subtracts evidence through a new `PropositionStore.subtractProvenance`, which names the refs to
+  subtracts evidence through `subtractProvenance`, which names the refs to
   remove — the ordinary `save` on the graph backend appends provenance and deletes no edge, so the
   folded rows used to outlive the undo, and the authoritative replace that would remove them has to
   name what *stays*, silently discarding evidence a concurrent extraction added since the read.
-  `subtractProvenance` ships with that read-modify-write as its default, documented, and
-  `DrivinePropositionRepository` overrides it with one statement that deletes the named edges and
-  prunes only their orphaned sources. Undo also reads both the survivor and the retired proposition
+  `DrivinePropositionRepository` performs it with one statement that deletes the named edges and
+  prunes only their orphaned sources; the entry below moves the operation onto its own capability
+  interface and states its atomicity. Undo also reads both the survivor and the retired proposition
   before writing anything, so a collapse whose participants have since been deleted leaves nothing
   half-written. It also authorizes on two conditions rather than trusting the trace: the collapse
   must be one the collector applied *into this survivor*, and it must still be in force.
@@ -803,7 +803,7 @@ and the consumer PRs that deliver it).
   run writes for a proposition, which matters because `DrivineCollectorRecordStore` MERGEs on
   (`propositionId`, `runId`) and keeps one row per member per run while the in-memory store keeps
   one per mark — reading a merge target off a mark gave different answers on the two stores.
-  `undoSingleCollapse` takes an optional `CollectorRecordStore` and, given one, requires a non-dry
+  `undoSingleCollapse` takes a `CollectorRecordStore` and requires a non-dry
   run and a record naming this survivor as the applied target.
 
   The second condition is that the undo has not already run, which needed a second new field:
@@ -863,11 +863,9 @@ and the consumer PRs that deliver it).
   and can hand back a proposition its first read saw. A
   deletion later than the store's last look is not detected, and the survivor is recreated by an
   upserting `save`; the design note records the residual per path and what closing it would take. An undo
-  interrupted after its stamp resumes by restoring the member only, without re-deriving evidence. `undoSingleCollapse` gains a trailing optional
-  `CollectorRecordStore` parameter and `@JvmOverloads`, so the existing four-argument descriptor
-  survives for both Kotlin and Java callers; the four-argument form keeps the weaker status-based
-  check, documented as such in its KDoc. `PropositionStore` gains `subtractProvenance` with a
-  default implementation, so every existing store compiles and behaves as before.
+  interrupted after its stamp resumes by restoring the member only, without re-deriving evidence.
+  `undoSingleCollapse` gains a `CollectorRecordStore` parameter; the entry below makes it required
+  and reshapes the parameter list, so read that entry for the call-site impact.
   `CollectorRecord` gains trailing optional `mergedIntoId` and
   `undoneAt` fields, keeping every existing constructor and `of(...)` descriptor through the
   `@JvmOverloads` already on both; audit rows written before this change carry neither property and
@@ -875,3 +873,80 @@ and the consumer PRs that deliver it).
   now reads each sibling of a collapse, so a decision with many retired members
   costs one extra read per
   member.
+
+- Collapse undo fails closed (fourth slice of DICE #64). Three ways it could previously act on
+  something the caller had no standing to reverse are shut, and the store operation it depends on
+  becomes an explicit promise.
+
+  **The undo names its context.** `undoSingleCollapse` took a survivor id and a retired id, so ids
+  found anywhere at all could reverse a collapse in a context the caller has no business writing to,
+  and every deployment that cared had to write its own ownership check in front of the call — the
+  assistant does exactly that today. The parameters are now a `CollapseUndoCommand(contextId,
+  survivorId, retiredId)`, and both propositions must live in that context. One that does not throws
+  `CollapseUndoContextMismatchException`, which carries the commanded context, the offending
+  proposition and the context that really owns it, and is thrown before either proposition is
+  written, so the other context is left as it was.
+
+  **A record store is required, and a dry-run record never authorizes.** Passing no
+  `CollectorRecordStore` used to skip the "did the collector really apply this merge" question
+  entirely and fall back on the member's status, which a later unrelated retirement satisfies just
+  as well — a decay sweep moving the member ACTIVE to STALE after a dry-run preview was enough to
+  arm an undo that then stripped a revision the survivor held for its own reasons. A null store now
+  throws `CollapseUndoConfigurationException` naming the missing store, before any read. The
+  authorizing record has to be live: `CollectorRun.dryRun` on the run header is how a preview is
+  marked, and a dry-run header refuses whatever its records say. Three tests share one world state
+  and vary only the audit trail — no store refuses, a dry-run record refuses, a live record
+  proceeds — and each refusal asserts the survivor's evidence, the member's status and the absence
+  of an `undoneAt` stamp.
+
+  **Evidence subtraction becomes an atomic capability.** `PropositionStore.subtractProvenance` and
+  its read-modify-write default are removed, replaced by `ProvenanceSubtractionCapable`, an opt-in
+  interface alongside `SourceRevisionQueryCapable`. Its contract states what a shared default body
+  could never deliver: the read of the current entries and the write of what survives land as one
+  step, evidence another writer adds while a subtraction is in flight survives it, and subtracting
+  the last entry from a proposition somebody already deleted answers null and writes nothing.
+  `supportsProvenanceSubtraction` reports the runtime truth for a decorator that forwards.
+  `InMemoryPropositionRepository` implements it over `ConcurrentHashMap.compute`, which holds the
+  key for the whole operation, and gets an `addProvenance` override on the same primitive so the
+  pair is race-free; `EventEmittingPropositionRepository` carries the capability type and forwards
+  to its delegate, reporting false when the delegate it was handed lacks it. Undo requires the
+  capability and refuses with `CollapseUndoConfigurationException` when the store cannot answer.
+  `ProvenanceSubtractionAtomicityTest` races a subtraction against an addition on one proposition
+  over 200 rounds with real threads and a start latch, and asserts both effects survive; the
+  read-modify-write shape it replaced loses the addition on the first round.
+
+  **Compatibility: BREAKING.** Two source-level breaks, both deliberate, and both with a mechanical
+  migration.
+
+  *`undoSingleCollapse`'s parameter list.* The four-argument form is gone. Migration:
+
+  ```kotlin
+  // before
+  undoSingleCollapse(traceQuery, propositionStore, survivorId, retiredId)
+  // after
+  undoSingleCollapse(
+      command = CollapseUndoCommand(contextId, survivorId, retiredId),
+      traceQuery = traceQuery,
+      propositions = propositionStore,   // must be ProvenanceSubtractionCapable
+      collectorRecords = collectorRecordStore,
+  )
+  ```
+
+  A caller with no `ContextId` to hand has to obtain one, which is the point: without it the call
+  had no way to say whose collapse it was reversing. A caller with no `CollectorRecordStore` has to
+  wire one; passing null compiles and throws, so the gap surfaces immediately. The known consumer is
+  the assistant's `MemoryUnmergeService`, which already resolves the user's context and checks both
+  propositions against it before calling in — the migration hands the SPI work that service was
+  doing by hand, and its own checks can stay or go.
+
+  *`PropositionStore.subtractProvenance`.* Removed along with its read-modify-write default. A store
+  that declared `override fun subtractProvenance` stops compiling until it declares
+  `ProvenanceSubtractionCapable` and drops the `override`. `DrivinePropositionRepository` is adapted
+  in this change: its body already deleted the named `DERIVED_FROM` edges in one statement and read
+  once afterwards, so it satisfied the new contract before the contract existed, and only the
+  supertype list moved. A store that never mentioned the operation compiles unchanged, and gains
+  nothing at runtime: absent the capability, undo refuses, where a racy fallback would have written
+  silently.
+
+  No stored data changes, and nothing in the provenance, trace or audit record shapes moves. Design
+  note: [docs/design/source-revisions.md](docs/design/source-revisions.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -775,6 +775,22 @@ and the consumer PRs that deliver it).
   block holds prefix-less keys that this build does not recognise, and re-saving that evidence adds a
   second edge for it; clearing such a development store is the whole of the fix.
 
+- `CollectorTraceQuery.findDecisionRetiring(propositionId)`: the newest decision in which a
+  proposition was a retired member, never one it survived. `findDecisionForProposition` answers
+  either side of a merge, so after A was folded into B and B into C, undoing B out of C could find
+  the decision where B survived and refuse. Both `undoSingleCollapse` overloads and `findRetirement`
+  now look up by retired member; `DrivineCollectorTraceStore` orders by `createdAt` and
+  `InMemoryCollectorTraceStore` keeps recording order.
+- `ProvenanceSubtractionCapable.subtractFoldedEvidence(propositionId, provenanceRefs, grounding,
+  sourceIds)`: the whole fold a collapse carried comes off in one atomic step, and
+  `subtractProvenance` is now a default over it with empty grounding and source ids. The guarded
+  undo calls it once and never saves the survivor, because a replacing `save` after the subtraction
+  wrote the undo's copy back over evidence another writer added in between. `InMemoryPropositionRepository`
+  does it in one `compute`; `DrivinePropositionRepository` in one statement that deletes the named
+  edges, prunes orphaned sources and rewrites the `grounding` and `sourceIds` lists together.
+  **Compatibility:** `findDecisionRetiring` and `subtractFoldedEvidence` are new abstract members on
+  experimental SPI interfaces in an unreleased train. An implementor outside DICE adds both; an
+  existing `subtractProvenance` override keeps compiling as an override of the new default.
 - Precise undo of a collapse that folded revisioned evidence (third slice of DICE #64).
   `RetiredProposition` gains `foldedProvenanceEvidenceKeys`, one `ProvenanceEvidenceKey` per entry a
   fold actually added to the survivor, and `MultiSignalCollectorStrategy` records it. Recording by
@@ -782,8 +798,9 @@ and the consumer PRs that deliver it).
   survivor already cited at `r1` shares that survivor's locator key, so the fold recorded nothing and
   `r2` stayed on the survivor after an undo; and a bare locator key matches revisionless evidence
   only, so a recorded ref could not reach a revisioned entry either. `undoSingleCollapse` now
-  subtracts evidence through `subtractProvenance`, which names the refs to
-  remove — the ordinary `save` on the graph backend appends provenance and deletes no edge, so the
+  subtracts the whole fold through `subtractFoldedEvidence`, which names the evidence refs, grounding
+  and source ids to remove and takes them off in one step, saving nothing over the survivor
+  afterwards. The ordinary `save` on the graph backend appends provenance and deletes no edge, so the
   folded rows used to outlive the undo, and the authoritative replace that would remove them has to
   name what *stays*, silently discarding evidence a concurrent extraction added since the read.
   `DrivinePropositionRepository` performs it with one statement that deletes the named edges and
@@ -829,8 +846,9 @@ and the consumer PRs that deliver it).
   from its `undoneAt` when records are supplied, so a sibling undone and then retired again by a
   later run no longer reads as still participating — and undoing every member of a shared fold
   returns the survivor to its pre-collapse evidence instead of pinning the shared entry forever.
-  The survivor's evidence subtraction now completes before the save that a decorator such as
-  `EventEmittingPropositionRepository` publishes from, so a listener sees the post-undo state.
+  The survivor is never written through `save`, so a decorator such as
+  `EventEmittingPropositionRepository` announces the member's restore and nothing for the survivor,
+  and a replacing backend cannot put back evidence another writer added after the subtraction.
   `DrivineCollectorTraceStore` persists and reads the new field. Tests fold a
   revisioned loser into a survivor, undo, and assert the survivor's evidence and its `DERIVED_FROM`
   edge count are exactly what they were before the fold, in memory and against Neo4j. Design note:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -915,10 +915,12 @@ and the consumer PRs that deliver it).
   over 200 rounds with real threads and a start latch, and asserts both effects survive; the
   read-modify-write shape it replaced loses the addition on the first round.
 
-  **Compatibility: BREAKING.** Two source-level breaks, both deliberate, and both with a mechanical
-  migration.
+  **Compatibility: one deprecation and one source-level break**, both with a mechanical migration.
 
-  *`undoSingleCollapse`'s parameter list.* The four-argument form is gone. Migration:
+  *`undoSingleCollapse`'s parameter list.* The four-argument form stays, marked `@Deprecated`, with
+  the body it shipped with: it checks neither context ownership nor the audit records, so a caller
+  still on it keeps the behavior it had and gets a compiler warning naming the guarded form. It is
+  removed in the next minor release. Migration:
 
   ```kotlin
   // before
@@ -934,10 +936,10 @@ and the consumer PRs that deliver it).
 
   A caller with no `ContextId` to hand has to obtain one, which is the point: without it the call
   had no way to say whose collapse it was reversing. A caller with no `CollectorRecordStore` has to
-  wire one; passing null compiles and throws, so the gap surfaces immediately. The known consumer is
-  the assistant's `MemoryUnmergeService`, which already resolves the user's context and checks both
-  propositions against it before calling in — the migration hands the SPI work that service was
-  doing by hand, and its own checks can stay or go.
+  wire one; passing null compiles and throws, so the gap surfaces immediately. The known downstream
+  caller already resolves the user's context and checks both propositions against it before calling
+  in — the migration hands the SPI the work that service was doing by hand, and its own checks can
+  stay or go.
 
   *`PropositionStore.subtractProvenance`.* Removed along with its read-modify-write default. A store
   that declared `override fun subtractProvenance` stops compiling until it declares

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -851,7 +851,18 @@ and the consumer PRs that deliver it).
   the survivor's writes and the member's restore; and an undo returns null having written nothing
   when a survivor or retired member no longer exists, when the collapse cannot be shown to have been
   applied into this survivor, when that collapse has already been undone, or when the member is not
-  currently retired — where it could previously have saved the reduced survivor first. An undo
+  currently retired — where it could previously have saved the reduced survivor first. A survivor
+  deleted between the undo's read of it and the subtraction is caught at the subtraction, which
+  answers null for a proposition the store no longer has: the undo ends there rather than saving
+  back the copy it read, which would recreate the deleted proposition with the folded evidence still
+  on it. The member stays retired, no stamp is written, and the null return says truthfully that no
+  restore happened. How much of the run that covers depends on the store: the graph backend's
+  override answers from a read taken after its one-statement delete, so its null is exact and only
+  the gap before the survivor's `save` stays open, while the read-modify-write default — on a store
+  inheriting `setProvenance`'s default too — can recreate the survivor inside its own subtraction
+  and can hand back a proposition its first read saw. A
+  deletion later than the store's last look is not detected, and the survivor is recreated by an
+  upserting `save`; the design note records the residual per path and what closing it would take. An undo
   interrupted after its stamp resumes by restoring the member only, without re-deriving evidence. `undoSingleCollapse` gains a trailing optional
   `CollectorRecordStore` parameter and `@JvmOverloads`, so the existing four-argument descriptor
   survives for both Kotlin and Java callers; the four-argument form keeps the weaker status-based

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -683,10 +683,6 @@ and the consumer PRs that deliver it).
   `clearProvenance`, which previously sat only on `PropositionRepository`, so evidence-sensitive
   callers can depend on the capability without probing for a richer type at runtime. Design note:
   [docs/design/source-revisions.md](docs/design/source-revisions.md).
-  **Interim limitation.** Collapse records fold references as plain locator keys until the collector
-  slice lands, so undoing a collapse that folded revisioned evidence leaves those entries on the
-  survivor; evidence is retained, never wrongly deleted. `ProvenanceEvidenceKey` is the codec that
-  will make those references exact.
   **Compatibility: additive, with a scoped ABI boundary.** Source, JSON, and Java
   constructor-descriptor compatibility are claimed: existing Kotlin and Java call sites compile
   unchanged, provenance JSON written before this change loads and round-trips with a null revision,
@@ -778,3 +774,93 @@ and the consumer PRs that deliver it).
   by an exactly matching revisionless entry. A graph written by a build of the previous entry in this
   block holds prefix-less keys that this build does not recognise, and re-saving that evidence adds a
   second edge for it; clearing such a development store is the whole of the fix.
+
+- Precise undo of a collapse that folded revisioned evidence (third slice of DICE #64).
+  `RetiredProposition` gains `foldedProvenanceEvidenceKeys`, one `ProvenanceEvidenceKey` per entry a
+  fold actually added to the survivor, and `MultiSignalCollectorStrategy` records it. Recording by
+  locator key alone was wrong in two ways, both now fixed: a loser citing `r2` of a document the
+  survivor already cited at `r1` shares that survivor's locator key, so the fold recorded nothing and
+  `r2` stayed on the survivor after an undo; and a bare locator key matches revisionless evidence
+  only, so a recorded ref could not reach a revisioned entry either. `undoSingleCollapse` now
+  subtracts evidence through a new `PropositionStore.subtractProvenance`, which names the refs to
+  remove — the ordinary `save` on the graph backend appends provenance and deletes no edge, so the
+  folded rows used to outlive the undo, and the authoritative replace that would remove them has to
+  name what *stays*, silently discarding evidence a concurrent extraction added since the read.
+  `subtractProvenance` ships with that read-modify-write as its default, documented, and
+  `DrivinePropositionRepository` overrides it with one statement that deletes the named edges and
+  prunes only their orphaned sources. Undo also reads both the survivor and the retired proposition
+  before writing anything, so a collapse whose participants have since been deleted leaves nothing
+  half-written. It also authorizes on two conditions rather than trusting the trace: the collapse
+  must be one the collector applied *into this survivor*, and it must still be in force.
+
+  The first condition needed a fact nothing recorded, so `CollectorRecord` gains `mergedIntoId` —
+  the survivor a sweep actually folded a proposition into, written by `DefaultCollectorRunner` only
+  after the merge is saved. Three different outcomes used to be indistinguishable from an applied
+  merge: a `StatusTransitionSweepPolicy` retirement, the fallback retirement the runner performs
+  when a merge target has vanished or is no longer active, and a member marked as a duplicate of
+  several survivors by different strategies, where only one merge ran. All three now leave
+  `mergedIntoId` null or naming the real target. The field is written identically on every record a
+  run writes for a proposition, which matters because `DrivineCollectorRecordStore` MERGEs on
+  (`propositionId`, `runId`) and keeps one row per member per run while the in-memory store keeps
+  one per mark — reading a merge target off a mark gave different answers on the two stores.
+  `undoSingleCollapse` takes an optional `CollectorRecordStore` and, given one, requires a non-dry
+  run and a record naming this survivor as the applied target.
+
+  The second condition is that the undo has not already run, which needed a second new field:
+  `CollectorRecord.undoneAt`, stamped by `undoSingleCollapse` when it finishes. Audit records never
+  expire, so without it a member re-retired later by anything at all — a decay sweep, a second
+  collector run — would re-arm the original undo and let it subtract that run's evidence a second
+  time, taking evidence the survivor had since re-gained and clobbering the newer retirement. A
+  store keyed by (proposition, run) updates its row in place; one that appends leaves the original
+  beside the stamped copy, and any stamped record for the pair settles it. Replaying a collector
+  outcome no longer erases the stamp — `DrivineCollectorRecordStore` writes it through `coalesce`,
+  and `CollectorRecordStore.record` states that requirement for other implementations. The stamp is
+  written after the survivor's evidence comes off but before the member's status is restored, so
+  every interruption of an undo is recoverable: before the stamp a retry re-runs the whole thing
+  (the subtraction is recomputed from current evidence, so it removes nothing twice), and after it a
+  retry completes the restore alone and touches no evidence. Recognising that half-finished state
+  needs the record to say where the collapse left the member and no other run to have *written* the
+  member since — counted over `TRANSITIONED` and `HARD_DELETED` records from non-dry runs, since a
+  `SKIPPED` record states a run left it alone and a dry run changes nothing. The member's own status is checked as
+  well, and is all a caller without records has. It costs one deliberate false
+  refusal — a member whose undo has not run and which has since revived to its prior status reads as
+  never retired, and refusing leaves evidence alone where accepting could delete it silently. A
+  sibling's folded refs are held on the survivor only until that sibling's own undo has run — read
+  from its `undoneAt` when records are supplied, so a sibling undone and then retired again by a
+  later run no longer reads as still participating — and undoing every member of a shared fold
+  returns the survivor to its pre-collapse evidence instead of pinning the shared entry forever.
+  The survivor's evidence subtraction now completes before the save that a decorator such as
+  `EventEmittingPropositionRepository` publishes from, so a listener sees the post-undo state.
+  `DrivineCollectorTraceStore` persists and reads the new field. Tests fold a
+  revisioned loser into a survivor, undo, and assert the survivor's evidence and its `DERIVED_FROM`
+  edge count are exactly what they were before the fold, in memory and against Neo4j. Design note:
+  [docs/design/source-revisions.md](docs/design/source-revisions.md).
+  **Compatibility: additive, with the same scoped ABI boundary as the first slice.** `@JvmOverloads`
+  on `RetiredProposition` preserves the five-argument Java constructor descriptor and adds one on the
+  end; full Kotlin synthetic constructor and `copy` ABI is not claimed, since adding a field to a
+  data class changes `copy`/`componentN` and the synthetic `$default` constructor. Stored traces need
+  no migration: a `:CollectorRetired` row written before this change has no
+  `foldedProvenanceEvidenceKeys` property, reads back with an empty list, and undoes at locator
+  granularity exactly as it did. Evidence keys are left out of the JSON view of a trace, so existing
+  trace JSON is unchanged and a trace that goes through JSON comes back undoing at locator
+  granularity. Three behavioural notes for hosts: undo now issues a `subtractProvenance` call *before* the
+  survivor's `save`, so a custom `PropositionStore` sees that call — and gets the documented
+  read-modify-write default unless it overrides — while the event a save decorator publishes
+  describes the survivor's final state; undo writes to the record
+  store when one is supplied, re-recording the run's row for the member with `undoneAt` set between
+  the survivor's writes and the member's restore; and an undo returns null having written nothing
+  when a survivor or retired member no longer exists, when the collapse cannot be shown to have been
+  applied into this survivor, when that collapse has already been undone, or when the member is not
+  currently retired — where it could previously have saved the reduced survivor first. An undo
+  interrupted after its stamp resumes by restoring the member only, without re-deriving evidence. `undoSingleCollapse` gains a trailing optional
+  `CollectorRecordStore` parameter and `@JvmOverloads`, so the existing four-argument descriptor
+  survives for both Kotlin and Java callers; the four-argument form keeps the weaker status-based
+  check, documented as such in its KDoc. `PropositionStore` gains `subtractProvenance` with a
+  default implementation, so every existing store compiles and behaves as before.
+  `CollectorRecord` gains trailing optional `mergedIntoId` and
+  `undoneAt` fields, keeping every existing constructor and `of(...)` descriptor through the
+  `@JvmOverloads` already on both; audit rows written before this change carry neither property and
+  read back as no merge and no undo, which is the right answer for a graph that predates them. Undo
+  now reads each sibling of a collapse, so a decision with many retired members
+  costs one extra read per
+  member.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -970,3 +970,14 @@ and the consumer PRs that deliver it).
 
   No stored data changes, and nothing in the provenance, trace or audit record shapes moves. Design
   note: [docs/design/source-revisions.md](docs/design/source-revisions.md).
+
+- Capability honesty in the event-emitting decorator. `EventEmittingPropositionRepository` is now
+  generic over its delegate, carrying `ProvenanceSubtractionCapable` only when its delegate does,
+  through `ProvenanceSubtractingEventEmittingPropositionRepository`. The base type drops the
+  provenance-subtraction surface. The same factory shape that built a `SourceRevisionQueryCapable`
+  wrapper picks the capability-matching shape, so a caller's `as? ProvenanceSubtractionCapable` or
+  `as? SourceRevisionQueryCapable` probe on the wrapper answers the way it answers on the delegate.
+  **Compatibility: source-breaking** for a caller that held the base `EventEmittingPropositionRepository`
+  type and called `subtractFoldedEvidence` on it. Direct constructor calls and `wrapping` calls keep
+  compiling; a caller that needs the operation must hold the typed shape `ProvenanceSubtractingEventEmittingPropositionRepository`
+  or probe with `as?`.

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/CollectorTraceRowMappers.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/CollectorTraceRowMappers.kt
@@ -117,6 +117,7 @@ object CollectorDecisionRowMapper {
         "foldedGrounding" to retired.foldedGrounding,
         "foldedProvenanceRefs" to retired.foldedProvenanceRefs,
         "foldedSourceIds" to retired.foldedSourceIds,
+        "foldedProvenanceEvidenceKeys" to retired.foldedProvenanceEvidenceKeys,
     )
 
     fun fromRow(row: Map<*, *>, retired: List<RetiredProposition>): CollectorDecision = CollectorDecision(
@@ -133,6 +134,8 @@ object CollectorDecisionRowMapper {
         foldedGrounding = row.stringList("foldedGrounding"),
         foldedProvenanceRefs = row.stringList("foldedProvenanceRefs"),
         foldedSourceIds = row.stringList("foldedSourceIds"),
+        // A row written before evidence keys existed has no such property, and reads back empty.
+        foldedProvenanceEvidenceKeys = row.stringList("foldedProvenanceEvidenceKeys"),
     )
 }
 

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivineCollectorRecordStore.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivineCollectorRecordStore.kt
@@ -33,6 +33,18 @@ import org.springframework.transaction.annotation.Transactional
  * [LineageSchema] declares, built from that same key, so a retried record updates the node already
  * there and the uniqueness constraint protecting it always covers what the write matched on. Every
  * statement is parameterized; user-derived values are never interpolated into Cypher.
+ *
+ * The natural key is (`propositionId`, `runId`), so one proposition marked by several strategies in
+ * one run keeps **one** row here and the last write wins — where the in-memory store keeps one row
+ * per mark. Anything a reader needs to trust across both stores has to be identical on every record
+ * a run writes for a proposition, which is why `mergedIntoId` carries the survivor the sweep
+ * actually merged into rather than the one an individual mark proposed.
+ *
+ * `undoneAt` is the exception to last-write-wins, and it has to be: replaying an outcome is
+ * supported, and a replayed record carries no stamp, so a plain `SET` would clear one already
+ * stored and re-authorize a collapse that was undone. It is written through `coalesce` instead, so
+ * a stamp arriving wins and a replay preserves whatever is there. The append-only in-memory store
+ * gets the same property for free, since the stamped record stays beside the replayed one.
  */
 @Transactional
 class DrivineCollectorRecordStore(
@@ -54,7 +66,9 @@ class DrivineCollectorRecordStore(
                     n.strategyName   = ${'$'}strategyName,
                     n.at             = ${'$'}at,
                     n.previousStatus = ${'$'}previousStatus,
-                    n.newStatus      = ${'$'}newStatus
+                    n.newStatus      = ${'$'}newStatus,
+                    n.mergedIntoId   = ${'$'}mergedIntoId,
+                    n.undoneAt       = coalesce(${'$'}undoneAt, n.undoneAt)
                 """.trimIndent(),
             ).bind(CollectorRecordRowMapper.bindMap(record)),
         )

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStore.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStore.kt
@@ -44,7 +44,8 @@ import java.time.Instant
  * - `(:CollectorDecision {id, runId, contextId, componentId, survivorId, action, createdAt})`
  *   with `id = "runId|componentId"`, plus one child
  *   `(:CollectorRetired {id, runId, contextId, propositionId, priorStatus, foldedGrounding,
- *   foldedProvenanceRefs, foldedSourceIds})-[:RETIRED_IN]->(:CollectorDecision)` per retired
+ *   foldedProvenanceRefs, foldedSourceIds, foldedProvenanceEvidenceKeys})
+ *   -[:RETIRED_IN]->(:CollectorDecision)` per retired
  *   proposition, so a reversal has everything a merging sweep folded onto the survivor.
  *
  * Every write is a single `UNWIND $rows AS r ...` round trip (see [com.embabel.dice.storage.CollectorTraceRowMappers] for
@@ -227,7 +228,8 @@ class DrivineCollectorTraceStore(
                 retired: [r IN retiredNodes WHERE r IS NOT NULL | {
                     propositionId: r.propositionId, priorStatus: r.priorStatus,
                     foldedGrounding: r.foldedGrounding, foldedProvenanceRefs: r.foldedProvenanceRefs,
-                    foldedSourceIds: r.foldedSourceIds
+                    foldedSourceIds: r.foldedSourceIds,
+                    foldedProvenanceEvidenceKeys: r.foldedProvenanceEvidenceKeys
                 }]
             } AS row
             """.trimIndent(),

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStore.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStore.kt
@@ -270,6 +270,22 @@ class DrivineCollectorTraceStore(
         }.onFailure { logger.warn("Skipping unreadable CollectorDecision row: {}", it.message) }.getOrNull()
     }
 
+    /** The newest decision that retired [propositionId]. Never one where it only survived. */
+    @Transactional(readOnly = true)
+    override fun findDecisionRetiring(propositionId: String): CollectorDecision? {
+        val node = queryRows(
+            """
+            MATCH (:CollectorRetired {propositionId: ${'$'}propositionId})-[:RETIRED_IN]->(d:CollectorDecision)
+            RETURN d ORDER BY d.createdAt DESC LIMIT 1
+            """.trimIndent(),
+            mapOf("propositionId" to propositionId),
+        ).firstOrNull() ?: return null
+        return runCatching {
+            val decisionId = node["id"]?.toString().orEmpty()
+            CollectorDecisionRowMapper.fromRow(node, retiredFor(decisionId))
+        }.onFailure { logger.warn("Skipping unreadable CollectorDecision row: {}", it.message) }.getOrNull()
+    }
+
     private fun retiredFor(decisionId: String): List<RetiredProposition> =
         queryRows(
             "MATCH (ret:CollectorRetired {decisionId: \$decisionId}) RETURN ret",

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
@@ -560,48 +560,76 @@ class DrivinePropositionRepository(
     }
 
     /**
-     * Subtract exactly the named evidence in one statement, without reading the proposition first.
+     * Take a whole fold off the proposition in one statement, without reading it first.
      *
      * This is how the store honours [ProvenanceSubtractionCapable]: naming what stays would mean
      * reading the entries, filtering, and replacing, and evidence another writer adds in between
-     * would be replaced away. Naming what goes closes that window. One `MATCH`/`DELETE` deletes the
-     * edges by their own identity and leaves every other edge on the proposition untouched, whenever
-     * it arrived, and Neo4j runs it as one transaction — so the read and the write the contract
-     * talks about land together. Nothing is written to the proposition node itself, so a proposition
-     * another writer has already deleted stays deleted.
+     * would be replaced away. Naming what goes closes that window. One statement deletes the named
+     * `DERIVED_FROM` edges by their own identity, prunes only the sources those edges pointed at,
+     * and rewrites the `grounding` and `sourceIds` lists with the named members taken out, and Neo4j
+     * runs all of it as one transaction, so the read and the write the contract talks about land
+     * together. A `save` after the evidence subtraction would write the survivor's evidence back
+     * from a copy taken before it, which is exactly the window this statement is here to close.
+     * Nothing else on the node is touched, and a proposition another writer has already deleted
+     * matches nothing and stays deleted.
      *
      * Two ref forms, matching the evidence-key contract. A minted key is compared against the
      * edge's `entryKey`, so it removes one entry. A bare locator key predates revisions and matches
      * revisionless evidence for that source only, which is why the second predicate requires a null
-     * `sourceRevision` — it also reaches edges written before `entryKey` existed. A ref carrying the
+     * `sourceRevision`; it also reaches edges written before `entryKey` existed. A ref carrying the
      * codec's prefix but an unknown version matches no stored key, so it removes nothing.
      *
-     * @return the proposition as the deletion left it, or null when this store has no proposition
-     *   with that id. Both branches answer from a fresh read, so a deleted id
-     *   answers null whether or not any refs were named. Collector undo reads that null as the
-     *   survivor having been deleted while it was working and stops rather than writing, so the
-     *   meaning is load-bearing — `subtractProvenance answers null for a proposition that is not
-     *   there` pins it.
+     * The revision clocks move only when something actually came off, so a subtraction that names
+     * nothing the proposition holds leaves it exactly as it was.
+     *
+     * @return the proposition as the subtraction left it, or null when this store has no proposition
+     *   with that id. Both branches answer from a fresh read, so a deleted id answers null whether
+     *   or not anything was named. Collector undo reads that null as the survivor having been
+     *   deleted while it was working and stops there, so the meaning is load-bearing;
+     *   `subtractProvenance answers null for a proposition that is not there` pins it.
      */
     @Transactional
-    override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {
-        if (provenanceRefs.isEmpty()) return findById(propositionId)
+    override fun subtractFoldedEvidence(
+        propositionId: String,
+        provenanceRefs: List<String>,
+        grounding: Collection<String>,
+        sourceIds: Collection<String>,
+    ): Proposition? {
+        if (provenanceRefs.isEmpty() && grounding.isEmpty() && sourceIds.isEmpty()) return findById(propositionId)
         val (encodedRefs, legacyKeys) = provenanceRefs.partition { it.startsWith(EVIDENCE_KEY_PREFIX) }
         persistenceManager.execute(
             QuerySpecification.withStatement(
                 """
-                MATCH (p:Proposition {id: ${'$'}propositionId})-[r:DERIVED_FROM]->(s:Source)
+                MATCH (p:Proposition {id: ${'$'}propositionId})
+                OPTIONAL MATCH (p)-[r:DERIVED_FROM]->(s:Source)
                 WHERE (r.entryKey IS NOT NULL AND r.entryKey IN ${'$'}encodedRefs)
                    OR (r.sourceRevision IS NULL AND s.key IN ${'$'}legacyKeys)
-                WITH collect(DISTINCT s) AS touched, collect(r) AS doomed
+                WITH p, collect(DISTINCT s) AS touched, collect(r) AS doomed
+                WITH p, touched, doomed,
+                     coalesce(p.grounding, []) AS oldGrounding,
+                     coalesce(p.sourceIds, []) AS oldSourceIds
+                WITH p, touched, doomed, oldGrounding, oldSourceIds,
+                     [g IN oldGrounding WHERE NOT g IN ${'$'}grounding] AS keptGrounding,
+                     [sid IN oldSourceIds WHERE NOT sid IN ${'$'}sourceIds] AS keptSourceIds
+                WITH p, touched, doomed, keptGrounding, keptSourceIds,
+                     (size(doomed) > 0
+                        OR size(keptGrounding) < size(oldGrounding)
+                        OR size(keptSourceIds) < size(oldSourceIds)) AS changed
                 FOREACH (rel IN doomed | DELETE rel)
                 FOREACH (orphan IN [src IN touched WHERE NOT (src)--()] | DELETE orphan)
+                SET p.grounding = keptGrounding,
+                    p.sourceIds = keptSourceIds,
+                    p.metadataRevised = CASE WHEN changed THEN ${'$'}now ELSE p.metadataRevised END,
+                    p.lastTouched = CASE WHEN changed THEN ${'$'}now ELSE p.lastTouched END
                 """.trimIndent()
             ).bind(
                 mapOf(
                     "propositionId" to propositionId,
                     "encodedRefs" to encodedRefs,
                     "legacyKeys" to legacyKeys,
+                    "grounding" to grounding.toList(),
+                    "sourceIds" to sourceIds.toList(),
+                    "now" to Instant.now(),
                 ),
             ),
         )

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
@@ -27,6 +27,7 @@ import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionQuery
 import com.embabel.dice.proposition.PropositionQuery.OrderBy
 import com.embabel.dice.proposition.PropositionRepository
+import com.embabel.dice.proposition.ProvenanceSubtractionCapable
 import com.embabel.dice.proposition.GraphQueryCapable
 import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.proposition.SourceRevisionQueryCapable
@@ -127,7 +128,7 @@ class DrivinePropositionRepository(
      * [findClusters] Cypher. Defaults to the canonical [VECTOR_INDEX]; overridable only for tests.
      */
     private val vectorIndexName: String = VECTOR_INDEX,
-) : PropositionRepository, GraphQueryCapable, SourceRevisionQueryCapable {
+) : PropositionRepository, GraphQueryCapable, SourceRevisionQueryCapable, ProvenanceSubtractionCapable {
 
     private val logger = LoggerFactory.getLogger(DrivinePropositionRepository::class.java)
 
@@ -561,10 +562,13 @@ class DrivinePropositionRepository(
     /**
      * Subtract exactly the named evidence in one statement, without reading the proposition first.
      *
-     * The base contract's default has to name what stays, so it reads the entries, filters, and
-     * replaces — and evidence another writer adds in between is replaced away. Naming what goes
-     * closes that window: this deletes edges by their own identity and leaves every other edge on
-     * the proposition untouched, whenever it arrived.
+     * This is how the store honours [ProvenanceSubtractionCapable]: naming what stays would mean
+     * reading the entries, filtering, and replacing, and evidence another writer adds in between
+     * would be replaced away. Naming what goes closes that window. One `MATCH`/`DELETE` deletes the
+     * edges by their own identity and leaves every other edge on the proposition untouched, whenever
+     * it arrived, and Neo4j runs it as one transaction — so the read and the write the contract
+     * talks about land together. Nothing is written to the proposition node itself, so a proposition
+     * another writer has already deleted stays deleted.
      *
      * Two ref forms, matching the evidence-key contract. A minted key is compared against the
      * edge's `entryKey`, so it removes one entry. A bare locator key predates revisions and matches

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
@@ -559,6 +559,45 @@ class DrivinePropositionRepository(
     }
 
     /**
+     * Subtract exactly the named evidence in one statement, without reading the proposition first.
+     *
+     * The base contract's default has to name what stays, so it reads the entries, filters, and
+     * replaces — and evidence another writer adds in between is replaced away. Naming what goes
+     * closes that window: this deletes edges by their own identity and leaves every other edge on
+     * the proposition untouched, whenever it arrived.
+     *
+     * Two ref forms, matching the evidence-key contract. A minted key is compared against the
+     * edge's `entryKey`, so it removes one entry. A bare locator key predates revisions and matches
+     * revisionless evidence for that source only, which is why the second predicate requires a null
+     * `sourceRevision` — it also reaches edges written before `entryKey` existed. A ref carrying the
+     * codec's prefix but an unknown version matches no stored key, so it removes nothing.
+     */
+    @Transactional
+    override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {
+        if (provenanceRefs.isEmpty()) return findById(propositionId)
+        val (encodedRefs, legacyKeys) = provenanceRefs.partition { it.startsWith(EVIDENCE_KEY_PREFIX) }
+        persistenceManager.execute(
+            QuerySpecification.withStatement(
+                """
+                MATCH (p:Proposition {id: ${'$'}propositionId})-[r:DERIVED_FROM]->(s:Source)
+                WHERE (r.entryKey IS NOT NULL AND r.entryKey IN ${'$'}encodedRefs)
+                   OR (r.sourceRevision IS NULL AND s.key IN ${'$'}legacyKeys)
+                WITH collect(DISTINCT s) AS touched, collect(r) AS doomed
+                FOREACH (rel IN doomed | DELETE rel)
+                FOREACH (orphan IN [src IN touched WHERE NOT (src)--()] | DELETE orphan)
+                """.trimIndent()
+            ).bind(
+                mapOf(
+                    "propositionId" to propositionId,
+                    "encodedRefs" to encodedRefs,
+                    "legacyKeys" to legacyKeys,
+                ),
+            ),
+        )
+        return findById(propositionId)
+    }
+
+    /**
      * Drop the edges this replacement no longer wants, then prune only the sources those edges
      * pointed at.
      *
@@ -1382,6 +1421,13 @@ class DrivinePropositionRepository(
     companion object {
         /** Stripe count for save-time dedup locks. */
         private const val DEDUP_STRIPES = 64
+
+        /**
+         * What every minted evidence key starts with. A ref lacking it is a locator key from before
+         * revisions existed. Locator keys are kind-prefixed (`uri:`, `file:`, `content:`,
+         * `connector:`), so the two forms cannot be confused.
+         */
+        private const val EVIDENCE_KEY_PREFIX = "dice-provenance:"
 
         /**
          * The node label and embedding property the proposition vector index covers. These mirror

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/DrivinePropositionRepository.kt
@@ -571,6 +571,13 @@ class DrivinePropositionRepository(
      * revisionless evidence for that source only, which is why the second predicate requires a null
      * `sourceRevision` — it also reaches edges written before `entryKey` existed. A ref carrying the
      * codec's prefix but an unknown version matches no stored key, so it removes nothing.
+     *
+     * @return the proposition as the deletion left it, or null when this store has no proposition
+     *   with that id. Both branches answer from a fresh read, so a deleted id
+     *   answers null whether or not any refs were named. Collector undo reads that null as the
+     *   survivor having been deleted while it was working and stops rather than writing, so the
+     *   meaning is load-bearing — `subtractProvenance answers null for a proposition that is not
+     *   there` pins it.
      */
     @Transactional
     override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {

--- a/dice-storage/src/main/kotlin/com/embabel/dice/storage/LineageRowMappers.kt
+++ b/dice-storage/src/main/kotlin/com/embabel/dice/storage/LineageRowMappers.kt
@@ -76,6 +76,11 @@ object CollectorRecordRowMapper {
         "at" to record.at.toString(),
         "previousStatus" to record.previousStatus?.name,
         "newStatus" to record.newStatus?.name,
+        // The survivor the sweep actually merged into, which the reason above cannot supply: one
+        // proposition can be marked a duplicate of several survivors and merged into only one.
+        "mergedIntoId" to record.mergedIntoId,
+        // Set once collapse undo has reversed the merge, so the row cannot authorize a second one.
+        "undoneAt" to record.undoneAt?.toString(),
     )
 
     /** Rebuild a [CollectorRecord], reconstructing the typed reason and the optional statuses. */
@@ -93,6 +98,9 @@ object CollectorRecordRowMapper {
         at = parseInstant(row.strOrNull("at")),
         previousStatus = row.statusOrNull("previousStatus"),
         newStatus = row.statusOrNull("newStatus"),
+        // Absent on rows written before this property existed, which read back as no merge.
+        mergedIntoId = row.strOrNull("mergedIntoId"),
+        undoneAt = row.strOrNull("undoneAt")?.let { parseInstant(it) },
     )
 }
 

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/CollectorTraceRowMapperTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/CollectorTraceRowMapperTest.kt
@@ -35,6 +35,7 @@ class CollectorTraceRowMapperTest {
             foldedGrounding = listOf("g1", "g2"),
             foldedProvenanceRefs = listOf("prov-1"),
             foldedSourceIds = listOf("src-1", "src-2"),
+            foldedProvenanceEvidenceKeys = listOf("dice-provenance:v1:evidence-1"),
         )
 
         val bindMap = CollectorDecisionRowMapper.retiredBindMap("run-1", mockDecision(), retired)
@@ -45,6 +46,23 @@ class CollectorTraceRowMapperTest {
         assertEquals(listOf("g1", "g2"), roundTripped.foldedGrounding)
         assertEquals(listOf("prov-1"), roundTripped.foldedProvenanceRefs)
         assertEquals(listOf("src-1", "src-2"), roundTripped.foldedSourceIds)
+        assertEquals(listOf("dice-provenance:v1:evidence-1"), roundTripped.foldedProvenanceEvidenceKeys)
+    }
+
+    @Test
+    fun `a retired row written before evidence keys existed stays readable`() {
+        val legacyRow = mapOf(
+            "propositionId" to "prop-1",
+            "priorStatus" to "ACTIVE",
+            "foldedGrounding" to emptyList<String>(),
+            "foldedProvenanceRefs" to listOf("uri:https://example.com/source"),
+            "foldedSourceIds" to emptyList<String>(),
+        )
+
+        val retired = CollectorDecisionRowMapper.retiredFromRow(legacyRow)
+
+        assertEquals(listOf("uri:https://example.com/source"), retired.foldedProvenanceRefs)
+        assertEquals(emptyList<String>(), retired.foldedProvenanceEvidenceKeys)
     }
 
     @Test

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStoreIntegrationTest.kt
@@ -16,11 +16,19 @@
 package com.embabel.dice.storage
 
 import com.embabel.agent.core.ContextId
+import com.embabel.dice.projection.lineage.CollectorOutcome
+import com.embabel.dice.projection.lineage.CollectorRecord
+import com.embabel.dice.projection.lineage.CollectorRun
 import com.embabel.dice.projection.memory.collector.CollectorRunContext
 import com.embabel.dice.projection.memory.collector.CollectorSurvivorPolicy
 import com.embabel.dice.projection.memory.collector.MultiSignalCollectorStrategy
 import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
+import com.embabel.dice.proposition.PropositionStore
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
+import com.embabel.dice.provenance.UriLocator
 import com.embabel.dice.spi.CandidatePair
 import com.embabel.dice.spi.CandidatePairSource
 import com.embabel.dice.spi.CollectorCandidateEdge
@@ -29,6 +37,7 @@ import com.embabel.dice.spi.CollectorDecision
 import com.embabel.dice.spi.CollectorSignalScore
 import com.embabel.dice.spi.CollectorSignalScorer
 import com.embabel.dice.spi.InMemoryConnectedComponentsFinder
+import com.embabel.dice.spi.MarkReason
 import com.embabel.dice.spi.RetiredProposition
 import com.embabel.dice.spi.undoSingleCollapse
 import org.drivine.manager.PersistenceManager
@@ -42,6 +51,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import java.time.Instant
 
 /**
  * Integration tests for [DrivineCollectorTraceStore] against a Neo4j testcontainer. Each test
@@ -68,9 +78,12 @@ class DrivineCollectorTraceStoreIntegrationTest {
     @Autowired
     private lateinit var propositionRepository: DrivinePropositionRepository
 
+    @Autowired
+    private lateinit var recordStore: DrivineCollectorRecordStore
+
     @AfterEach
     fun cleanUp() {
-        CollectorTraceSchema.LABELS.forEach { label ->
+        (CollectorTraceSchema.LABELS + listOf("CollectorRecord", "CollectorRun")).forEach { label ->
             persistenceManager.execute(QuerySpecification.withStatement("MATCH (n:$label) DETACH DELETE n"))
         }
         propositionRepository.clearAll()
@@ -81,6 +94,7 @@ class DrivineCollectorTraceStoreIntegrationTest {
         text: String,
         status: PropositionStatus = PropositionStatus.ACTIVE,
         grounding: List<String> = emptyList(),
+        provenance: List<ProvenanceEntry> = emptyList(),
     ) = Proposition(
         id = id,
         contextId = ContextId("ctx-undo"),
@@ -89,7 +103,50 @@ class DrivineCollectorTraceStoreIntegrationTest {
         confidence = 0.9,
         status = status,
         grounding = grounding,
+        provenanceEntries = provenance,
     )
+
+    private fun derivedFromEdges(propositionId: String): Long =
+        persistenceManager.getOne(
+            QuerySpecification
+                .withStatement("MATCH (:Proposition {id: \$id})-[r:DERIVED_FROM]->() RETURN count(r) AS c")
+                .bind(mapOf("id" to propositionId))
+                .transform(Long::class.java),
+        )
+
+    /** A deterministic one-pair collapse, so the trace under test comes from the real strategy. */
+    private fun collapsingStrategy(survivorId: String) = MultiSignalCollectorStrategy(
+        pairSources = listOf(
+            CandidatePairSource { candidates, _ -> listOf(CandidatePair(anchor = candidates[0], member = candidates[1])) },
+        ),
+        scorers = listOf(CollectorSignalScorer { _, _ -> CollectorSignalScore(signal = "fixed", score = 1.0) }),
+        componentsFinder = InMemoryConnectedComponentsFinder(),
+        traceStore = traceStore,
+        survivorPolicy = CollectorSurvivorPolicy { members -> members.single { it.id == survivorId } },
+        matchThreshold = 0.5,
+    )
+
+    /** Counts the writes an undo attempts, so "nothing was written" is an assertion. */
+    private class RecordingPropositionRepository(
+        private val delegate: PropositionRepository,
+    ) : PropositionRepository by delegate {
+
+        var writes = 0
+            private set
+
+        override fun save(proposition: Proposition): Proposition {
+            writes++
+            return delegate.save(proposition)
+        }
+
+        override fun setProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? {
+            writes++
+            return delegate.setProvenance(propositionId, entries)
+        }
+    }
+
+    /** A caller holding nothing richer than the base store contract. */
+    private class BaseStoreView(delegate: PropositionRepository) : PropositionStore by delegate
 
     private fun edge(anchorId: String, memberId: String, vetoed: Boolean = false, score: Double = 0.9) = CollectorCandidateEdge(
         anchorId = anchorId,
@@ -115,6 +172,7 @@ class DrivineCollectorTraceStoreIntegrationTest {
                 foldedGrounding = listOf("g1", "g2"),
                 foldedProvenanceRefs = listOf("prov-1"),
                 foldedSourceIds = listOf("src-1", "src-2"),
+                foldedProvenanceEvidenceKeys = listOf("dice-provenance:v1:evidence-1"),
             ),
         ),
     )
@@ -150,6 +208,7 @@ class DrivineCollectorTraceStoreIntegrationTest {
         assertEquals(listOf("g1", "g2"), retired.foldedGrounding)
         assertEquals(listOf("prov-1"), retired.foldedProvenanceRefs)
         assertEquals(listOf("src-1", "src-2"), retired.foldedSourceIds)
+        assertEquals(listOf("dice-provenance:v1:evidence-1"), retired.foldedProvenanceEvidenceKeys)
     }
 
     @Test
@@ -225,6 +284,8 @@ class DrivineCollectorTraceStoreIntegrationTest {
         assertEquals("R4", retirement?.propositionId)
         assertEquals(PropositionStatus.ACTIVE, retirement?.priorStatus)
         assertEquals(listOf("g1", "g2"), retirement?.foldedGrounding)
+        // The path undo reads: the whole node, not the projected decision row.
+        assertEquals(listOf("dice-provenance:v1:evidence-1"), retirement?.foldedProvenanceEvidenceKeys)
 
         assertNull(traceStore.findRetirement("S4")) // survivor id, not a retired member
         assertNull(traceStore.findRetirement("unknown"))
@@ -323,9 +384,12 @@ class DrivineCollectorTraceStoreIntegrationTest {
 
         strategy.mark(listOf(survivor, loser), propositionRepository, CollectorRunContext(runId, contextId))
 
-        // Merge the loser's evidence onto the survivor the way DefaultCollectorRunner would.
+        // Merge the loser's evidence onto the survivor and retire it, the way
+        // DefaultCollectorRunner would. Undo reads the retirement off the loser's status, so a
+        // fold that never transitioned it is not an applied fold.
         val mergedSurvivor = propositionRepository.findById(survivor.id)!!.absorbEvidence(loser)
         propositionRepository.save(mergedSurvivor)
+        propositionRepository.save(propositionRepository.findById(loser.id)!!.withStatus(PropositionStatus.STALE))
 
         val decision = traceStore.findDecisionsByRun(runId).single()
         val retired = decision.retired.single { it.propositionId == loser.id }
@@ -349,5 +413,289 @@ class DrivineCollectorTraceStoreIntegrationTest {
         // (a) the survivor keeps "shared" — it owned that ref before the merge.
         // (b) the survivor loses "loser-exclusive" — that one really did come from the loser.
         assertEquals(setOf("shared"), updatedSurvivor?.grounding?.toSet())
+    }
+
+    @Test
+    fun `folding a revisioned loser and undoing leaves the survivor's evidence as it was`() {
+        // The survivor cites r1 of a document; the loser cites r1 and r2. Both revisions share one
+        // locator key, so a fold recorded by locator key alone would name nothing, and r2 would sit
+        // on the survivor after the undo with an edge nobody can account for.
+        val runId = "run-revision-undo"
+        val locator = UriLocator("https://example.com/revision-undo")
+        val revisionOne = ProvenanceEntry(locator = locator, sourceRevision = "r1")
+        val revisionTwo = ProvenanceEntry(locator = locator, sourceRevision = "r2")
+        val survivor = propositionRepository.save(
+            prop("survivor-revision", "Acme signed the agreement", provenance = listOf(revisionOne)),
+        )
+        val loser = propositionRepository.save(
+            prop("loser-revision", "Acme signed an agreement", provenance = listOf(revisionOne, revisionTwo)),
+        )
+        val evidenceBeforeTheFold = propositionRepository.findById(survivor.id)!!.provenanceEntries
+        assertEquals(listOf(revisionOne), evidenceBeforeTheFold)
+        assertEquals(1L, derivedFromEdges(survivor.id))
+
+        collapsingStrategy(survivor.id).mark(
+            listOf(survivor, loser),
+            propositionRepository,
+            CollectorRunContext(runId, survivor.contextId),
+        )
+        propositionRepository.save(propositionRepository.findById(survivor.id)!!.absorbEvidence(loser))
+        propositionRepository.save(propositionRepository.findById(loser.id)!!.withStatus(PropositionStatus.STALE))
+
+        assertEquals(
+            setOf(revisionOne, revisionTwo),
+            propositionRepository.findById(survivor.id)!!.provenanceEntries.toSet(),
+        )
+        assertEquals(2L, derivedFromEdges(survivor.id))
+        assertEquals(
+            listOf(ProvenanceEvidenceKey.encode(revisionTwo)),
+            traceStore.findRetirement(loser.id)?.foldedProvenanceEvidenceKeys,
+        )
+
+        undoSingleCollapse(
+            traceQuery = traceStore,
+            propositions = propositionRepository,
+            survivorId = survivor.id,
+            retiredId = loser.id,
+        )
+
+        assertEquals(evidenceBeforeTheFold, propositionRepository.findById(survivor.id)?.provenanceEntries)
+        assertEquals(1L, derivedFromEdges(survivor.id))
+        assertEquals(PropositionStatus.ACTIVE, propositionRepository.findById(loser.id)?.status)
+    }
+
+    @Test
+    fun `undo removes folded evidence for a caller holding only the base store`() {
+        val runId = "run-base-store-undo"
+        val keep = ProvenanceEntry(UriLocator("https://example.com/base-store-undo/keep"))
+        val folded = ProvenanceEntry(UriLocator("https://example.com/base-store-undo/remove"))
+        val survivor = propositionRepository.save(
+            prop("survivor-base-store", "Acme signed the agreement", provenance = listOf(keep, folded)),
+        )
+        propositionRepository.save(
+            prop(
+                "retired-base-store",
+                "Acme signed an agreement",
+                status = PropositionStatus.STALE,
+                provenance = listOf(folded),
+            ),
+        )
+        traceStore.recordRunContext(runId, survivor.contextId)
+        traceStore.recordDecision(
+            runId,
+            CollectorDecision(
+                runId = runId,
+                componentId = "component-base-store",
+                survivorId = survivor.id,
+                action = "duplicate-merge",
+                retired = listOf(
+                    RetiredProposition(
+                        propositionId = "retired-base-store",
+                        priorStatus = PropositionStatus.ACTIVE,
+                        foldedProvenanceRefs = listOf(folded.locator.key()),
+                        foldedProvenanceEvidenceKeys = listOf(ProvenanceEvidenceKey.encode(folded)),
+                    ),
+                ),
+            ),
+        )
+
+        undoSingleCollapse(
+            traceQuery = traceStore,
+            propositions = BaseStoreView(propositionRepository),
+            survivorId = survivor.id,
+            retiredId = "retired-base-store",
+        )
+
+        assertEquals(listOf(keep), propositionRepository.findById(survivor.id)?.provenanceEntries)
+        assertEquals(1L, derivedFromEdges(survivor.id))
+    }
+
+    @Test
+    fun `undoing both members of a shared fold drains the survivor's edge back to pre-collapse`() {
+        // Two losers folded the same revision onto the survivor. Only the last undo may take it,
+        // and it must take the DERIVED_FROM edge with it — the whole point of routing evidence
+        // removal through setProvenance rather than save.
+        val runId = "run-shared-fold"
+        val locator = UriLocator("https://example.com/shared-fold")
+        val kept = ProvenanceEntry(locator = locator, sourceRevision = "r1")
+        val shared = ProvenanceEntry(locator = locator, sourceRevision = "r2")
+        val survivor = propositionRepository.save(
+            prop("survivor-shared", "Acme signed the agreement", provenance = listOf(kept, shared)),
+        )
+        propositionRepository.save(
+            prop("loser-a-shared", "Acme signed a deal", status = PropositionStatus.STALE, provenance = listOf(shared)),
+        )
+        propositionRepository.save(
+            prop("loser-b-shared", "Acme signed the deal", status = PropositionStatus.STALE, provenance = listOf(shared)),
+        )
+        val sharedKey = ProvenanceEvidenceKey.encode(shared)
+        traceStore.recordRunContext(runId, survivor.contextId)
+        traceStore.recordDecision(
+            runId,
+            CollectorDecision(
+                runId = runId,
+                componentId = "comp-shared-fold",
+                survivorId = survivor.id,
+                action = "duplicate-merge",
+                retired = listOf(
+                    RetiredProposition(
+                        propositionId = "loser-a-shared",
+                        priorStatus = PropositionStatus.ACTIVE,
+                        foldedProvenanceEvidenceKeys = listOf(sharedKey),
+                    ),
+                    RetiredProposition(
+                        propositionId = "loser-b-shared",
+                        priorStatus = PropositionStatus.ACTIVE,
+                        foldedProvenanceEvidenceKeys = listOf(sharedKey),
+                    ),
+                ),
+            ),
+        )
+        assertEquals(2L, derivedFromEdges(survivor.id))
+
+        undoSingleCollapse(traceStore, propositionRepository, survivor.id, "loser-a-shared")
+
+        assertEquals(
+            setOf(kept, shared),
+            propositionRepository.findById(survivor.id)!!.provenanceEntries.toSet(),
+        )
+        assertEquals(2L, derivedFromEdges(survivor.id))
+
+        undoSingleCollapse(traceStore, propositionRepository, survivor.id, "loser-b-shared")
+
+        assertEquals(listOf(kept), propositionRepository.findById(survivor.id)?.provenanceEntries)
+        assertEquals(1L, derivedFromEdges(survivor.id))
+        assertEquals(PropositionStatus.ACTIVE, propositionRepository.findById("loser-a-shared")?.status)
+        assertEquals(PropositionStatus.ACTIVE, propositionRepository.findById("loser-b-shared")?.status)
+    }
+
+    @Test
+    fun `on the graph store one record survives per member and it names the applied merge target`() {
+        // The audit store MERGEs on (propositionId, runId), so a member marked by two strategies
+        // keeps ONE row here and the last write wins. Reading the merge target off the mark would
+        // therefore report whichever mark happened to be written last — here, a survivor the sweep
+        // never merged into. The applied target is written on every one of the member's records, so
+        // it is the same answer whichever row survives.
+        val runId = "run-overwrite"
+        val locator = UriLocator("https://example.com/overwrite")
+        val kept = ProvenanceEntry(locator = locator, sourceRevision = "r1")
+        val disputed = ProvenanceEntry(locator = locator, sourceRevision = "r2")
+        val appliedSurvivor = propositionRepository.save(
+            prop("survivor-applied-target", "Acme signed the agreement", provenance = listOf(kept, disputed)),
+        )
+        val bystander = propositionRepository.save(
+            prop("survivor-never-merged", "Acme closed the round", provenance = listOf(kept, disputed)),
+        )
+        propositionRepository.save(
+            prop(
+                "loser-overwrite",
+                "Acme signed an agreement",
+                status = PropositionStatus.STALE,
+                provenance = listOf(disputed),
+            ),
+        )
+        // The trace names the bystander as survivor — the collapse some strategy proposed.
+        traceStore.recordRunContext(runId, bystander.contextId)
+        traceStore.recordDecision(
+            runId,
+            CollectorDecision(
+                runId = runId,
+                componentId = "comp-overwrite",
+                survivorId = bystander.id,
+                action = "duplicate-merge",
+                retired = listOf(
+                    RetiredProposition(
+                        propositionId = "loser-overwrite",
+                        priorStatus = PropositionStatus.ACTIVE,
+                        foldedProvenanceEvidenceKeys = listOf(ProvenanceEvidenceKey.encode(disputed)),
+                    ),
+                ),
+            ),
+        )
+        recordStore.recordRun(CollectorRun(runId = runId, startedAt = Instant.now(), dryRun = false))
+        // Two marks, written in the order the runner writes them, both carrying the applied target.
+        recordStore.record(collectorRecord(runId, "loser-overwrite", proposed = appliedSurvivor.id, applied = appliedSurvivor.id))
+        recordStore.record(collectorRecord(runId, "loser-overwrite", proposed = bystander.id, applied = appliedSurvivor.id))
+
+        // The overwrite is real: one row, and its reason names the LAST mark written.
+        val stored = recordStore.findByProposition("loser-overwrite").single()
+        assertEquals(bystander.id, (stored.reason as MarkReason.Duplicate).survivorId)
+        assertEquals(appliedSurvivor.id, stored.mergedIntoId)
+
+        val result = undoSingleCollapse(traceStore, propositionRepository, bystander.id, "loser-overwrite", recordStore)
+
+        assertNull(result)
+        assertEquals(
+            setOf(kept, disputed),
+            propositionRepository.findById(bystander.id)!!.provenanceEntries.toSet(),
+            "the survivor the sweep never merged into keeps everything it owns",
+        )
+        assertEquals(2L, derivedFromEdges(bystander.id))
+    }
+
+    private fun collectorRecord(runId: String, propositionId: String, proposed: String, applied: String?) =
+        CollectorRecord(
+            propositionId = propositionId,
+            reason = MarkReason.Duplicate(survivorId = proposed),
+            outcome = CollectorOutcome.TRANSITIONED,
+            strategyName = "strategy-$proposed",
+            runId = runId,
+            previousStatus = PropositionStatus.ACTIVE,
+            newStatus = PropositionStatus.STALE,
+            mergedIntoId = applied,
+        )
+
+    @Test
+    fun `undo writes nothing when the retired proposition is missing`() {
+        val runId = "run-missing-retired"
+        val evidence = ProvenanceEntry(UriLocator("https://example.com/missing-retired"))
+        val survivor = propositionRepository.save(
+            prop("survivor-missing-retired", "Survivor remains", provenance = listOf(evidence)),
+        )
+        traceStore.recordRunContext(runId, survivor.contextId)
+        traceStore.recordDecision(
+            runId,
+            decisionFor("comp-missing-retired", survivorId = survivor.id, retiredId = "missing-retired"),
+        )
+        val before = propositionRepository.findAll().sortedBy { it.id }
+        val recording = RecordingPropositionRepository(propositionRepository)
+
+        val result = undoSingleCollapse(
+            traceQuery = traceStore,
+            propositions = recording,
+            survivorId = survivor.id,
+            retiredId = "missing-retired",
+        )
+
+        assertNull(result)
+        assertEquals(0, recording.writes)
+        assertEquals(before, propositionRepository.findAll().sortedBy { it.id })
+        assertEquals(1L, derivedFromEdges(survivor.id))
+    }
+
+    @Test
+    fun `undo writes nothing when the survivor proposition is missing`() {
+        val runId = "run-missing-survivor"
+        val retired = propositionRepository.save(
+            prop("retired-missing-survivor", "Retired remains", status = PropositionStatus.STALE),
+        )
+        traceStore.recordRunContext(runId, retired.contextId)
+        traceStore.recordDecision(
+            runId,
+            decisionFor("comp-missing-survivor", survivorId = "missing-survivor", retiredId = retired.id),
+        )
+        val before = propositionRepository.findAll().sortedBy { it.id }
+        val recording = RecordingPropositionRepository(propositionRepository)
+
+        val result = undoSingleCollapse(
+            traceQuery = traceStore,
+            propositions = recording,
+            survivorId = "missing-survivor",
+            retiredId = retired.id,
+        )
+
+        assertNull(result)
+        assertEquals(0, recording.writes)
+        assertEquals(before, propositionRepository.findAll().sortedBy { it.id })
     }
 }

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStoreIntegrationTest.kt
@@ -18,6 +18,7 @@ package com.embabel.dice.storage
 import com.embabel.agent.core.ContextId
 import com.embabel.dice.projection.lineage.CollectorOutcome
 import com.embabel.dice.projection.lineage.CollectorRecord
+import com.embabel.dice.projection.lineage.CollectorRecordStore
 import com.embabel.dice.projection.lineage.CollectorRun
 import com.embabel.dice.projection.memory.collector.CollectorRunContext
 import com.embabel.dice.projection.memory.collector.CollectorSurvivorPolicy
@@ -26,10 +27,12 @@ import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.proposition.PropositionStore
+import com.embabel.dice.proposition.ProvenanceSubtractionCapable
 import com.embabel.dice.provenance.ProvenanceEntry
 import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import com.embabel.dice.provenance.UriLocator
 import com.embabel.dice.spi.CandidatePair
+import com.embabel.dice.spi.CollapseUndoCommand
 import com.embabel.dice.spi.CandidatePairSource
 import com.embabel.dice.spi.CollectorCandidateEdge
 import com.embabel.dice.spi.CollectorComponent
@@ -89,6 +92,35 @@ class DrivineCollectorTraceStoreIntegrationTest {
         propositionRepository.clearAll()
     }
 
+    /** The context every fixture proposition below is built in, and the one an undo is issued for. */
+    private val undoContextId = ContextId("ctx-undo")
+
+    /**
+     * Calls the real entry point. Undo requires a context and an audit record store, so every test
+     * here goes through one place that supplies both.
+     */
+    private fun undo(
+        propositions: PropositionStore,
+        survivorId: String,
+        retiredId: String,
+        records: CollectorRecordStore? = recordStore,
+        context: ContextId = undoContextId,
+    ) = undoSingleCollapse(
+        command = CollapseUndoCommand(contextId = context, survivorId = survivorId, retiredId = retiredId),
+        traceQuery = traceStore,
+        propositions = propositions,
+        collectorRecords = records,
+    )
+
+    /**
+     * The audit trail a real merging sweep leaves behind: a live run header and a transition record
+     * naming the survivor it folded this member into. That pair is what authorizes an undo.
+     */
+    private fun authorize(runId: String, memberId: String, survivorId: String) {
+        recordStore.recordRun(CollectorRun(runId = runId, startedAt = Instant.now(), dryRun = false))
+        recordStore.record(collectorRecord(runId, memberId, proposed = survivorId, applied = survivorId))
+    }
+
     private fun prop(
         id: String,
         text: String,
@@ -128,8 +160,8 @@ class DrivineCollectorTraceStoreIntegrationTest {
 
     /** Counts the writes an undo attempts, so "nothing was written" is an assertion. */
     private class RecordingPropositionRepository(
-        private val delegate: PropositionRepository,
-    ) : PropositionRepository by delegate {
+        private val delegate: DrivinePropositionRepository,
+    ) : PropositionRepository by delegate, ProvenanceSubtractionCapable {
 
         var writes = 0
             private set
@@ -143,10 +175,25 @@ class DrivineCollectorTraceStoreIntegrationTest {
             writes++
             return delegate.setProvenance(propositionId, entries)
         }
+
+        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {
+            writes++
+            return delegate.subtractProvenance(propositionId, provenanceRefs)
+        }
     }
 
-    /** A caller holding nothing richer than the base store contract. */
-    private class BaseStoreView(delegate: PropositionRepository) : PropositionStore by delegate
+    /**
+     * What a caller holding no repository type sees: the base store contract plus the one capability
+     * undo insists on. The subtraction forwards to the Drivine repository, so this pins that undo
+     * needs nothing richer than that pair.
+     */
+    private class BaseStoreView(
+        private val delegate: DrivinePropositionRepository,
+    ) : PropositionStore by delegate, ProvenanceSubtractionCapable {
+
+        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? =
+            delegate.subtractProvenance(propositionId, provenanceRefs)
+    }
 
     private fun edge(anchorId: String, memberId: String, vetoed: Boolean = false, score: Double = 0.9) = CollectorCandidateEdge(
         anchorId = anchorId,
@@ -324,13 +371,9 @@ class DrivineCollectorTraceStoreIntegrationTest {
             ),
         )
         traceStore.recordDecision(runId, decision)
+        authorize(runId, "loserA-5", survivor.id)
 
-        val result = undoSingleCollapse(
-            traceQuery = traceStore,
-            propositions = propositionRepository,
-            survivorId = survivor.id,
-            retiredId = "loserA-5",
-        )
+        val result = undo(propositionRepository, survivor.id, "loserA-5")
 
         assertTrue(result != null)
         assertEquals(PropositionStatus.ACTIVE, result!!.restored.status)
@@ -395,13 +438,9 @@ class DrivineCollectorTraceStoreIntegrationTest {
         val retired = decision.retired.single { it.propositionId == loser.id }
         // The fix under test: only the delta the loser actually contributed is recorded.
         assertEquals(listOf("loser-exclusive"), retired.foldedGrounding)
+        authorize(runId, loser.id, survivor.id)
 
-        val result = undoSingleCollapse(
-            traceQuery = traceStore,
-            propositions = propositionRepository,
-            survivorId = survivor.id,
-            retiredId = loser.id,
-        )
+        val result = undo(propositionRepository, survivor.id, loser.id)
 
         assertTrue(result != null)
         assertEquals(PropositionStatus.ACTIVE, result!!.restored.status)
@@ -451,13 +490,9 @@ class DrivineCollectorTraceStoreIntegrationTest {
             listOf(ProvenanceEvidenceKey.encode(revisionTwo)),
             traceStore.findRetirement(loser.id)?.foldedProvenanceEvidenceKeys,
         )
+        authorize(runId, loser.id, survivor.id)
 
-        undoSingleCollapse(
-            traceQuery = traceStore,
-            propositions = propositionRepository,
-            survivorId = survivor.id,
-            retiredId = loser.id,
-        )
+        undo(propositionRepository, survivor.id, loser.id)
 
         assertEquals(evidenceBeforeTheFold, propositionRepository.findById(survivor.id)?.provenanceEntries)
         assertEquals(1L, derivedFromEdges(survivor.id))
@@ -465,7 +500,7 @@ class DrivineCollectorTraceStoreIntegrationTest {
     }
 
     @Test
-    fun `undo removes folded evidence for a caller holding only the base store`() {
+    fun `undo removes folded evidence for a caller holding the base store and the subtraction`() {
         val runId = "run-base-store-undo"
         val keep = ProvenanceEntry(UriLocator("https://example.com/base-store-undo/keep"))
         val folded = ProvenanceEntry(UriLocator("https://example.com/base-store-undo/remove"))
@@ -499,12 +534,9 @@ class DrivineCollectorTraceStoreIntegrationTest {
             ),
         )
 
-        undoSingleCollapse(
-            traceQuery = traceStore,
-            propositions = BaseStoreView(propositionRepository),
-            survivorId = survivor.id,
-            retiredId = "retired-base-store",
-        )
+        authorize(runId, "retired-base-store", survivor.id)
+
+        undo(BaseStoreView(propositionRepository), survivor.id, "retired-base-store")
 
         assertEquals(listOf(keep), propositionRepository.findById(survivor.id)?.provenanceEntries)
         assertEquals(1L, derivedFromEdges(survivor.id))
@@ -552,8 +584,10 @@ class DrivineCollectorTraceStoreIntegrationTest {
             ),
         )
         assertEquals(2L, derivedFromEdges(survivor.id))
+        authorize(runId, "loser-a-shared", survivor.id)
+        authorize(runId, "loser-b-shared", survivor.id)
 
-        undoSingleCollapse(traceStore, propositionRepository, survivor.id, "loser-a-shared")
+        undo(propositionRepository, survivor.id, "loser-a-shared")
 
         assertEquals(
             setOf(kept, shared),
@@ -561,7 +595,7 @@ class DrivineCollectorTraceStoreIntegrationTest {
         )
         assertEquals(2L, derivedFromEdges(survivor.id))
 
-        undoSingleCollapse(traceStore, propositionRepository, survivor.id, "loser-b-shared")
+        undo(propositionRepository, survivor.id, "loser-b-shared")
 
         assertEquals(listOf(kept), propositionRepository.findById(survivor.id)?.provenanceEntries)
         assertEquals(1L, derivedFromEdges(survivor.id))
@@ -622,7 +656,7 @@ class DrivineCollectorTraceStoreIntegrationTest {
         assertEquals(bystander.id, (stored.reason as MarkReason.Duplicate).survivorId)
         assertEquals(appliedSurvivor.id, stored.mergedIntoId)
 
-        val result = undoSingleCollapse(traceStore, propositionRepository, bystander.id, "loser-overwrite", recordStore)
+        val result = undo(propositionRepository, bystander.id, "loser-overwrite")
 
         assertNull(result)
         assertEquals(
@@ -660,12 +694,9 @@ class DrivineCollectorTraceStoreIntegrationTest {
         val before = propositionRepository.findAll().sortedBy { it.id }
         val recording = RecordingPropositionRepository(propositionRepository)
 
-        val result = undoSingleCollapse(
-            traceQuery = traceStore,
-            propositions = recording,
-            survivorId = survivor.id,
-            retiredId = "missing-retired",
-        )
+        authorize(runId, "missing-retired", survivor.id)
+
+        val result = undo(recording, survivor.id, "missing-retired")
 
         assertNull(result)
         assertEquals(0, recording.writes)
@@ -687,12 +718,9 @@ class DrivineCollectorTraceStoreIntegrationTest {
         val before = propositionRepository.findAll().sortedBy { it.id }
         val recording = RecordingPropositionRepository(propositionRepository)
 
-        val result = undoSingleCollapse(
-            traceQuery = traceStore,
-            propositions = recording,
-            survivorId = "missing-survivor",
-            retiredId = retired.id,
-        )
+        authorize(runId, retired.id, "missing-survivor")
+
+        val result = undo(recording, "missing-survivor", retired.id)
 
         assertNull(result)
         assertEquals(0, recording.writes)

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStoreIntegrationTest.kt
@@ -514,7 +514,7 @@ class DrivineCollectorTraceStoreIntegrationTest {
     fun `undoing both members of a shared fold drains the survivor's edge back to pre-collapse`() {
         // Two losers folded the same revision onto the survivor. Only the last undo may take it,
         // and it must take the DERIVED_FROM edge with it — the whole point of routing evidence
-        // removal through setProvenance rather than save.
+        // removal through subtractProvenance rather than save.
         val runId = "run-shared-fold"
         val locator = UriLocator("https://example.com/shared-fold")
         val kept = ProvenanceEntry(locator = locator, sourceRevision = "r1")

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStoreIntegrationTest.kt
@@ -274,6 +274,26 @@ class DrivineCollectorTraceStoreIntegrationTest {
     }
 
     @Test
+    fun `findDecisionRetiring ignores a decision the id survived and returns the newest retirement`() {
+        val contextId = ContextId("ctx-retiring")
+        traceStore.recordRunContext("run-survivor-only", contextId)
+        traceStore.recordDecision("run-survivor-only", decisionFor("comp-survivor-only", survivorId = "S", retiredId = "other"))
+
+        traceStore.recordRunContext("run-first-retiring", contextId)
+        traceStore.recordDecision("run-first-retiring", decisionFor("comp-first-retiring", survivorId = "B", retiredId = "S"))
+
+        // The two retirements of "S" need distinguishable createdAt timestamps to order by.
+        Thread.sleep(5)
+
+        traceStore.recordRunContext("run-second-retiring", contextId)
+        traceStore.recordDecision("run-second-retiring", decisionFor("comp-second-retiring", survivorId = "C", retiredId = "S"))
+
+        val retiring = traceStore.findDecisionRetiring("S")
+        assertEquals("comp-second-retiring", retiring?.componentId)
+        assertEquals("C", retiring?.survivorId)
+    }
+
+    @Test
     fun `deleteTracesForContext removes only that context's rows and leaves another context intact`() {
         val runA = "run-a"
         val runB = "run-b"

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineCollectorTraceStoreIntegrationTest.kt
@@ -176,9 +176,14 @@ class DrivineCollectorTraceStoreIntegrationTest {
             return delegate.setProvenance(propositionId, entries)
         }
 
-        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {
+        override fun subtractFoldedEvidence(
+            propositionId: String,
+            provenanceRefs: List<String>,
+            grounding: Collection<String>,
+            sourceIds: Collection<String>,
+        ): Proposition? {
             writes++
-            return delegate.subtractProvenance(propositionId, provenanceRefs)
+            return delegate.subtractFoldedEvidence(propositionId, provenanceRefs, grounding, sourceIds)
         }
     }
 
@@ -191,8 +196,13 @@ class DrivineCollectorTraceStoreIntegrationTest {
         private val delegate: DrivinePropositionRepository,
     ) : PropositionStore by delegate, ProvenanceSubtractionCapable {
 
-        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? =
-            delegate.subtractProvenance(propositionId, provenanceRefs)
+        override fun subtractFoldedEvidence(
+            propositionId: String,
+            provenanceRefs: List<String>,
+            grounding: Collection<String>,
+            sourceIds: Collection<String>,
+        ): Proposition? =
+            delegate.subtractFoldedEvidence(propositionId, provenanceRefs, grounding, sourceIds)
     }
 
     private fun edge(anchorId: String, memberId: String, vetoed: Boolean = false, score: Double = 0.9) = CollectorCandidateEdge(

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineLineageRecordStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivineLineageRecordStoreIntegrationTest.kt
@@ -197,6 +197,62 @@ class DrivineLineageRecordStoreIntegrationTest {
     }
 
     @Test
+    fun `the applied merge target and its undo stamp round-trip, and stamping updates in place`() {
+        val record = CollectorRecord(
+            propositionId = "p-merged",
+            reason = MarkReason.Duplicate("proposed-survivor"),
+            outcome = CollectorOutcome.TRANSITIONED,
+            strategyName = "dedup",
+            runId = "run-merge",
+            at = Instant.parse("2026-01-01T00:01:00Z"),
+            previousStatus = PropositionStatus.ACTIVE,
+            newStatus = PropositionStatus.STALE,
+            mergedIntoId = "applied-survivor",
+        )
+
+        collectorStore.record(record)
+        assertEquals(record, collectorStore.all().single())
+
+        // Finishing an undo re-records the same natural key with the stamp set.
+        val stamped = record.copy(undoneAt = Instant.parse("2026-01-02T00:00:00Z"))
+        collectorStore.record(stamped)
+
+        val reloaded = collectorStore.all().single()
+        assertEquals(stamped, reloaded)
+        assertEquals("applied-survivor", reloaded.mergedIntoId)
+        assertEquals(Instant.parse("2026-01-02T00:00:00Z"), reloaded.undoneAt)
+
+        // Replaying the original outcome must not wipe the stamp: a replayed record carries none,
+        // and a plain SET would clear the stored one and re-authorize the collapse.
+        collectorStore.record(record)
+
+        assertEquals(stamped, collectorStore.all().single())
+    }
+
+    @Test
+    fun `a collector row written before the merge and undo properties existed reads back without them`() {
+        // Simulates a graph written by an earlier build: the node has no mergedIntoId or undoneAt.
+        persistenceManager.execute(
+            QuerySpecification.withStatement(
+                """
+                CREATE (n:CollectorRecord {
+                    propositionId: 'p-legacy', runId: 'run-legacy', reason: 'duplicate',
+                    survivorId: 'survivor-legacy', outcome: 'TRANSITIONED', strategyName: 'dedup',
+                    at: '2026-01-01T00:00:00Z', previousStatus: 'ACTIVE', newStatus: 'STALE'
+                })
+                """.trimIndent(),
+            ),
+        )
+
+        val legacy = collectorStore.findByProposition("p-legacy").single()
+
+        assertNull(legacy.mergedIntoId, "an old row records no merge, so it cannot authorize an undo")
+        assertNull(legacy.undoneAt)
+        assertEquals("survivor-legacy", (legacy.reason as MarkReason.Duplicate).survivorId)
+        assertEquals(CollectorOutcome.TRANSITIONED, legacy.outcome)
+    }
+
+    @Test
     fun `collector record is idempotent on the same proposition-run pair`() {
         collectorStore.record(
             CollectorRecord("p1", MarkReason.Stale, CollectorOutcome.MARKED, "decay", "run-1"),

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -1758,16 +1758,20 @@ class DrivinePropositionStoreIntegrationTest {
     }
 
     @Test
-    fun `evidence added while a subtraction is in flight survives it on the graph backend`() {
-        // The race the subtractive operation exists for, forced deterministically, run twice over
-        // the same scenario: once on the base contract's read-modify-write default, once on this
-        // backend's override.
+    fun `evidence the subtraction does not name survives it on the graph backend`() {
+        // The property the subtractive operation exists for: only named evidence goes. The second
+        // half is the one that carries weight — a newcomer added before the call survives the
+        // override because its one delete statement names what goes and touches nothing else. The
+        // add completes before the subtraction starts, so this pins preservation, not concurrent
+        // interleaving; evidence is only ever at risk when it lands after the read that determines
+        // the remainder, which no sequential schedule reaches.
         //
-        // The two halves inject the concurrent write at different moments, and that asymmetry is
-        // the finding rather than a flaw in the harness. The default has a read to race with, so
-        // `ConcurrentAddOnRead` lands the newcomer exactly there. The override issues one statement
-        // and reads nothing, so there is no interior moment to aim at — the newcomer goes in
-        // immediately before the call, which is the worst case available to it.
+        // The first half does NOT currently demonstrate the default losing that newcomer, and the
+        // comment here used to claim it did. Kotlin interface delegation generates a forwarder for
+        // `subtractProvenance`, so `ConcurrentAddOnRead` hands the call straight to the delegate and
+        // its overridden `findById` is never reached: nothing is injected, and the assertion below
+        // holds for the ordinary reason that the subtraction removed `folded`. Exercising the
+        // default needs a store that does not override it at all, which delegation cannot give.
         val locator = UriLocator("https://example.com/subtract/race")
         val original = evidence(locator, null)
         val folded = evidence(locator, "r1")
@@ -1782,7 +1786,8 @@ class DrivinePropositionStoreIntegrationTest {
         assertEquals(
             setOf(original),
             repository.findById(viaDefault.id)?.provenanceEntries?.toSet(),
-            "the read-modify-write default replaces away the entry that arrived after its read",
+            "the subtraction removes the folded entry; see the note above about what this half does " +
+                "not show",
         )
 
         val viaOverride = repository.save(
@@ -1800,10 +1805,13 @@ class DrivinePropositionStoreIntegrationTest {
     }
 
     /**
-     * Lands [concurrent] on [propositionId] the first time anything reads it, which is where a
-     * read-modify-write subtraction is vulnerable. Deliberately does not override
-     * `subtractProvenance`, so the base contract's default runs against this decorator and takes its
-     * read from the overridden [findById].
+     * Lands [concurrent] on [propositionId] the first time anything reads it through this
+     * decorator, which is where a read-modify-write subtraction would be vulnerable.
+     *
+     * It does not reach the subtraction, though: interface delegation forwards
+     * `subtractProvenance` to [delegate], so the default never runs against this decorator and
+     * [findById] here is not called during that path. Kept because the injection point is the right
+     * one and a harness that can invoke the default would use it unchanged.
      */
     private class ConcurrentAddOnRead(
         private val delegate: DrivinePropositionRepository,
@@ -1836,6 +1844,28 @@ class DrivinePropositionStoreIntegrationTest {
 
         assertEquals(listOf(revisioned), updated?.provenanceEntries)
         assertEquals(1L, edgeCount(saved.id))
+    }
+
+    @Test
+    fun `subtractProvenance answers null for a proposition that is not there`() {
+        // Undo leans on this: a null answer is how it learns the survivor was deleted after it read
+        // it, and it stops there instead of saving its copy back. The override holds no earlier
+        // read to fall back on: the empty-refs branch is nothing but a fresh read, and the matched
+        // branch reads again after its delete statement — this pins that both answer null, and
+        // for an id the store never held.
+        val locator = UriLocator("https://example.com/subtract/deleted")
+        val entry = evidence(locator, "r1")
+        val saved = repository.save(
+            prop("deleted before subtract", context = "ctx-subtract-deleted", provenance = listOf(entry)),
+        )
+        assertTrue(repository.delete(saved.id))
+
+        assertNull(repository.subtractProvenance(saved.id, listOf(ProvenanceEvidenceKey.encode(entry))))
+        assertNull(
+            repository.subtractProvenance(saved.id, emptyList()),
+            "the empty-refs shortcut has to answer the same way",
+        )
+        assertNull(repository.subtractProvenance("never-existed-at-all", listOf(locator.key())))
     }
 
     private fun sourceCount(sourceKey: String): Long =

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -1828,6 +1828,45 @@ class DrivinePropositionStoreIntegrationTest {
         assertNull(repository.subtractProvenance("never-existed-at-all", listOf(locator.key())))
     }
 
+    @Test
+    fun `subtractFoldedEvidence takes evidence, grounding and source ids off in one step and leaves the rest`() {
+        // A collapse folds three things onto the survivor, and the undo takes all three off in the
+        // one statement, so nothing is saved over the survivor afterwards. The revision clock moves
+        // only when something actually came off.
+        val locator = UriLocator("https://example.com/subtract/fold")
+        val keep = evidence(locator, "r1")
+        val folded = evidence(locator, "r2")
+        val before = Instant.now().minusSeconds(60)
+        val saved = repository.save(
+            prop(
+                "whole fold",
+                context = "ctx-subtract-fold",
+                contentRevised = before,
+                grounding = listOf("chunk-keep", "chunk-folded"),
+                sourceIds = listOf("src-keep", "src-folded"),
+                provenance = listOf(keep, folded),
+            ),
+        )
+
+        val after = repository.subtractFoldedEvidence(
+            saved.id,
+            listOf(ProvenanceEvidenceKey.encode(folded)),
+            listOf("chunk-folded"),
+            listOf("src-folded"),
+        )
+
+        assertEquals(setOf(keep), after?.provenanceEntries?.toSet())
+        assertEquals(listOf("chunk-keep"), after?.grounding)
+        assertEquals(listOf("src-keep"), after?.sourceIds)
+        assertEquals(1L, edgeCount(saved.id))
+        assertTrue(after!!.metadataRevised.isAfter(before), "the metadata clock moves when something came off")
+        assertEquals(setOf(keep), repository.findById(saved.id)?.provenanceEntries?.toSet())
+
+        val untouched = repository.subtractFoldedEvidence(saved.id, emptyList(), listOf("chunk-not-there"), emptyList())
+        assertEquals(after.metadataRevised, untouched?.metadataRevised, "naming nothing it holds leaves the clocks alone")
+        assertEquals(listOf("chunk-keep"), untouched?.grounding)
+    }
+
     private fun sourceCount(sourceKey: String): Long =
         persistenceManager.getOne(
             QuerySpecification

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -26,9 +26,11 @@ import com.embabel.dice.proposition.EntityMention
 import com.embabel.dice.proposition.MentionRole
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionQuery
+import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.provenance.ConnectorRef
 import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import com.embabel.dice.provenance.SourceRevisionRef
 import com.embabel.dice.provenance.UriLocator
 import com.embabel.dice.temporal.TemporalMetadata
@@ -1725,6 +1727,123 @@ class DrivinePropositionStoreIntegrationTest {
             endOffset = endOffset,
             contentHash = contentHash,
             sourceRevision = revision,
+        )
+
+    @Test
+    fun `subtractProvenance removes exactly the named evidence and prunes only its orphaned source`() {
+        val kept = UriLocator("https://example.com/subtract/kept")
+        val dropped = UriLocator("https://example.com/subtract/dropped")
+        val keptRevisionOne = evidence(kept, "r1")
+        val keptRevisionTwo = evidence(kept, "r2")
+        val droppedEvidence = evidence(dropped, null)
+        val saved = repository.save(
+            prop(
+                "subtract exactly",
+                context = "ctx-subtract",
+                provenance = listOf(keptRevisionOne, keptRevisionTwo, droppedEvidence),
+            ),
+        )
+        assertEquals(3L, edgeCount(saved.id))
+
+        val updated = repository.subtractProvenance(
+            saved.id,
+            listOf(ProvenanceEvidenceKey.encode(keptRevisionTwo), ProvenanceEvidenceKey.encode(droppedEvidence)),
+        )
+
+        assertEquals(listOf(keptRevisionOne), updated?.provenanceEntries)
+        assertEquals(listOf(keptRevisionOne), repository.findById(saved.id)?.provenanceEntries)
+        assertEquals(1L, edgeCount(saved.id))
+        assertEquals(1L, sourceCount(kept.key()), "the shared source keeps its remaining revision")
+        assertEquals(0L, sourceCount(dropped.key()), "the source nothing cites any more is pruned")
+    }
+
+    @Test
+    fun `evidence added while a subtraction is in flight survives it on the graph backend`() {
+        // The race the subtractive operation exists for, forced deterministically, run twice over
+        // the same scenario: once on the base contract's read-modify-write default, once on this
+        // backend's override.
+        //
+        // The two halves inject the concurrent write at different moments, and that asymmetry is
+        // the finding rather than a flaw in the harness. The default has a read to race with, so
+        // `ConcurrentAddOnRead` lands the newcomer exactly there. The override issues one statement
+        // and reads nothing, so there is no interior moment to aim at — the newcomer goes in
+        // immediately before the call, which is the worst case available to it.
+        val locator = UriLocator("https://example.com/subtract/race")
+        val original = evidence(locator, null)
+        val folded = evidence(locator, "r1")
+        val concurrent = evidence(locator, "r2")
+        val refsToRemove = listOf(ProvenanceEvidenceKey.encode(folded))
+
+        val viaDefault = repository.save(
+            prop("default subtract", context = "ctx-subtract-race", provenance = listOf(original, folded)),
+        )
+        ConcurrentAddOnRead(repository, viaDefault.id, concurrent).subtractProvenance(viaDefault.id, refsToRemove)
+
+        assertEquals(
+            setOf(original),
+            repository.findById(viaDefault.id)?.provenanceEntries?.toSet(),
+            "the read-modify-write default replaces away the entry that arrived after its read",
+        )
+
+        val viaOverride = repository.save(
+            prop("atomic subtract", context = "ctx-subtract-race", provenance = listOf(original, folded)),
+        )
+        repository.addProvenance(viaOverride.id, listOf(concurrent))
+        repository.subtractProvenance(viaOverride.id, refsToRemove)
+
+        assertEquals(
+            setOf(original, concurrent),
+            repository.findById(viaOverride.id)?.provenanceEntries?.toSet(),
+            "the atomic subtraction removes the folded entry by name and leaves everything else",
+        )
+        assertEquals(2L, edgeCount(viaOverride.id))
+    }
+
+    /**
+     * Lands [concurrent] on [propositionId] the first time anything reads it, which is where a
+     * read-modify-write subtraction is vulnerable. Deliberately does not override
+     * `subtractProvenance`, so the base contract's default runs against this decorator and takes its
+     * read from the overridden [findById].
+     */
+    private class ConcurrentAddOnRead(
+        private val delegate: DrivinePropositionRepository,
+        private val propositionId: String,
+        private val concurrent: ProvenanceEntry,
+    ) : PropositionRepository by delegate {
+
+        private var injected = false
+
+        override fun findById(id: String): Proposition? {
+            val current = delegate.findById(id)
+            if (id == propositionId && !injected) {
+                injected = true
+                delegate.addProvenance(propositionId, listOf(concurrent))
+            }
+            return current
+        }
+    }
+
+    @Test
+    fun `subtractProvenance takes a legacy locator ref off revisionless evidence only`() {
+        val locator = UriLocator("https://example.com/subtract/legacy")
+        val revisionless = evidence(locator, null)
+        val revisioned = evidence(locator, "r1")
+        val saved = repository.save(
+            prop("legacy subtract", context = "ctx-subtract-legacy", provenance = listOf(revisionless, revisioned)),
+        )
+
+        val updated = repository.subtractProvenance(saved.id, listOf(locator.key()))
+
+        assertEquals(listOf(revisioned), updated?.provenanceEntries)
+        assertEquals(1L, edgeCount(saved.id))
+    }
+
+    private fun sourceCount(sourceKey: String): Long =
+        persistenceManager.getOne(
+            QuerySpecification
+                .withStatement("MATCH (s:Source {key: \$sourceKey}) RETURN count(s) AS c")
+                .bind(mapOf("sourceKey" to sourceKey))
+                .transform(Long::class.java),
         )
 
     private fun edgeCount(propositionId: String): Long =

--- a/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
+++ b/dice-storage/src/test/kotlin/com/embabel/dice/storage/DrivinePropositionStoreIntegrationTest.kt
@@ -1759,76 +1759,36 @@ class DrivinePropositionStoreIntegrationTest {
 
     @Test
     fun `evidence the subtraction does not name survives it on the graph backend`() {
-        // The property the subtractive operation exists for: only named evidence goes. The second
-        // half is the one that carries weight — a newcomer added before the call survives the
-        // override because its one delete statement names what goes and touches nothing else. The
-        // add completes before the subtraction starts, so this pins preservation, not concurrent
-        // interleaving; evidence is only ever at risk when it lands after the read that determines
-        // the remainder, which no sequential schedule reaches.
+        // The property the operation exists for, and the one `ProvenanceSubtractionCapable` asks
+        // every implementation to promise: only named evidence goes. A newcomer added before the
+        // call survives, because the one delete statement names what goes and touches nothing else.
+        // The add completes before the subtraction starts, so this pins preservation on a
+        // sequential schedule; the true concurrent interleaving is pinned in memory by
+        // `evidence added while a subtraction is running survives it`, which needs threads the
+        // testcontainer schedule here cannot give deterministically.
         //
-        // The first half does NOT currently demonstrate the default losing that newcomer, and the
-        // comment here used to claim it did. Kotlin interface delegation generates a forwarder for
-        // `subtractProvenance`, so `ConcurrentAddOnRead` hands the call straight to the delegate and
-        // its overridden `findById` is never reached: nothing is injected, and the assertion below
-        // holds for the ordinary reason that the subtraction removed `folded`. Exercising the
-        // default needs a store that does not override it at all, which delegation cannot give.
+        // This used to have a second half aimed at the base contract's read-modify-write default,
+        // through a decorator that injected evidence on read. It never demonstrated the loss —
+        // Kotlin interface delegation forwarded the call straight past the decorator's `findById` —
+        // and the default it aimed at no longer exists, so it is gone with it.
         val locator = UriLocator("https://example.com/subtract/race")
         val original = evidence(locator, null)
         val folded = evidence(locator, "r1")
         val concurrent = evidence(locator, "r2")
         val refsToRemove = listOf(ProvenanceEvidenceKey.encode(folded))
 
-        val viaDefault = repository.save(
-            prop("default subtract", context = "ctx-subtract-race", provenance = listOf(original, folded)),
-        )
-        ConcurrentAddOnRead(repository, viaDefault.id, concurrent).subtractProvenance(viaDefault.id, refsToRemove)
-
-        assertEquals(
-            setOf(original),
-            repository.findById(viaDefault.id)?.provenanceEntries?.toSet(),
-            "the subtraction removes the folded entry; see the note above about what this half does " +
-                "not show",
-        )
-
-        val viaOverride = repository.save(
+        val subject = repository.save(
             prop("atomic subtract", context = "ctx-subtract-race", provenance = listOf(original, folded)),
         )
-        repository.addProvenance(viaOverride.id, listOf(concurrent))
-        repository.subtractProvenance(viaOverride.id, refsToRemove)
+        repository.addProvenance(subject.id, listOf(concurrent))
+        repository.subtractProvenance(subject.id, refsToRemove)
 
         assertEquals(
             setOf(original, concurrent),
-            repository.findById(viaOverride.id)?.provenanceEntries?.toSet(),
+            repository.findById(subject.id)?.provenanceEntries?.toSet(),
             "the atomic subtraction removes the folded entry by name and leaves everything else",
         )
-        assertEquals(2L, edgeCount(viaOverride.id))
-    }
-
-    /**
-     * Lands [concurrent] on [propositionId] the first time anything reads it through this
-     * decorator, which is where a read-modify-write subtraction would be vulnerable.
-     *
-     * It does not reach the subtraction, though: interface delegation forwards
-     * `subtractProvenance` to [delegate], so the default never runs against this decorator and
-     * [findById] here is not called during that path. Kept because the injection point is the right
-     * one and a harness that can invoke the default would use it unchanged.
-     */
-    private class ConcurrentAddOnRead(
-        private val delegate: DrivinePropositionRepository,
-        private val propositionId: String,
-        private val concurrent: ProvenanceEntry,
-    ) : PropositionRepository by delegate {
-
-        private var injected = false
-
-        override fun findById(id: String): Proposition? {
-            val current = delegate.findById(id)
-            if (id == propositionId && !injected) {
-                injected = true
-                delegate.addProvenance(propositionId, listOf(concurrent))
-            }
-            return current
-        }
+        assertEquals(2L, edgeCount(subject.id))
     }
 
     @Test

--- a/dice/src/main/kotlin/com/embabel/dice/projection/lineage/CollectorRecord.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/projection/lineage/CollectorRecord.kt
@@ -38,6 +38,26 @@ import java.time.Instant
  * @property at When this record was created
  * @property previousStatus The proposition's status before the outcome, or null if not applicable
  * @property newStatus The proposition's status after the outcome, or null if not applicable
+ * @property mergedIntoId The survivor this proposition's evidence was folded into, when the sweep
+ *   actually performed a merge. Null everywhere else — a plain status transition, a skip, a hard
+ *   delete, and the fallback retirement a runner does when a merge target has vanished or is no
+ *   longer active all leave it null, which is what separates them from a merge that ran. On a
+ *   preview record from a dry run it names the target the run would have merged into; the run
+ *   header's `dryRun` flag is what says nothing happened.
+ *
+ *   This is the *applied* target, not the one a mark proposed. A proposition can be marked as a
+ *   duplicate of several different survivors in one run while the sweep merges into exactly one of
+ *   them, so a reader that needs to know what really happened has to read this rather than the
+ *   reason. It is recorded identically on every record the run writes for this proposition, so a
+ *   store that keeps one row per (proposition, run) reports the same answer as one that keeps them
+ *   all.
+ * @property undoneAt When this run's merge was reversed, or null while it still stands. Written by
+ *   collapse undo once it has finished, so a record cannot authorize the same undo twice. Without
+ *   it the audit trail is immortal and says "applied" forever, and a member re-retired later by
+ *   anything at all — a decay sweep, a second collector run — would re-arm the original undo and
+ *   let it subtract that run's evidence a second time. A store that keeps one row per (proposition,
+ *   run) updates that row in place; one that appends leaves both, so a reader should treat *any*
+ *   record for the pair carrying this as the whole collapse being undone.
  */
 data class CollectorRecord @JvmOverloads constructor(
     val propositionId: String,
@@ -48,6 +68,8 @@ data class CollectorRecord @JvmOverloads constructor(
     val at: Instant = Instant.now(),
     val previousStatus: PropositionStatus? = null,
     val newStatus: PropositionStatus? = null,
+    val mergedIntoId: String? = null,
+    val undoneAt: Instant? = null,
 ) {
 
     init {
@@ -68,6 +90,8 @@ data class CollectorRecord @JvmOverloads constructor(
          * @param at When this record was created
          * @param previousStatus The proposition's status before the outcome
          * @param newStatus The proposition's status after the outcome
+         * @param mergedIntoId The survivor the sweep merged this proposition into, if it did
+         * @param undoneAt When that merge was reversed, or null while it stands
          */
         @JvmStatic
         @JvmOverloads
@@ -80,6 +104,8 @@ data class CollectorRecord @JvmOverloads constructor(
             at: Instant = Instant.now(),
             previousStatus: PropositionStatus? = null,
             newStatus: PropositionStatus? = null,
+            mergedIntoId: String? = null,
+            undoneAt: Instant? = null,
         ): CollectorRecord = CollectorRecord(
             propositionId = propositionId,
             reason = reason,
@@ -89,6 +115,8 @@ data class CollectorRecord @JvmOverloads constructor(
             at = at,
             previousStatus = previousStatus,
             newStatus = newStatus,
+            mergedIntoId = mergedIntoId,
+            undoneAt = undoneAt,
         )
     }
 }

--- a/dice/src/main/kotlin/com/embabel/dice/projection/lineage/CollectorRecordStore.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/projection/lineage/CollectorRecordStore.kt
@@ -31,6 +31,13 @@ interface CollectorRecordStore {
     /**
      * Record a collector outcome.
      *
+     * Replaying an outcome is supported and expected. An implementation that upserts on a natural
+     * key must not let a replay clear a stored [CollectorRecord.undoneAt]: the replayed record
+     * carries none, and dropping the stamp would re-authorize a collapse that has already been
+     * undone. Take the incoming value when it is non-null and keep the stored one otherwise. An
+     * append-only implementation satisfies this by construction, since the stamped record survives
+     * alongside the replayed one.
+     *
      * @param record The collector record to store
      */
     fun record(record: CollectorRecord)

--- a/dice/src/main/kotlin/com/embabel/dice/projection/memory/DefaultCollectorRunner.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/projection/memory/DefaultCollectorRunner.kt
@@ -140,7 +140,13 @@ class DefaultCollectorRunner(
                     is SweepAction.TransitionStatus ->
                         records += records(decision.marks, runId, CollectorOutcome.MARKED, proposition.status, action.newStatus)
                     is SweepAction.MergeInto ->
-                        records += records(decision.marks, runId, CollectorOutcome.MARKED, proposition.status, action.thenStatus)
+                        // The preview's target, unresolved: a real run walks survivor chains and
+                        // breaks cycles before merging. The run header's dryRun flag is what says
+                        // this did not happen.
+                        records += records(
+                            decision.marks, runId, CollectorOutcome.MARKED, proposition.status, action.thenStatus,
+                            mergedIntoId = action.survivorId,
+                        )
                     SweepAction.HardDelete ->
                         records += records(decision.marks, runId, CollectorOutcome.MARKED, proposition.status, null)
                     SweepAction.Skip -> {
@@ -266,7 +272,13 @@ class DefaultCollectorRunner(
                 freshById[survivorId] = savedSurvivor
                 for ((decision, action) in group) {
                     val loser = freshById.getValue(decision.propositionId)
-                    val saved = retire(loser, action.thenStatus, decision.marks, runId, records, applied)
+                    // The merge is done, so each loser's records name the survivor it landed on.
+                    // This is the only place that fact exists: a loser's marks may propose several
+                    // survivors, and only one of them received the evidence.
+                    val saved = retire(
+                        loser, action.thenStatus, decision.marks, runId, records, applied,
+                        mergedIntoId = survivorId,
+                    )
                     freshById[decision.propositionId] = saved
                 }
             }
@@ -383,6 +395,12 @@ class DefaultCollectorRunner(
      *
      * @return the saved proposition, so a caller tracking per-run freshest state can cache it.
      */
+    /**
+     * @param mergedIntoId the survivor this proposition's evidence was just folded into, or null
+     *   when it is being retired without a merge. Recorded on every one of its marks' records so
+     *   an audit store that keeps one row per (proposition, run) answers the same as one that keeps
+     *   them all.
+     */
     private fun retire(
         proposition: Proposition,
         newStatus: PropositionStatus,
@@ -390,10 +408,11 @@ class DefaultCollectorRunner(
         runId: String,
         records: MutableList<CollectorRecord>,
         applied: MutableList<PropositionMark>,
+        mergedIntoId: String? = null,
     ): Proposition {
         val previousStatus = proposition.status
         val saved = repository.save(proposition.withStatus(newStatus))
-        records += records(propMarks, runId, CollectorOutcome.TRANSITIONED, previousStatus, newStatus)
+        records += records(propMarks, runId, CollectorOutcome.TRANSITIONED, previousStatus, newStatus, mergedIntoId)
         applied.addAll(propMarks)
         emitStatusChanged(saved, previousStatus, newStatus, propMarks)
         return saved
@@ -405,6 +424,7 @@ class DefaultCollectorRunner(
         outcome: CollectorOutcome,
         previousStatus: PropositionStatus?,
         newStatus: PropositionStatus?,
+        mergedIntoId: String? = null,
     ): List<CollectorRecord> = propMarks.map { mark ->
         CollectorRecord(
             propositionId = mark.propositionId,
@@ -414,6 +434,7 @@ class DefaultCollectorRunner(
             runId = runId,
             previousStatus = previousStatus,
             newStatus = newStatus,
+            mergedIntoId = mergedIntoId,
         )
     }
 

--- a/dice/src/main/kotlin/com/embabel/dice/projection/memory/collector/MultiSignalCollectorStrategy.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/projection/memory/collector/MultiSignalCollectorStrategy.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.core.ContextId
 import com.embabel.dice.projection.memory.RunAwareCollectorStrategy
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionRepository
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import com.embabel.dice.spi.CandidatePair
 import com.embabel.dice.spi.CandidatePairSource
 import com.embabel.dice.spi.CollectorCandidateEdge
@@ -305,16 +306,31 @@ class MultiSignalCollectorStrategy(
             // set: absorbEvidence is a deduplicating union, so any ref the survivor already owned
             // pre-merge (common for near-duplicates from the same source) must not be recorded as
             // "folded", or undo would later strip evidence the survivor held independently.
+            //
+            // Evidence is compared by its full evidence key, so one document read at two revisions
+            // counts as two pieces of evidence: a survivor citing r1 does not hide the loser's r2,
+            // and undo can name r2 exactly. The locator keys stay beside them for trace readers and
+            // for consumers still reading the older field.
             val survivorGrounding = survivor.grounding.toSet()
-            val survivorProvenanceRefs = survivor.provenanceEntries.map { it.locator.key() }.toSet()
+            val survivorProvenanceRefs = survivor.provenanceEntries
+                .map { it.locator.key() }
+                .toSet()
+            val survivorEvidenceKeys = survivor.provenanceEntries
+                .map(ProvenanceEvidenceKey::encode)
+                .toSet()
             val survivorSourceIds = survivor.sourceIds.toSet()
             val retired = losers.map { loser ->
                 RetiredProposition(
                     propositionId = loser.id,
                     priorStatus = loser.status,
                     foldedGrounding = loser.grounding - survivorGrounding,
-                    foldedProvenanceRefs = loser.provenanceEntries.map { it.locator.key() } - survivorProvenanceRefs,
+                    foldedProvenanceRefs = loser.provenanceEntries
+                        .map { it.locator.key() }
+                        .distinct() - survivorProvenanceRefs,
                     foldedSourceIds = loser.sourceIds - survivorSourceIds,
+                    foldedProvenanceEvidenceKeys = loser.provenanceEntries
+                        .map(ProvenanceEvidenceKey::encode)
+                        .distinct() - survivorEvidenceKeys,
                 )
             }
             trace("recordDecision") {

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingPropositionRepository.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingPropositionRepository.kt
@@ -49,10 +49,10 @@ import org.slf4j.LoggerFactory
  * Throw isolation is the listener's responsibility — wrap the listener in `SafeDiceEventListener`
  * if you need graceful degradation.
  *
- * This class does not itself implement `SourceRevisionQueryCapable`, so it carries the capability
- * only when its delegate does: use [wrapping] to build the right shape for whatever delegate you
- * hand it, so a caller's `as? SourceRevisionQueryCapable` probe on the wrapper answers the same way
- * it would on the delegate.
+ * This class carries capabilities only when its delegate does. The [wrapping] factory method
+ * picks the right shape for whatever delegate you hand it, so a caller's `as? SourceRevisionQueryCapable`
+ * or `as? ProvenanceSubtractionCapable` probe on the wrapper answers the same way it would on the
+ * delegate.
  *
  * Example usage:
  * ```kotlin
@@ -65,37 +65,37 @@ import org.slf4j.LoggerFactory
  * @property delegate The underlying repository. All non-write methods forward here.
  * @property listener Notified after each persist. Defaults to [DiceEventListener.DEV_NULL] (no-op).
  */
-open class EventEmittingPropositionRepository(
-    protected val delegate: PropositionRepository,
+open class EventEmittingPropositionRepository<D : PropositionRepository>(
+    protected val delegate: D,
     private val listener: DiceEventListener = DiceEventListener.DEV_NULL,
-) : PropositionRepository by delegate, ProvenanceSubtractionCapable {
+) : PropositionRepository by delegate {
 
     private val logger = LoggerFactory.getLogger(EventEmittingPropositionRepository::class.java)
 
     companion object {
         /**
          * Build the decorator over [delegate], picking the shape that matches what [delegate] can
-         * do: when it implements [SourceRevisionQueryCapable], the returned instance does too and
-         * forwards to it, so a caller's `as?` probe on the wrapper answers the way it answers on the
-         * delegate. Over a plain repository, the returned instance carries no source-revision
-         * surface at all.
+         * do: when it implements [SourceRevisionQueryCapable] and [ProvenanceSubtractionCapable],
+         * the returned instance does too and forwards to both, so a caller's `as?` probe on the
+         * wrapper answers the way it answers on the delegate. Over a delegate with only provenance
+         * subtraction, the wrapper carries that capability alone. Over a plain repository, the
+         * returned instance carries no source-revision or provenance-subtraction surface at all.
          */
         @JvmStatic
         @JvmOverloads
         fun wrapping(
             delegate: PropositionRepository,
             listener: DiceEventListener = DiceEventListener.DEV_NULL,
-        ): EventEmittingPropositionRepository =
-            if (delegate is SourceRevisionQueryCapable) {
-                SourceRevisionEventEmittingPropositionRepository(delegate, listener)
-            } else {
-                EventEmittingPropositionRepository(delegate, listener)
+        ): EventEmittingPropositionRepository<out PropositionRepository> =
+            when {
+                delegate is SourceRevisionQueryCapable && delegate is ProvenanceSubtractionCapable ->
+                    SourceRevisionEventEmittingPropositionRepository(delegate, listener)
+                delegate is ProvenanceSubtractionCapable ->
+                    ProvenanceSubtractingEventEmittingPropositionRepository(delegate, listener)
+                else ->
+                    EventEmittingPropositionRepository(delegate, listener)
             }
     }
-
-    /** The delegate's atomic evidence subtraction, if it has one. Resolved once at construction. */
-    private val delegateSubtraction: ProvenanceSubtractionCapable? =
-        delegate as? ProvenanceSubtractionCapable
 
     /**
      * Persists via the delegate, then emits one lifecycle event carrying the saved instance.
@@ -175,47 +175,47 @@ open class EventEmittingPropositionRepository(
         query: PropositionQuery,
     ): List<Cluster<Proposition>> =
         delegate.findClusters(similarityThreshold, topK, query)
-
-    /** True only when the delegate this decorator was handed can subtract atomically. */
-    override val supportsProvenanceSubtraction: Boolean
-        get() = delegateSubtraction?.supportsProvenanceSubtraction == true
-
-    /**
-     * Forwards the atomic fold subtraction to the delegate, which is where the atomicity lives.
-     *
-     * This decorator instruments [save] alone, so the subtraction passes through unannounced, the
-     * same treatment the other provenance operations get through `by delegate`. Carrying the
-     * capability type matters because Kotlin's interface delegation only covers
-     * [PropositionRepository]: without this, wrapping a capable store would hide the capability
-     * from every caller that probes for it, and collector undo would refuse.
-     */
-    override fun subtractFoldedEvidence(
-        propositionId: String,
-        provenanceRefs: List<String>,
-        grounding: Collection<String>,
-        sourceIds: Collection<String>,
-    ): Proposition? =
-        (
-            delegateSubtraction
-                ?: throw UnsupportedOperationException(
-                    "subtractFoldedEvidence needs a delegate that implements ProvenanceSubtractionCapable; " +
-                        "${delegate.javaClass.name} cannot subtract evidence atomically",
-                )
-            ).subtractFoldedEvidence(propositionId, provenanceRefs, grounding, sourceIds)
 }
 
 /**
- * The same event-emitting decorator, over a delegate that also answers source-revision queries.
+ * The event-emitting decorator, over a delegate that can subtract provenance atomically.
  *
- * Carrying `SourceRevisionQueryCapable by delegate` here and not on the base class is what makes
- * the capability honest: a caller's `as? SourceRevisionQueryCapable` probe on this wrapper answers
- * exactly the way it would on the delegate. It cannot pass the type check and then fail at call
- * time. Built by [EventEmittingPropositionRepository.wrapping]; construct it directly only if you
+ * Carrying `ProvenanceSubtractionCapable by delegate` here and not on the base class is what makes
+ * the capability honest: a caller's `as? ProvenanceSubtractionCapable` probe on this wrapper answers
+ * exactly the way it would on the delegate. It cannot pass the type check and then fail at call time.
+ * The subtraction passes through unannounced, the same treatment the other provenance operations get
+ * through `by delegate`. Carrying the capability type matters because Kotlin's interface delegation
+ * only covers [PropositionRepository]: without this, wrapping a capable store would hide the
+ * capability from every caller that probes for it, and collector undo would refuse.
+ *
+ * Built by [EventEmittingPropositionRepository.wrapping]; construct it directly only if you
  * already have a delegate typed as both interfaces in hand.
  */
-class SourceRevisionEventEmittingPropositionRepository<T>(
-    delegate: T,
+class ProvenanceSubtractingEventEmittingPropositionRepository<D>(
+    delegate: D,
     listener: DiceEventListener = DiceEventListener.DEV_NULL,
-) : EventEmittingPropositionRepository(delegate, listener),
-    SourceRevisionQueryCapable by delegate
-    where T : PropositionRepository, T : SourceRevisionQueryCapable
+) : EventEmittingPropositionRepository<D>(delegate, listener),
+    ProvenanceSubtractionCapable by delegate
+    where D : PropositionRepository, D : ProvenanceSubtractionCapable
+
+/**
+ * The event-emitting decorator, over a delegate that answers both source-revision queries and
+ * provenance subtraction.
+ *
+ * Carrying `SourceRevisionQueryCapable by delegate` and `ProvenanceSubtractionCapable by delegate`
+ * here and not on the base class is what makes both capabilities honest: a caller's `as?` probe on
+ * this wrapper answers exactly the way it would on the delegate. It cannot pass the type check and
+ * then fail at call time. The two capabilities are paired here because every source-revision-capable
+ * store today also subtracts provenance; adding a fourth shape is a matter for the day a store needs
+ * it.
+ *
+ * Built by [EventEmittingPropositionRepository.wrapping]; construct it directly only if you
+ * already have a delegate typed as both interfaces in hand.
+ */
+class SourceRevisionEventEmittingPropositionRepository<D>(
+    delegate: D,
+    listener: DiceEventListener = DiceEventListener.DEV_NULL,
+) : EventEmittingPropositionRepository<D>(delegate, listener),
+    SourceRevisionQueryCapable by delegate,
+    ProvenanceSubtractionCapable by delegate
+    where D : PropositionRepository, D : ProvenanceSubtractionCapable, D : SourceRevisionQueryCapable

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingPropositionRepository.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingPropositionRepository.kt
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory
 open class EventEmittingPropositionRepository(
     protected val delegate: PropositionRepository,
     private val listener: DiceEventListener = DiceEventListener.DEV_NULL,
-) : PropositionRepository by delegate {
+) : PropositionRepository by delegate, ProvenanceSubtractionCapable {
 
     private val logger = LoggerFactory.getLogger(EventEmittingPropositionRepository::class.java)
 
@@ -92,6 +92,10 @@ open class EventEmittingPropositionRepository(
                 EventEmittingPropositionRepository(delegate, listener)
             }
     }
+
+    /** The delegate's atomic evidence subtraction, if it has one. Resolved once at construction. */
+    private val delegateSubtraction: ProvenanceSubtractionCapable? =
+        delegate as? ProvenanceSubtractionCapable
 
     /**
      * Persists via the delegate, then emits one lifecycle event carrying the saved instance.
@@ -171,6 +175,28 @@ open class EventEmittingPropositionRepository(
         query: PropositionQuery,
     ): List<Cluster<Proposition>> =
         delegate.findClusters(similarityThreshold, topK, query)
+
+    /** True only when the delegate this decorator was handed can subtract atomically. */
+    override val supportsProvenanceSubtraction: Boolean
+        get() = delegateSubtraction?.supportsProvenanceSubtraction == true
+
+    /**
+     * Forwards the atomic subtraction to the delegate, which is where the atomicity lives.
+     *
+     * This decorator instruments [save] alone, so the subtraction passes through unannounced —
+     * the same treatment the other provenance operations get through `by delegate`. Carrying the
+     * capability type matters because Kotlin's interface delegation only covers
+     * [PropositionRepository]: without this, wrapping a capable store would hide the capability
+     * from every caller that probes for it, and collector undo would refuse.
+     */
+    override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? =
+        (
+            delegateSubtraction
+                ?: throw UnsupportedOperationException(
+                    "subtractProvenance needs a delegate that implements ProvenanceSubtractionCapable; " +
+                        "${delegate.javaClass.name} cannot subtract evidence atomically",
+                )
+            ).subtractProvenance(propositionId, provenanceRefs)
 }
 
 /**

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingPropositionRepository.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/EventEmittingPropositionRepository.kt
@@ -181,22 +181,27 @@ open class EventEmittingPropositionRepository(
         get() = delegateSubtraction?.supportsProvenanceSubtraction == true
 
     /**
-     * Forwards the atomic subtraction to the delegate, which is where the atomicity lives.
+     * Forwards the atomic fold subtraction to the delegate, which is where the atomicity lives.
      *
-     * This decorator instruments [save] alone, so the subtraction passes through unannounced —
-     * the same treatment the other provenance operations get through `by delegate`. Carrying the
+     * This decorator instruments [save] alone, so the subtraction passes through unannounced, the
+     * same treatment the other provenance operations get through `by delegate`. Carrying the
      * capability type matters because Kotlin's interface delegation only covers
      * [PropositionRepository]: without this, wrapping a capable store would hide the capability
      * from every caller that probes for it, and collector undo would refuse.
      */
-    override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? =
+    override fun subtractFoldedEvidence(
+        propositionId: String,
+        provenanceRefs: List<String>,
+        grounding: Collection<String>,
+        sourceIds: Collection<String>,
+    ): Proposition? =
         (
             delegateSubtraction
                 ?: throw UnsupportedOperationException(
-                    "subtractProvenance needs a delegate that implements ProvenanceSubtractionCapable; " +
+                    "subtractFoldedEvidence needs a delegate that implements ProvenanceSubtractionCapable; " +
                         "${delegate.javaClass.name} cannot subtract evidence atomically",
                 )
-            ).subtractProvenance(propositionId, provenanceRefs)
+            ).subtractFoldedEvidence(propositionId, provenanceRefs, grounding, sourceIds)
 }
 
 /**

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionStore.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionStore.kt
@@ -19,7 +19,6 @@ import com.embabel.agent.core.ContextId
 import com.embabel.agent.rag.service.RetrievableIdentifier
 import com.embabel.dice.common.DiceMetadataKeys
 import com.embabel.dice.provenance.ProvenanceEntry
-import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import org.slf4j.LoggerFactory
 import java.time.Instant
 
@@ -206,36 +205,6 @@ interface PropositionStore {
      */
     fun setProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? =
         findById(propositionId)?.let { save(it.withProvenance(entries)) }
-
-    /**
-     * Remove exactly the evidence named by [provenanceRefs], leaving everything else alone.
-     *
-     * Refs follow the shared evidence-key contract: one minted by
-     * [com.embabel.dice.provenance.ProvenanceEvidenceKey] names a single entry, and a bare locator
-     * key from before revisions existed matches revisionless entries for that source only.
-     *
-     * This is the subtractive counterpart of [addProvenance], and it exists because
-     * [setProvenance] cannot express "remove these" safely. Naming what stays means reading the
-     * entries first, and anything that arrives between that read and the write is silently
-     * dropped by the replace — a concurrent extraction adding evidence to this proposition loses
-     * it. Naming what goes has no such window.
-     *
-     * The default implementation is that read-modify-write, so it carries the race it describes.
-     * It is written this way for compatibility: an existing store keeps working, and a single-JVM
-     * in-memory store has nothing to race with. A backend that can delete evidence in one
-     * statement should override, and the graph backend does.
-     *
-     * @return the updated proposition, or null if no proposition with that id exists.
-     */
-    fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {
-        val current = findById(propositionId) ?: return null
-        if (provenanceRefs.isEmpty()) return current
-        val remaining = current.provenanceEntries.filterNot { entry ->
-            provenanceRefs.any { ProvenanceEvidenceKey.matches(entry, it) }
-        }
-        if (remaining.size == current.provenanceEntries.size) return current
-        return setProvenance(propositionId, remaining)
-    }
 
     /**
      * Remove all provenance from a proposition.

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionStore.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/PropositionStore.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.core.ContextId
 import com.embabel.agent.rag.service.RetrievableIdentifier
 import com.embabel.dice.common.DiceMetadataKeys
 import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import org.slf4j.LoggerFactory
 import java.time.Instant
 
@@ -205,6 +206,36 @@ interface PropositionStore {
      */
     fun setProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? =
         findById(propositionId)?.let { save(it.withProvenance(entries)) }
+
+    /**
+     * Remove exactly the evidence named by [provenanceRefs], leaving everything else alone.
+     *
+     * Refs follow the shared evidence-key contract: one minted by
+     * [com.embabel.dice.provenance.ProvenanceEvidenceKey] names a single entry, and a bare locator
+     * key from before revisions existed matches revisionless entries for that source only.
+     *
+     * This is the subtractive counterpart of [addProvenance], and it exists because
+     * [setProvenance] cannot express "remove these" safely. Naming what stays means reading the
+     * entries first, and anything that arrives between that read and the write is silently
+     * dropped by the replace — a concurrent extraction adding evidence to this proposition loses
+     * it. Naming what goes has no such window.
+     *
+     * The default implementation is that read-modify-write, so it carries the race it describes.
+     * It is written this way for compatibility: an existing store keeps working, and a single-JVM
+     * in-memory store has nothing to race with. A backend that can delete evidence in one
+     * statement should override, and the graph backend does.
+     *
+     * @return the updated proposition, or null if no proposition with that id exists.
+     */
+    fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {
+        val current = findById(propositionId) ?: return null
+        if (provenanceRefs.isEmpty()) return current
+        val remaining = current.provenanceEntries.filterNot { entry ->
+            provenanceRefs.any { ProvenanceEvidenceKey.matches(entry, it) }
+        }
+        if (remaining.size == current.provenanceEntries.size) return current
+        return setProvenance(propositionId, remaining)
+    }
 
     /**
      * Remove all provenance from a proposition.

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/ProvenanceSubtractionCapable.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/ProvenanceSubtractionCapable.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.proposition
+
+/**
+ * Opt-in capability for taking named evidence off a proposition in one atomic step.
+ *
+ * Collector undo is what needs it. Reversing a fold means deleting exactly the entries the fold
+ * added and leaving everything else alone. [PropositionStore.setProvenance] cannot express that
+ * safely, because it names what should remain: the caller has to read the entries first, and any
+ * evidence another extraction adds between that read and the write is replaced away with nothing
+ * left to recover it from. Naming what goes has no such window.
+ *
+ * The capability sits outside [PropositionStore] deliberately. Closing that window is a promise
+ * about how a backend writes, and no shared default body can make it — a read-modify-write default
+ * would compile everywhere while quietly carrying the very data loss it claims to prevent. So a
+ * store that cannot subtract atomically is absent from this type, and a caller probes with an `as?`
+ * test and handles the absence as its own case:
+ *
+ * ```kotlin
+ * val subtraction = store as? ProvenanceSubtractionCapable
+ *     ?: error("this backend cannot subtract provenance atomically")
+ * ```
+ *
+ * ## What implementing this promises
+ *
+ * - **Atomicity.** Reading the current entries and writing what survives happen as one step —
+ *   a compare-and-set retry loop, a lock the store already holds over the row, or a single delete
+ *   statement the backend runs itself. Evidence another writer adds while a subtraction is in
+ *   flight is still there when the subtraction finishes.
+ * - **Exactness.** Refs follow the shared evidence-key contract: a ref minted by
+ *   [com.embabel.dice.provenance.ProvenanceEvidenceKey] names one entry, and a bare locator key
+ *   from before revisions existed reaches revisionless entries for that source only. Every entry
+ *   the refs do not name survives untouched.
+ * - **No resurrection.** Subtracting the last entry from a proposition another writer has already
+ *   deleted answers null and writes nothing. The proposition stays deleted.
+ *
+ * A decorator wrapping a capable store carries this type and forwards to its delegate;
+ * [EventEmittingPropositionRepository] is the worked example.
+ */
+interface ProvenanceSubtractionCapable {
+
+    /**
+     * Whether this particular instance can really subtract. Implementing the interface is a
+     * type-level promise; this is the runtime truth, for a decorator that forwards to a backend it
+     * only discovers when it is constructed. A caller checks this before trusting the type.
+     */
+    val supportsProvenanceSubtraction: Boolean get() = true
+
+    /**
+     * Take exactly the evidence named by [provenanceRefs] off [propositionId], leaving the rest of
+     * its evidence alone.
+     *
+     * Passing no refs reads and returns the proposition unchanged.
+     *
+     * @param propositionId the proposition to subtract from
+     * @param provenanceRefs evidence keys or bare locator keys naming what goes
+     * @return the proposition as the subtraction left it, or null when the store holds no
+     *   proposition under that id — which a caller reads as "somebody deleted it".
+     */
+    fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition?
+}

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/ProvenanceSubtractionCapable.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/ProvenanceSubtractionCapable.kt
@@ -24,8 +24,15 @@ package com.embabel.dice.proposition
  * evidence another extraction adds between that read and the write is replaced away with nothing
  * left to recover it from. Naming what goes has no such window.
  *
+ * A collapse folds three things onto its survivor at once, evidence, grounding and source ids, so
+ * reversing it has to take all three off together. Subtracting the evidence and then saving the
+ * survivor with the grounding and source ids removed would write the survivor's evidence back from
+ * a copy taken before the subtraction, losing whatever another writer added in between. That is why
+ * [subtractFoldedEvidence] takes all three off in the one step this capability promises, and why
+ * undo never follows it with a plain `save`.
+ *
  * The capability sits outside [PropositionStore] deliberately. Closing that window is a promise
- * about how a backend writes, and no shared default body can make it — a read-modify-write default
+ * about how a backend writes, and no shared default body can make it: a read-modify-write default
  * would compile everywhere while quietly carrying the very data loss it claims to prevent. So a
  * store that cannot subtract atomically is absent from this type, and a caller probes with an `as?`
  * test and handles the absence as its own case:
@@ -37,7 +44,7 @@ package com.embabel.dice.proposition
  *
  * ## What implementing this promises
  *
- * - **Atomicity.** Reading the current entries and writing what survives happen as one step —
+ * - **Atomicity.** Reading the current entries and writing what survives happen as one step,
  *   a compare-and-set retry loop, a lock the store already holds over the row, or a single delete
  *   statement the backend runs itself. Evidence another writer adds while a subtraction is in
  *   flight is still there when the subtraction finishes.
@@ -62,14 +69,42 @@ interface ProvenanceSubtractionCapable {
 
     /**
      * Take exactly the evidence named by [provenanceRefs] off [propositionId], leaving the rest of
-     * its evidence alone.
+     * its evidence, grounding and source ids alone.
      *
-     * Passing no refs reads and returns the proposition unchanged.
+     * Passing no refs reads and returns the proposition unchanged. A default over
+     * [subtractFoldedEvidence] with empty grounding and source ids; implementors only need to
+     * provide that one.
      *
      * @param propositionId the proposition to subtract from
      * @param provenanceRefs evidence keys or bare locator keys naming what goes
      * @return the proposition as the subtraction left it, or null when the store holds no
-     *   proposition under that id — which a caller reads as "somebody deleted it".
+     *   proposition under that id, which a caller reads as "somebody deleted it".
      */
-    fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition?
+    fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? =
+        subtractFoldedEvidence(propositionId, provenanceRefs, emptyList(), emptyList())
+
+    /**
+     * Take exactly the fold a collapse carried off [propositionId] in one atomic step: the evidence
+     * named by [provenanceRefs], the grounding chunk ids in [grounding], and the source ids in
+     * [sourceIds]. Everything else on the proposition is left alone.
+     *
+     * This is the operation collector undo actually needs. A fold onto a survivor is never evidence
+     * alone, it also carries grounding and source ids, and reversing it has to take all three off
+     * together, in the same step the evidence subtraction promises, or a later `save` of the
+     * grounding/source-id change would write the survivor's evidence back from a stale copy and lose
+     * whatever another extraction added since.
+     *
+     * @param propositionId the proposition to subtract from
+     * @param provenanceRefs evidence keys or bare locator keys naming which evidence entries go
+     * @param grounding chunk ids to remove from the proposition's grounding
+     * @param sourceIds source ids to remove from the proposition's abstraction sources
+     * @return the proposition as the subtraction left it, or null when the store holds no
+     *   proposition under that id, which a caller reads as "somebody deleted it".
+     */
+    fun subtractFoldedEvidence(
+        propositionId: String,
+        provenanceRefs: List<String>,
+        grounding: Collection<String>,
+        sourceIds: Collection<String>,
+    ): Proposition?
 }

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/ProvenanceSubtractionCapable.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/ProvenanceSubtractionCapable.kt
@@ -56,14 +56,14 @@ package com.embabel.dice.proposition
  *   deleted answers null and writes nothing. The proposition stays deleted.
  *
  * A decorator wrapping a capable store carries this type and forwards to its delegate;
- * [EventEmittingPropositionRepository] is the worked example.
+ * [ProvenanceSubtractingEventEmittingPropositionRepository] is the worked example.
  */
 interface ProvenanceSubtractionCapable {
 
     /**
      * Whether this particular instance can really subtract. Implementing the interface is a
-     * type-level promise; this is the runtime truth, for a decorator that forwards to a backend it
-     * only discovers when it is constructed. A caller checks this before trusting the type.
+     * type-level promise; this is the runtime truth for an implementor whose ability depends on
+     * configuration. A caller checks this before trusting the type.
      */
     val supportsProvenanceSubtraction: Boolean get() = true
 

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/store/InMemoryPropositionRepository.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/store/InMemoryPropositionRepository.kt
@@ -24,10 +24,13 @@ import com.embabel.common.core.types.TextSimilaritySearchRequest
 import com.embabel.common.core.types.ZeroToOne
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.ProvenanceScanningSourceRevisionQueries
+import com.embabel.dice.proposition.ProvenanceSubtractionCapable
 import com.embabel.dice.proposition.PropositionQuery
 import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.proposition.matchesFilters
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
@@ -46,7 +49,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class InMemoryPropositionRepository(
     private val embeddingService: EmbeddingService? = null,
-) : PropositionRepository, ProvenanceScanningSourceRevisionQueries {
+) : PropositionRepository, ProvenanceScanningSourceRevisionQueries, ProvenanceSubtractionCapable {
 
     private val logger = LoggerFactory.getLogger(InMemoryPropositionRepository::class.java)
 
@@ -189,6 +192,50 @@ class InMemoryPropositionRepository(
     }
 
     override fun count(): Int = propositions.size
+
+    // ========================================================================
+    // Provenance management
+    // ========================================================================
+
+    /**
+     * Takes the named evidence off in one atomic step, honouring
+     * [ProvenanceSubtractionCapable]'s contract.
+     *
+     * `ConcurrentHashMap.compute` holds the bin for this id while the remapping function runs, and
+     * every other write here goes through the same map, so a concurrent [addProvenance] or [save]
+     * on this proposition waits its turn. Whichever of the two lands first, both effects are on the
+     * proposition when they finish.
+     *
+     * Handing back null for an absent id also leaves the map alone, so a proposition another writer
+     * has deleted stays deleted. Embeddings are keyed on text, which a subtraction never changes,
+     * so the embedding cache needs no attention here.
+     */
+    override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? =
+        propositions.compute(propositionId) { _, current ->
+            when {
+                current == null -> null
+                provenanceRefs.isEmpty() -> current
+                else -> {
+                    val remaining = current.provenanceEntries.filterNot { entry ->
+                        provenanceRefs.any { ProvenanceEvidenceKey.matches(entry, it) }
+                    }
+                    if (remaining.size == current.provenanceEntries.size) current else current.withProvenance(remaining)
+                }
+            }
+        }
+
+    /**
+     * Appends evidence in one atomic step, so an entry added while a [subtractProvenance] is in
+     * flight survives it.
+     *
+     * The base contract's default reads through [findById] and writes through [save], which leaves
+     * a window where a subtraction running alongside can replace the append away. Both operations
+     * go through `compute` here, which closes it — and makes the pair testable under real threads.
+     */
+    override fun addProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? =
+        propositions.compute(propositionId) { _, current ->
+            current?.withProvenanceEntries(entries)
+        }
 
     /**
      * Clear all propositions and cached embeddings. Useful for testing.

--- a/dice/src/main/kotlin/com/embabel/dice/proposition/store/InMemoryPropositionRepository.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/proposition/store/InMemoryPropositionRepository.kt
@@ -30,7 +30,6 @@ import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.proposition.matchesFilters
 import com.embabel.dice.provenance.ProvenanceEntry
-import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
@@ -198,7 +197,7 @@ class InMemoryPropositionRepository(
     // ========================================================================
 
     /**
-     * Takes the named evidence off in one atomic step, honouring
+     * Takes a whole collapse's fold off in one atomic step, honouring
      * [ProvenanceSubtractionCapable]'s contract.
      *
      * `ConcurrentHashMap.compute` holds the bin for this id while the remapping function runs, and
@@ -210,17 +209,25 @@ class InMemoryPropositionRepository(
      * has deleted stays deleted. Embeddings are keyed on text, which a subtraction never changes,
      * so the embedding cache needs no attention here.
      */
-    override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? =
+    override fun subtractFoldedEvidence(
+        propositionId: String,
+        provenanceRefs: List<String>,
+        grounding: Collection<String>,
+        sourceIds: Collection<String>,
+    ): Proposition? =
         propositions.compute(propositionId) { _, current ->
-            when {
-                current == null -> null
-                provenanceRefs.isEmpty() -> current
-                else -> {
-                    val remaining = current.provenanceEntries.filterNot { entry ->
-                        provenanceRefs.any { ProvenanceEvidenceKey.matches(entry, it) }
-                    }
-                    if (remaining.size == current.provenanceEntries.size) current else current.withProvenance(remaining)
-                }
+            if (current == null) {
+                null
+            } else {
+                val updated = current.withoutFoldedEvidence(
+                    groundingToRemove = grounding.toList(),
+                    provenanceRefsToRemove = provenanceRefs,
+                    sourceIdsToRemove = sourceIds.toList(),
+                )
+                val nothingMatched = updated.grounding == current.grounding &&
+                    updated.provenanceEntries == current.provenanceEntries &&
+                    updated.sourceIds == current.sourceIds
+                if (nothingMatched) current else updated
             }
         }
 

--- a/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
@@ -485,6 +485,64 @@ fun undoSingleCollapse(
 }
 
 /**
+ * The undo as it shipped before the command form: no context to check ownership against and no
+ * audit records to confirm the collapse was applied, so it restores the member and subtracts its
+ * folded refs on the trace's word alone. Kept so a caller compiled against the four-argument form
+ * keeps working; the guarded form above is what new code should call, and this one goes in the
+ * next minor release.
+ *
+ * @param traceQuery where the collapse decision (and its retired members) is looked up
+ * @param propositions where the survivor and retired proposition are read and saved
+ * @param survivorId the collapse's survivor — must match the decision that retired [retiredId]
+ * @param retiredId the one retired member to restore
+ * @return the updated survivor and restored proposition, or null if nothing was retired under
+ *   [retiredId] or either proposition no longer exists
+ * @throws IllegalArgumentException if [retiredId] was retired into a different survivor than
+ *   [survivorId]
+ */
+@Deprecated(
+    "Unguarded: checks neither context ownership nor the collector's audit records. " +
+        "Build a CollapseUndoCommand and pass the CollectorRecordStore.",
+    ReplaceWith(
+        "undoSingleCollapse(CollapseUndoCommand(contextId, survivorId, retiredId), traceQuery, propositions, collectorRecords)",
+        "com.embabel.dice.spi.CollapseUndoCommand",
+    ),
+)
+fun undoSingleCollapse(
+    traceQuery: CollectorTraceQuery,
+    propositions: PropositionStore,
+    survivorId: String,
+    retiredId: String,
+): CollapseUndoResult? {
+    val decision = traceQuery.findDecisionForProposition(retiredId) ?: return null
+    require(decision.survivorId == survivorId) {
+        "Proposition $retiredId was retired into survivor ${decision.survivorId}, not $survivorId"
+    }
+    val retirement = decision.retired.firstOrNull { it.propositionId == retiredId } ?: return null
+
+    // Other members of this same collapse: whatever they also folded must stay on the survivor
+    // even though we're subtracting retirement's copy of it.
+    val others = decision.retired.filter { it.propositionId != retiredId }
+    val stillNeededGrounding = others.flatMap { it.foldedGrounding }.toSet()
+    val stillNeededProvenanceRefs = others.flatMap { it.foldedProvenanceRefs }.toSet()
+    val stillNeededSourceIds = others.flatMap { it.foldedSourceIds }.toSet()
+
+    val survivor = propositions.findById(survivorId) ?: return null
+    val updatedSurvivor = propositions.save(
+        survivor.withoutFoldedEvidence(
+            groundingToRemove = retirement.foldedGrounding.filterNot { it in stillNeededGrounding },
+            provenanceRefsToRemove = retirement.foldedProvenanceRefs.filterNot { it in stillNeededProvenanceRefs },
+            sourceIdsToRemove = retirement.foldedSourceIds.filterNot { it in stillNeededSourceIds },
+        ),
+    )
+
+    val retiredProposition = propositions.findById(retiredId) ?: return null
+    val restored = propositions.save(retiredProposition.withStatus(retirement.priorStatus))
+
+    return CollapseUndoResult(survivor = updatedSurvivor, restored = restored)
+}
+
+/**
  * What the run's audit records permit for this collapse: run it, finish an interrupted one, or
  * nothing.
  *

--- a/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
@@ -22,6 +22,7 @@ import com.embabel.dice.projection.lineage.CollectorRecordStore
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.proposition.PropositionStore
+import com.embabel.dice.proposition.ProvenanceSubtractionCapable
 import com.fasterxml.jackson.annotation.JsonIgnore
 import org.slf4j.LoggerFactory
 import java.time.Instant
@@ -182,27 +183,98 @@ data class CollapseUndoResult(
 )
 
 /**
+ * Names one collapse to undo, inside the context that owns it.
+ *
+ * The context is required, and it is the reason this type exists. Undo used to take a survivor id
+ * and a retired id and nothing more, so ids picked up anywhere at all could reverse a collapse in a
+ * context the caller has no business writing to, and every deployment that cared about that had to
+ * bolt its own ownership check on in front. [undoSingleCollapse] now owns the check: both
+ * propositions have to live in [contextId], and an id from elsewhere is refused with
+ * [CollapseUndoContextMismatchException] before anything is written.
+ *
+ * @property contextId the context both propositions must belong to
+ * @property survivorId the collapse's survivor — must match the decision that retired [retiredId]
+ * @property retiredId the one retired member to restore
+ */
+data class CollapseUndoCommand(
+    val contextId: ContextId,
+    val survivorId: String,
+    val retiredId: String,
+) {
+
+    init {
+        require(survivorId.isNotBlank()) { "survivorId must not be blank" }
+        require(retiredId.isNotBlank()) { "retiredId must not be blank" }
+    }
+}
+
+/**
+ * A proposition the undo was told to touch lives in a different context. Thrown before any write,
+ * so the other context's graph is left exactly as it was.
+ *
+ * @property commandedContextId the context the undo was issued for
+ * @property propositionId the proposition that failed the check
+ * @property actualContextId the context that proposition really belongs to
+ */
+class CollapseUndoContextMismatchException(
+    val commandedContextId: ContextId,
+    val propositionId: String,
+    val actualContextId: ContextId,
+) : IllegalArgumentException(
+    "Proposition $propositionId belongs to context ${actualContextId.value}, and the undo was " +
+        "issued for context ${commandedContextId.value}; refusing to touch it",
+)
+
+/**
+ * The undo was wired with something it cannot work from: no audit records to authorize it, or a
+ * proposition store that cannot subtract evidence atomically. Both are configuration mistakes, and
+ * both are thrown before the undo reads or writes anything.
+ */
+class CollapseUndoConfigurationException(message: String) : IllegalStateException(message)
+
+/**
  * Undoes ONE collapse — a single survivor/retired-member pair — without disturbing the run's
  * other collapses. This is the targeted counterpart to a run-level undo: restore exactly the
- * member named by [retiredId] to its prior status, and subtract only what it (not some other
- * still-retired member of the same collapse) contributed to the survivor.
+ * member named by [CollapseUndoCommand.retiredId] to its prior status, and subtract only what it
+ * (no other still-retired member of the same collapse) contributed to the survivor.
+ *
+ * **Undo is destructive, so it fails closed.** Three things must be in place before it reads or
+ * writes anything, and a missing one refuses:
+ *
+ * 1. *The context that owns the collapse.* [command] carries it, and both propositions must live
+ *    in it. An id belonging to another context throws [CollapseUndoContextMismatchException] with
+ *    that context's graph untouched. The ids reach this function from wherever the caller found
+ *    them — a URL path, a UI card — so this is the boundary that keeps one tenant's ids off
+ *    another tenant's propositions.
+ * 2. *The run's audit records.* [collectorRecords] settles whether the collector really applied
+ *    this merge; a null one throws [CollapseUndoConfigurationException]. The trace store cannot
+ *    settle it, because it records that a collapse was *proposed*: the strategy writes the
+ *    decision during the mark phase, before the runner has decided anything. A dry run, a skipped
+ *    merge, and a merge the runner declined all leave a trace that reads exactly like an applied
+ *    fold, and reversing one of those strips evidence the survivor holds for its own reasons.
+ * 3. *A store that can subtract evidence atomically.* [propositions] must implement
+ *    [ProvenanceSubtractionCapable] and answer true to its
+ *    [ProvenanceSubtractionCapable.supportsProvenanceSubtraction]; a store that cannot throws
+ *    [CollapseUndoConfigurationException]. That interface carries the promise this depends on.
  *
  * Overlap-safe: if another member of the same [CollectorDecision] has not yet been undone and also
  * folded the same grounding/provenance/source id, that ref is left on the survivor — subtracting
- * [retiredId]'s copy would otherwise strip evidence a sibling merge still needs. Once that sibling
+ * this member's copy would otherwise strip evidence a sibling merge still needs. Once that sibling
  * is itself undone it holds its own copy again, so the last member to be undone takes the shared
  * ref with it and the survivor lands back on what it had before the collapse. This is why each
  * [RetiredProposition] carries its own folded set rather than the decision carrying one shared
  * union.
  *
- * Evidence comes off the survivor through [PropositionStore.subtractProvenance], which names the
- * refs to delete. A persistent backend's ordinary `save` appends provenance and never removes it, so
- * an undo that only saved the reduced proposition would leave the folded evidence on the graph. The
- * subtraction runs first and the survivor's `save` last; the write order below says why.
+ * Evidence comes off the survivor through [ProvenanceSubtractionCapable.subtractProvenance], which
+ * names the refs to delete. A persistent backend's ordinary `save` appends provenance and never
+ * removes it, so an undo that only saved the reduced proposition would leave the folded evidence on
+ * the graph. The subtraction runs first and the survivor's `save` last; the write order below says
+ * why. Because the subtraction names what goes and lands in one step, evidence another extraction
+ * adds to the survivor while this undo is running survives it.
  *
  * Both propositions are read before anything is written. A missing participant ends the undo with
- * nothing changed, rather than leaving a survivor whose evidence has been subtracted and a member
- * that was never restored. So does a collapse the collector never applied.
+ * nothing changed, leaving no survivor whose evidence has been subtracted and no member stranded
+ * unrestored. So does a collapse the collector never applied.
  *
  * A survivor deleted *between* that read and the subtraction is caught when the subtraction answers
  * null for a proposition the store no longer has. The undo ends there, writing nothing — saving the
@@ -211,38 +283,22 @@ data class CollapseUndoResult(
  * A caller left with a member retired into a survivor that no longer exists has to decide what that
  * member should be; this function will not guess.
  *
- * **How much of the run that covers depends on the store**, because it depends on when the
- * subtraction last looked.
- *
- * - The graph backend's override of [PropositionStore.subtractProvenance] deletes the edges in one
- *   statement and answers from a read taken after it, writing nothing to the proposition itself.
- *   Null there is exact, so every deletion up to that read is caught, and the window that stays open
- *   is the gap between it and the survivor's `save` below.
- * - The base contract's default is a read-modify-write, and it can recreate the survivor *itself*,
- *   before this function ever sees an answer. On a store inheriting both defaults it reads,
- *   delegates to [PropositionStore.setProvenance], which reads again and saves — a deletion landing
- *   after that second read is undone by that save. A store that overrides [PropositionStore.setProvenance]
- *   moves that last look to wherever its own write reads.
- *   Its other two exits — no refs to subtract, or none of them matching — hand back the proposition
- *   as its first read saw it, so a deletion after that read is invisible and the survivor's `save`
- *   recreates it. Both of those exits are reachable from here: a fold that added no new evidence
- *   subtracts nothing, and a retried undo matches nothing.
- *
- * So the guard is exact on the graph backend and best-effort on a read-modify-write store. Closing
- * the rest needs a conditional write the store contract does not have, and it would have to reach
- * every save in the chain rather than only the one below. The residual is written up in
+ * Every deletion up to the subtraction's own last look is caught this way, because
+ * [ProvenanceSubtractionCapable] promises a store never recreates a proposition it is subtracting
+ * from. The window that stays open is the gap between that answer and the survivor's `save` below,
+ * which upserts. Closing it needs a conditional write the store contract does not have, and it
+ * would have to reach every save in the chain. The residual is written up in
  * `docs/design/source-revisions.md`.
  *
- * **Authorization is two conditions, and both must hold.**
+ * **Authorization is three conditions, and all must hold.**
  *
- * 1. *The collector applied this merge, into this survivor.* Settled by [collectorRecords] when the
- *    caller has them, and unavailable otherwise — the trace store records that a collapse was
- *    *proposed*, since the strategy writes it during the mark phase before the runner decides
- *    anything. The records carry `CollectorRun.dryRun` and, on each member's record,
+ * 1. *The collector applied this merge, into this survivor.* Settled by [collectorRecords]. They
+ *    carry `CollectorRun.dryRun` on the run header and, on each member's record,
  *    `CollectorRecord.mergedIntoId`: the survivor the sweep really folded that member into, written
  *    after the merge was saved. A plain status transition, a skipped merge, and the fallback
  *    retirement a runner performs when a merge target has vanished all leave it null, so none of
- *    them can authorize an undo.
+ *    them can authorize an undo. A dry run's records name the target it *would* have used, and the
+ *    header's `dryRun` flag is what says nothing happened — so a preview never authorizes either.
  * 2. *The undo has not already run.* Settled by [collectorRecords] too: finishing an undo stamps
  *    `CollectorRecord.undoneAt` on the run's record for that member, and a stamped record never
  *    authorizes again. This is what makes a repeat undo a no-op even when the member has been
@@ -250,22 +306,12 @@ data class CollapseUndoResult(
  *    somewhere else. Without the stamp, immortal records plus any new retirement would re-arm the
  *    original undo and let it subtract that run's evidence a second time, taking evidence the
  *    survivor had since re-gained and clobbering the newer retirement.
- * 3. *The merge is still in force.* Settled by the member's status. Without [collectorRecords] it
- *    is the only signal available for conditions 1 and 2 as well, and it is much weaker: it says
- *    "this member is not at its prior status", which a later unrelated retirement also satisfies.
- *    See [isCurrentlyRetired].
+ * 3. *The merge is still in force.* Settled by the member's status. See [isCurrentlyRetired].
  *
- * Conditions 2 and 3 together make a second undo of the same collapse a no-op. On the records path
- * that holds however the member's status has moved since; on the status-only path it holds only
- * while the member sits at its prior status, so a caller without records should not rely on it.
+ * Conditions 2 and 3 together make a second undo of the same collapse a no-op, however the member's
+ * status has moved since.
  *
- * **Passing [collectorRecords] is strongly preferred.** Without them, condition 1 is simply not
- * checked, and condition 2 alone will accept a dry run's trace followed by an unrelated lifecycle
- * transition — a decay sweep moving the member ACTIVE → STALE — after which the undo strips a
- * revision the survivor holds for its own reasons. That is the older, weaker behaviour, kept for
- * existing callers.
- *
- * Three shapes of collapse are refused on the records path, all of them correctly, and all of them
+ * Three shapes of collapse are refused, all of them correctly, and all of them
  * silent apart from a log line:
  *
  * - *A chain-resolved merge.* With stacked strategies, a member marked into B while B is itself
@@ -305,45 +351,73 @@ data class CollapseUndoResult(
  *   Steps 1 and 2 are safe to repeat because the subtraction is recomputed from the survivor's
  *   *current* evidence by key, so a ref that is already gone removes nothing.
  *
+ * @param command the context, the survivor and the retired member this undo is for
  * @param traceQuery where the collapse decision (and its retired members) is looked up
  * @param propositions where the survivor and retired proposition are read and saved, where each
  *   sibling's current status is checked, and where the folded evidence is subtracted from the
- *   survivor by name
- * @param survivorId the collapse's survivor — must match the decision that retired [retiredId]
- * @param retiredId the one retired member to restore
- * @param collectorRecords the run's audit records, if the caller has them. Supplying them makes
- *   "was this collapse applied" a recorded fact rather than an inference from status; omitting
- *   them keeps the older, weaker behaviour described above.
+ *   survivor by name. Must be [ProvenanceSubtractionCapable].
+ * @param collectorRecords the run's audit records. Required: they are what makes "was this collapse
+ *   applied, and has it been reversed already" a recorded fact.
  * @return the updated survivor and restored proposition, or null if nothing was retired under
- *   [retiredId] (no trace of this collapse), if either proposition was already gone when this
- *   function read it, if the subtraction reports the survivor gone — every deletion up to that
- *   point on the graph backend, and up to the default's own last read on a read-modify-write
- *   store — or if the collapse cannot be shown to have been applied. A deletion landing later than
- *   that is not detected, and the survivor is recreated; see the paragraphs above.
- * @throws IllegalArgumentException if [retiredId] was retired into a different survivor than
- *   [survivorId] — a caller error, not a missing-data case
+ *   [CollapseUndoCommand.retiredId] (no trace of this collapse), if either proposition was already
+ *   gone when this function read it, if the subtraction reports the survivor gone, or if the
+ *   collapse cannot be shown to have been applied. A deletion landing after the subtraction's own
+ *   answer goes undetected and the survivor is recreated; see the paragraphs above.
+ * @throws CollapseUndoConfigurationException if [collectorRecords] is null, or if [propositions]
+ *   cannot subtract evidence atomically — wiring mistakes, caught before anything is read
+ * @throws CollapseUndoContextMismatchException if either proposition lives in some context other
+ *   than [CollapseUndoCommand.contextId] — caught before anything is written, and ahead of the
+ *   survivor-mismatch check, so a caller from another context learns only that it was refused
+ * @throws IllegalArgumentException if the retired member was retired into a different survivor from
+ *   the one [command] names — a caller error, and no missing-data case. Reached only once both
+ *   propositions have been shown to belong to the commanded context, since its message quotes the
+ *   survivor the decision names.
  */
-@JvmOverloads
 fun undoSingleCollapse(
+    command: CollapseUndoCommand,
     traceQuery: CollectorTraceQuery,
     propositions: PropositionStore,
-    survivorId: String,
-    retiredId: String,
-    collectorRecords: CollectorRecordStore? = null,
+    collectorRecords: CollectorRecordStore?,
 ): CollapseUndoResult? {
+    val survivorId = command.survivorId
+    val retiredId = command.retiredId
+    // Both configuration refusals come first, ahead of every read, so a misconfigured undo cannot
+    // get far enough to write. A caller with no records has no way to tell an applied merge from a
+    // preview of one, and a store that cannot subtract by name would have to reach for a wholesale
+    // replacement of the survivor's evidence, losing whatever arrived since it read.
+    val records = collectorRecords ?: throw CollapseUndoConfigurationException(
+        "Undoing the collapse of $retiredId into $survivorId needs a CollectorRecordStore to " +
+            "authorize it, and none was supplied",
+    )
+    val subtraction = (propositions as? ProvenanceSubtractionCapable)
+        ?.takeIf { it.supportsProvenanceSubtraction }
+        ?: throw CollapseUndoConfigurationException(
+            "Undoing the collapse of $retiredId into $survivorId needs a store implementing " +
+                "ProvenanceSubtractionCapable; ${propositions.javaClass.name} cannot subtract " +
+                "evidence atomically",
+        )
+
     val decision = traceQuery.findDecisionForProposition(retiredId) ?: return null
+    val retirement = decision.retired.firstOrNull { it.propositionId == retiredId } ?: return null
+
+    // Ownership is settled first, on both propositions this undo writes, and ahead of the
+    // survivor-mismatch check below. Order matters for what a foreign caller is told: the mismatch
+    // message quotes the survivor the decision really names, so running it first would hand
+    // somebody probing with a borrowed member id the id of the survivor in the context that owns
+    // it. Checking ownership first means a caller from elsewhere gets the mismatch refusal and
+    // nothing more.
+    val retiredProposition = propositions.findById(retiredId) ?: return null
+    retiredProposition.requireOwnedBy(command)
+    val survivor = propositions.findById(survivorId) ?: return null
+    survivor.requireOwnedBy(command)
+
     require(decision.survivorId == survivorId) {
         "Proposition $retiredId was retired into survivor ${decision.survivorId}, not $survivorId"
     }
-    val retirement = decision.retired.firstOrNull { it.propositionId == retiredId } ?: return null
-
-    val survivor = propositions.findById(survivorId) ?: return null
-    val retiredProposition = propositions.findById(retiredId) ?: return null
 
     // The member must still be retired, whatever else is true: nothing to reverse otherwise.
     if (!retirement.isCurrentlyRetired(retiredProposition)) return null
-    val authorization = collectorRecords?.authorize(decision.runId, survivorId, retiredId, retiredProposition)
-        ?: UndoAuthorization.Proceed(marker = null)
+    val authorization = records.authorize(decision.runId, survivorId, retiredId, retiredProposition)
     if (authorization is UndoAuthorization.Refuse) return null
 
     // Resuming an undo that was interrupted between its stamp and its restore: the evidence is
@@ -362,7 +436,7 @@ fun undoSingleCollapse(
     // reference forms count, because a sibling recorded before evidence keys existed names its
     // evidence by locator key alone.
     val others = decision.retired.filter {
-        it.propositionId != retiredId && it.stillHoldsAClaim(propositions, collectorRecords, decision.runId)
+        it.propositionId != retiredId && it.stillHoldsAClaim(propositions, records, decision.runId)
     }
     val stillNeededGrounding = others.flatMap { it.foldedGrounding }.toSet()
     val stillNeededProvenanceRefs = others
@@ -372,19 +446,17 @@ fun undoSingleCollapse(
 
     val refsToSubtract = retirement.provenanceRefsForUndo().filterNot { it in stillNeededProvenanceRefs }
 
-    // Evidence goes first and by name. subtractProvenance deletes exactly these refs, so on a store
-    // that can express that in one statement — the graph backend can — evidence another writer adds
-    // while this undo is running survives it. Naming what stays instead would replace it away. The
-    // base contract's default still reads and replaces, so it keeps that window; its own KDoc says
-    // so. The save then carries grounding and source ids over the survivor as the subtraction left
-    // it, and goes last because save is the write a decorator instruments: the event a listener
-    // receives describes the final state.
+    // Evidence goes first and by name. The capability deletes exactly these refs in one atomic
+    // step, so evidence another writer adds while this undo is running survives it. Naming what
+    // stays would replace it away, which is why the store has to promise this before undo will run
+    // at all. The save then carries grounding and source ids over the survivor as the subtraction
+    // left it, and goes last because save is the write a decorator instruments: the event a
+    // listener receives describes the final state.
     //
     // A null answer means the store has no such proposition, so the survivor went away after this
     // function read it. The copy read then is all that is left, and saving it back would recreate
-    // what the other writer deleted, folded evidence and all. The deletion wins. How late a deletion
-    // can land and still be reported this way is a per-store question — see the KDoc.
-    val subtracted = propositions.subtractProvenance(survivorId, refsToSubtract)
+    // what the other writer deleted, folded evidence and all. The deletion wins.
+    val subtracted = subtraction.subtractProvenance(survivorId, refsToSubtract)
     if (subtracted == null) {
         undoLogger.warn(
             "Abandoning the undo of {} in run {}: survivor {} was already gone when the subtraction " +
@@ -405,9 +477,7 @@ fun undoSingleCollapse(
     // window recoverable — see the KDoc's crash matrix. Losing it after the restore would leave a
     // finished undo still authorized, and an immediate retry could not repair that because the
     // member would already be back at its prior status.
-    if (undoMarker != null) {
-        collectorRecords?.record(undoMarker.copy(undoneAt = Instant.now()))
-    }
+    records.record(undoMarker.copy(undoneAt = Instant.now()))
 
     val restored = propositions.save(retiredProposition.withStatus(retirement.priorStatus))
 
@@ -460,8 +530,8 @@ private val WRITING_OUTCOMES = setOf(CollectorOutcome.TRANSITIONED, CollectorOut
 
 private sealed interface UndoAuthorization {
 
-    /** Run the whole undo. [marker] is the record to stamp, or null when no record store was given. */
-    data class Proceed(val marker: CollectorRecord?) : UndoAuthorization
+    /** Run the whole undo. [marker] is the live record that authorized it, and the one to stamp. */
+    data class Proceed(val marker: CollectorRecord) : UndoAuthorization
 
     /** An interrupted undo: the evidence is already off, only the member's restore is outstanding. */
     data object ResumeRestore : UndoAuthorization
@@ -540,9 +610,7 @@ private fun CollectorRecordStore.authorize(
  *
  * Note what it does *not* say: "still retired *by this collapse*". A member retired again later by
  * anything at all — a decay sweep, a second collector run folding it somewhere else — satisfies it
- * just as well. That is why the completion signal on the records path is the `undoneAt` stamp
- * rather than this, and why a caller without records has nothing stopping an unrelated retirement
- * from re-arming an undo that already ran.
+ * just as well. That is why the completion signal is the `undoneAt` stamp, which says so directly.
  *
  * The cost of leaning on it is one false refusal. A member that was genuinely retired, whose undo
  * has not run, and which has since revived to its prior status reads as never retired. Refusing
@@ -560,27 +628,48 @@ private fun RetiredProposition.isCurrentlyRetired(proposition: Proposition): Boo
 /**
  * Whether this sibling's fold still stands, so the survivor must keep holding what it contributed.
  *
- * With records, the answer is the sibling's own `undoneAt` for *this* run: once its undo has run it
- * holds its own copy again, and nothing that happens to it afterwards changes that. Status alone
- * gets this wrong in a way that pins evidence permanently — a sibling undone and then re-retired by
- * a later run reads as still participating, so the shared evidence is retained even though both
- * original folds are reversed and the survivor never returns to its pre-collapse state.
- *
- * Without records the fallback is status, which is what a legacy caller gets: it holds while the
- * sibling sits off its prior status, for whatever reason.
+ * The first answer is the sibling's own `undoneAt` for *this* run: once its undo has run it holds
+ * its own copy again, and nothing that happens to it afterwards changes that. Status alone gets this
+ * wrong in a way that pins evidence permanently — a sibling undone and then re-retired by a later
+ * run reads as still participating, so the shared evidence is retained even though both original
+ * folds are reversed and the survivor never returns to its pre-collapse state. Where the records say
+ * nothing about the sibling, status is the fallback: the claim holds while the sibling sits off its
+ * prior status, for whatever reason.
  *
  * A sibling that has been deleted counts as still holding its claim either way: the survivor's copy
- * of its evidence is then the only one left, and dropping it would erase the evidence rather than
- * return it to anyone.
+ * of its evidence is then the only one left, and dropping it would erase the evidence with nobody
+ * left to hand it back to.
  */
 private fun RetiredProposition.stillHoldsAClaim(
     propositions: PropositionStore,
-    collectorRecords: CollectorRecordStore?,
+    collectorRecords: CollectorRecordStore,
     runId: String,
 ): Boolean {
-    if (collectorRecords != null && collectorRecords.undoneInRun(propositionId, runId)) return false
+    if (collectorRecords.undoneInRun(propositionId, runId)) return false
     val current = propositions.findById(propositionId) ?: return true
     return isCurrentlyRetired(current)
+}
+
+/**
+ * Stops the undo unless this proposition lives in the context [command] names.
+ *
+ * Undo takes ids from whatever handed them to it, so without this a caller could name a survivor in
+ * one context and reverse a collapse in another. The check runs on both propositions before either
+ * is written, so a refusal leaves the other context exactly as it was.
+ */
+private fun Proposition.requireOwnedBy(command: CollapseUndoCommand) {
+    if (contextId != command.contextId) {
+        undoLogger.warn(
+            "Refusing to undo the collapse of {} into {}: proposition {} belongs to context {}, " +
+                "and the undo was issued for context {}",
+            command.retiredId, command.survivorId, id, contextId.value, command.contextId.value,
+        )
+        throw CollapseUndoContextMismatchException(
+            commandedContextId = command.contextId,
+            propositionId = id,
+            actualContextId = contextId,
+        )
+    }
 }
 
 /** Whether this run's fold of [propositionId] has already been reversed. */

--- a/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
@@ -195,13 +195,43 @@ data class CollapseUndoResult(
  * [RetiredProposition] carries its own folded set rather than the decision carrying one shared
  * union.
  *
- * Evidence comes off the survivor through [PropositionStore.setProvenance], the authoritative
- * replace. A persistent backend's ordinary `save` appends provenance and never removes it, so an
- * undo that only saved the reduced proposition would leave the folded evidence on the graph.
+ * Evidence comes off the survivor through [PropositionStore.subtractProvenance], which names the
+ * refs to delete. A persistent backend's ordinary `save` appends provenance and never removes it, so
+ * an undo that only saved the reduced proposition would leave the folded evidence on the graph. The
+ * subtraction runs first and the survivor's `save` last; the write order below says why.
  *
  * Both propositions are read before anything is written. A missing participant ends the undo with
  * nothing changed, rather than leaving a survivor whose evidence has been subtracted and a member
  * that was never restored. So does a collapse the collector never applied.
+ *
+ * A survivor deleted *between* that read and the subtraction is caught when the subtraction answers
+ * null for a proposition the store no longer has. The undo ends there, writing nothing — saving the
+ * copy it read would recreate a proposition another writer deleted, with the folded evidence still
+ * on it. Nothing is stamped, the member stays retired, and the null return says no restore happened.
+ * A caller left with a member retired into a survivor that no longer exists has to decide what that
+ * member should be; this function will not guess.
+ *
+ * **How much of the run that covers depends on the store**, because it depends on when the
+ * subtraction last looked.
+ *
+ * - The graph backend's override of [PropositionStore.subtractProvenance] deletes the edges in one
+ *   statement and answers from a read taken after it, writing nothing to the proposition itself.
+ *   Null there is exact, so every deletion up to that read is caught, and the window that stays open
+ *   is the gap between it and the survivor's `save` below.
+ * - The base contract's default is a read-modify-write, and it can recreate the survivor *itself*,
+ *   before this function ever sees an answer. On a store inheriting both defaults it reads,
+ *   delegates to [PropositionStore.setProvenance], which reads again and saves — a deletion landing
+ *   after that second read is undone by that save. A store that overrides [PropositionStore.setProvenance]
+ *   moves that last look to wherever its own write reads.
+ *   Its other two exits — no refs to subtract, or none of them matching — hand back the proposition
+ *   as its first read saw it, so a deletion after that read is invisible and the survivor's `save`
+ *   recreates it. Both of those exits are reachable from here: a fold that added no new evidence
+ *   subtracts nothing, and a retried undo matches nothing.
+ *
+ * So the guard is exact on the graph backend and best-effort on a read-modify-write store. Closing
+ * the rest needs a conditional write the store contract does not have, and it would have to reach
+ * every save in the chain rather than only the one below. The residual is written up in
+ * `docs/design/source-revisions.md`.
  *
  * **Authorization is two conditions, and both must hold.**
  *
@@ -258,9 +288,9 @@ data class CollapseUndoResult(
  *   matches them. An entry differing in any of the six fields — a different revision of the same
  *   source, say — is a different key and is untouched.
  * - **No transaction spans the writes**, so the order is chosen to make every interruption
- *   recoverable. It runs: (1) `setProvenance` subtracts the evidence, (2) `save` carries grounding
- *   and source ids and fires the persistence event, (3) the `undoneAt` stamp, (4) the member's
- *   restore. The stamp sits between the survivor's writes and the restore deliberately — after the
+ *   recoverable. It runs: (1) `subtractProvenance` takes the evidence off, (2) `save` carries
+ *   grounding and source ids and fires the persistence event, (3) the `undoneAt` stamp, (4) the
+ *   member's restore. The stamp sits between the survivor's writes and the restore deliberately — after the
  *   restore, losing it would leave a finished undo still authorized, and a retry could not repair
  *   that because the member would already be back at its prior status.
  *
@@ -277,16 +307,19 @@ data class CollapseUndoResult(
  *
  * @param traceQuery where the collapse decision (and its retired members) is looked up
  * @param propositions where the survivor and retired proposition are read and saved, where each
- *   sibling's current status is checked, and where the survivor's remaining evidence is set
- *   authoritatively
+ *   sibling's current status is checked, and where the folded evidence is subtracted from the
+ *   survivor by name
  * @param survivorId the collapse's survivor — must match the decision that retired [retiredId]
  * @param retiredId the one retired member to restore
  * @param collectorRecords the run's audit records, if the caller has them. Supplying them makes
  *   "was this collapse applied" a recorded fact rather than an inference from status; omitting
  *   them keeps the older, weaker behaviour described above.
  * @return the updated survivor and restored proposition, or null if nothing was retired under
- *   [retiredId] (no trace of this collapse), if either proposition no longer exists, or if the
- *   collapse cannot be shown to have been applied
+ *   [retiredId] (no trace of this collapse), if either proposition was already gone when this
+ *   function read it, if the subtraction reports the survivor gone — every deletion up to that
+ *   point on the graph backend, and up to the default's own last read on a read-modify-write
+ *   store — or if the collapse cannot be shown to have been applied. A deletion landing later than
+ *   that is not detected, and the survivor is recreated; see the paragraphs above.
  * @throws IllegalArgumentException if [retiredId] was retired into a different survivor than
  *   [survivorId] — a caller error, not a missing-data case
  */
@@ -339,12 +372,27 @@ fun undoSingleCollapse(
 
     val refsToSubtract = retirement.provenanceRefsForUndo().filterNot { it in stillNeededProvenanceRefs }
 
-    // Evidence goes first and by name. subtractProvenance deletes exactly these refs against
-    // whatever the store holds now, so evidence another writer adds while this undo is running is
-    // left alone — naming what stays instead would replace it away. The save then carries grounding
-    // and source ids over the survivor as the subtraction left it, and goes last because save is
-    // the write a decorator instruments: the event a listener receives describes the final state.
-    val subtracted = propositions.subtractProvenance(survivorId, refsToSubtract) ?: survivor
+    // Evidence goes first and by name. subtractProvenance deletes exactly these refs, so on a store
+    // that can express that in one statement — the graph backend can — evidence another writer adds
+    // while this undo is running survives it. Naming what stays instead would replace it away. The
+    // base contract's default still reads and replaces, so it keeps that window; its own KDoc says
+    // so. The save then carries grounding and source ids over the survivor as the subtraction left
+    // it, and goes last because save is the write a decorator instruments: the event a listener
+    // receives describes the final state.
+    //
+    // A null answer means the store has no such proposition, so the survivor went away after this
+    // function read it. The copy read then is all that is left, and saving it back would recreate
+    // what the other writer deleted, folded evidence and all. The deletion wins. How late a deletion
+    // can land and still be reported this way is a per-store question — see the KDoc.
+    val subtracted = propositions.subtractProvenance(survivorId, refsToSubtract)
+    if (subtracted == null) {
+        undoLogger.warn(
+            "Abandoning the undo of {} in run {}: survivor {} was already gone when the subtraction " +
+                "ran, so nothing is written and the member stays retired",
+            retiredId, decision.runId, survivorId,
+        )
+        return null
+    }
     val updatedSurvivor = propositions.save(
         subtracted.withoutFoldedEvidence(
             groundingToRemove = retirement.foldedGrounding.filterNot { it in stillNeededGrounding },

--- a/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
@@ -16,9 +16,18 @@
 package com.embabel.dice.spi
 
 import com.embabel.agent.core.ContextId
+import com.embabel.dice.projection.lineage.CollectorOutcome
+import com.embabel.dice.projection.lineage.CollectorRecord
+import com.embabel.dice.projection.lineage.CollectorRecordStore
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.proposition.PropositionStore
+import com.fasterxml.jackson.annotation.JsonIgnore
+import org.slf4j.LoggerFactory
+import java.time.Instant
+
+/** Why an undo declined to act — the decision is silent otherwise, since it returns null. */
+private val undoLogger = LoggerFactory.getLogger("com.embabel.dice.spi.CollapseUndo")
 
 /**
  * One proposed pair of propositions worth scoring.
@@ -99,13 +108,26 @@ data class CollectorDecision(
 /**
  * One proposition that was folded into a survivor, and what a merging sweep would carry over
  * from it (grounding, provenance and source ids) so the fold can be undone.
+ *
+ * @property foldedProvenanceRefs Locator keys for the sources this proposition brought that the
+ *   survivor was not already citing. A locator key names a source, not a version of it, so this
+ *   list can be empty while [foldedProvenanceEvidenceKeys] is not — a loser carrying `r2` of a
+ *   document the survivor already cites at `r1` adds no new source. Trace readers display these,
+ *   and undo falls back to them when a trace predates evidence keys.
+ * @property foldedProvenanceEvidenceKeys One evidence key per entry the fold actually added,
+ *   minted by `ProvenanceEvidenceKey`. This is what undo subtracts, and it is what makes an undo
+ *   of revisioned evidence exact. Empty on traces recorded before this field existed. Kept out of
+ *   JSON, so a trace serialized and read back undoes at locator granularity — JSON is not a round
+ *   trip for a trace you intend to undo from.
  */
-data class RetiredProposition(
+data class RetiredProposition @JvmOverloads constructor(
     val propositionId: String,
     val priorStatus: PropositionStatus,
     val foldedGrounding: List<String> = emptyList(),
     val foldedProvenanceRefs: List<String> = emptyList(),
     val foldedSourceIds: List<String> = emptyList(),
+    @get:JsonIgnore
+    val foldedProvenanceEvidenceKeys: List<String> = emptyList(),
 )
 
 /**
@@ -165,26 +187,116 @@ data class CollapseUndoResult(
  * member named by [retiredId] to its prior status, and subtract only what it (not some other
  * still-retired member of the same collapse) contributed to the survivor.
  *
- * Overlap-safe: if another member retired in the same [CollectorDecision] also folded the same
- * grounding/provenance/source id, that ref is left on the survivor — subtracting [retiredId]'s
- * copy would otherwise strip evidence a sibling merge still needs. This is why each
+ * Overlap-safe: if another member of the same [CollectorDecision] has not yet been undone and also
+ * folded the same grounding/provenance/source id, that ref is left on the survivor — subtracting
+ * [retiredId]'s copy would otherwise strip evidence a sibling merge still needs. Once that sibling
+ * is itself undone it holds its own copy again, so the last member to be undone takes the shared
+ * ref with it and the survivor lands back on what it had before the collapse. This is why each
  * [RetiredProposition] carries its own folded set rather than the decision carrying one shared
  * union.
  *
+ * Evidence comes off the survivor through [PropositionStore.setProvenance], the authoritative
+ * replace. A persistent backend's ordinary `save` appends provenance and never removes it, so an
+ * undo that only saved the reduced proposition would leave the folded evidence on the graph.
+ *
+ * Both propositions are read before anything is written. A missing participant ends the undo with
+ * nothing changed, rather than leaving a survivor whose evidence has been subtracted and a member
+ * that was never restored. So does a collapse the collector never applied.
+ *
+ * **Authorization is two conditions, and both must hold.**
+ *
+ * 1. *The collector applied this merge, into this survivor.* Settled by [collectorRecords] when the
+ *    caller has them, and unavailable otherwise — the trace store records that a collapse was
+ *    *proposed*, since the strategy writes it during the mark phase before the runner decides
+ *    anything. The records carry `CollectorRun.dryRun` and, on each member's record,
+ *    `CollectorRecord.mergedIntoId`: the survivor the sweep really folded that member into, written
+ *    after the merge was saved. A plain status transition, a skipped merge, and the fallback
+ *    retirement a runner performs when a merge target has vanished all leave it null, so none of
+ *    them can authorize an undo.
+ * 2. *The undo has not already run.* Settled by [collectorRecords] too: finishing an undo stamps
+ *    `CollectorRecord.undoneAt` on the run's record for that member, and a stamped record never
+ *    authorizes again. This is what makes a repeat undo a no-op even when the member has been
+ *    retired again in the meantime — by a decay sweep, or by a later collector run folding it into
+ *    somewhere else. Without the stamp, immortal records plus any new retirement would re-arm the
+ *    original undo and let it subtract that run's evidence a second time, taking evidence the
+ *    survivor had since re-gained and clobbering the newer retirement.
+ * 3. *The merge is still in force.* Settled by the member's status. Without [collectorRecords] it
+ *    is the only signal available for conditions 1 and 2 as well, and it is much weaker: it says
+ *    "this member is not at its prior status", which a later unrelated retirement also satisfies.
+ *    See [isCurrentlyRetired].
+ *
+ * Conditions 2 and 3 together make a second undo of the same collapse a no-op. On the records path
+ * that holds however the member's status has moved since; on the status-only path it holds only
+ * while the member sits at its prior status, so a caller without records should not rely on it.
+ *
+ * **Passing [collectorRecords] is strongly preferred.** Without them, condition 1 is simply not
+ * checked, and condition 2 alone will accept a dry run's trace followed by an unrelated lifecycle
+ * transition — a decay sweep moving the member ACTIVE → STALE — after which the undo strips a
+ * revision the survivor holds for its own reasons. That is the older, weaker behaviour, kept for
+ * existing callers.
+ *
+ * Three shapes of collapse are refused on the records path, all of them correctly, and all of them
+ * silent apart from a log line:
+ *
+ * - *A chain-resolved merge.* With stacked strategies, a member marked into B while B is itself
+ *   merged into C is folded onto the terminal survivor C, and the record names C — while the trace
+ *   decision still names B. Undoing against B fails the record check, and undoing against C fails
+ *   the `require` below as a caller error. Refusing is right either way: the folded evidence keys
+ *   were computed against B's evidence, so subtracting them from C would remove the wrong set.
+ * - *A member revived without a retry.* Covered below under [isCurrentlyRetired].
+ * - *A shadowed decision.* [CollectorTraceQuery.findDecisionForProposition] returns an arbitrary
+ *   first match on both shipped stores, so a dry-run preview of a collapse recorded before the real
+ *   one can shadow the applied decision. The undo then evaluates the preview's run, finds a dry-run
+ *   header, and declines. Conservative, and worth knowing if an undo refuses for no visible reason.
+ *
+ * Two things worth knowing before relying on this:
+ *
+ * - **Evidence the survivor re-gained on its own is still subtracted.** A collapse folds an entry,
+ *   and afterwards the survivor is independently extracted with the identical entry. Structural
+ *   dedup keeps one copy, so nothing distinguishes the re-gained entry from the folded one, and the
+ *   undo removes it. Grounding refs and source ids have always behaved this way; evidence now
+ *   matches them. An entry differing in any of the six fields — a different revision of the same
+ *   source, say — is a different key and is untouched.
+ * - **No transaction spans the writes**, so the order is chosen to make every interruption
+ *   recoverable. It runs: (1) `setProvenance` subtracts the evidence, (2) `save` carries grounding
+ *   and source ids and fires the persistence event, (3) the `undoneAt` stamp, (4) the member's
+ *   restore. The stamp sits between the survivor's writes and the restore deliberately — after the
+ *   restore, losing it would leave a finished undo still authorized, and a retry could not repair
+ *   that because the member would already be back at its prior status.
+ *
+ *   | Interrupted after | State | What a retry does |
+ *   | --- | --- | --- |
+ *   | nothing | untouched | the whole undo |
+ *   | (1) | evidence off, grounding on | re-derives against current evidence, so the subtraction is a no-op, then finishes |
+ *   | (2) | survivor final, member retired, no stamp | same — re-subtracts nothing, stamps, restores |
+ *   | (3) | stamped, member still retired | restores only, touching no evidence |
+ *   | (4) | complete | nothing; the stamp refuses |
+ *
+ *   Steps 1 and 2 are safe to repeat because the subtraction is recomputed from the survivor's
+ *   *current* evidence by key, so a ref that is already gone removes nothing.
+ *
  * @param traceQuery where the collapse decision (and its retired members) is looked up
- * @param propositions where the survivor and retired proposition are read and saved
+ * @param propositions where the survivor and retired proposition are read and saved, where each
+ *   sibling's current status is checked, and where the survivor's remaining evidence is set
+ *   authoritatively
  * @param survivorId the collapse's survivor — must match the decision that retired [retiredId]
  * @param retiredId the one retired member to restore
+ * @param collectorRecords the run's audit records, if the caller has them. Supplying them makes
+ *   "was this collapse applied" a recorded fact rather than an inference from status; omitting
+ *   them keeps the older, weaker behaviour described above.
  * @return the updated survivor and restored proposition, or null if nothing was retired under
- *   [retiredId] (no trace of this collapse), or if either proposition no longer exists
+ *   [retiredId] (no trace of this collapse), if either proposition no longer exists, or if the
+ *   collapse cannot be shown to have been applied
  * @throws IllegalArgumentException if [retiredId] was retired into a different survivor than
  *   [survivorId] — a caller error, not a missing-data case
  */
+@JvmOverloads
 fun undoSingleCollapse(
     traceQuery: CollectorTraceQuery,
     propositions: PropositionStore,
     survivorId: String,
     retiredId: String,
+    collectorRecords: CollectorRecordStore? = null,
 ): CollapseUndoResult? {
     val decision = traceQuery.findDecisionForProposition(retiredId) ?: return null
     require(decision.survivorId == survivorId) {
@@ -192,27 +304,250 @@ fun undoSingleCollapse(
     }
     val retirement = decision.retired.firstOrNull { it.propositionId == retiredId } ?: return null
 
+    val survivor = propositions.findById(survivorId) ?: return null
+    val retiredProposition = propositions.findById(retiredId) ?: return null
+
+    // The member must still be retired, whatever else is true: nothing to reverse otherwise.
+    if (!retirement.isCurrentlyRetired(retiredProposition)) return null
+    val authorization = collectorRecords?.authorize(decision.runId, survivorId, retiredId, retiredProposition)
+        ?: UndoAuthorization.Proceed(marker = null)
+    if (authorization is UndoAuthorization.Refuse) return null
+
+    // Resuming an undo that was interrupted between its stamp and its restore: the evidence is
+    // already off, and re-deriving it here would subtract against a survivor that no longer holds
+    // it. Only the restore is outstanding.
+    if (authorization is UndoAuthorization.ResumeRestore) {
+        val resumed = propositions.save(retiredProposition.withStatus(retirement.priorStatus))
+        return CollapseUndoResult(survivor = survivor, restored = resumed)
+    }
+    val undoMarker = (authorization as UndoAuthorization.Proceed).marker
+
     // Other members of this same collapse: whatever they also folded must stay on the survivor
-    // even though we're subtracting retirement's copy of it.
-    val others = decision.retired.filter { it.propositionId != retiredId }
+    // even though we're subtracting retirement's copy of it — but only while their fold still
+    // stands. A sibling whose own undo has run holds its own copy again and has no claim on the
+    // survivor's, so counting it would pin the shared evidence to the survivor forever. Both
+    // reference forms count, because a sibling recorded before evidence keys existed names its
+    // evidence by locator key alone.
+    val others = decision.retired.filter {
+        it.propositionId != retiredId && it.stillHoldsAClaim(propositions, collectorRecords, decision.runId)
+    }
     val stillNeededGrounding = others.flatMap { it.foldedGrounding }.toSet()
-    val stillNeededProvenanceRefs = others.flatMap { it.foldedProvenanceRefs }.toSet()
+    val stillNeededProvenanceRefs = others
+        .flatMap { it.foldedProvenanceEvidenceKeys + it.foldedProvenanceRefs }
+        .toSet()
     val stillNeededSourceIds = others.flatMap { it.foldedSourceIds }.toSet()
 
-    val survivor = propositions.findById(survivorId) ?: return null
+    val refsToSubtract = retirement.provenanceRefsForUndo().filterNot { it in stillNeededProvenanceRefs }
+
+    // Evidence goes first and by name. subtractProvenance deletes exactly these refs against
+    // whatever the store holds now, so evidence another writer adds while this undo is running is
+    // left alone — naming what stays instead would replace it away. The save then carries grounding
+    // and source ids over the survivor as the subtraction left it, and goes last because save is
+    // the write a decorator instruments: the event a listener receives describes the final state.
+    val subtracted = propositions.subtractProvenance(survivorId, refsToSubtract) ?: survivor
     val updatedSurvivor = propositions.save(
-        survivor.withoutFoldedEvidence(
+        subtracted.withoutFoldedEvidence(
             groundingToRemove = retirement.foldedGrounding.filterNot { it in stillNeededGrounding },
-            provenanceRefsToRemove = retirement.foldedProvenanceRefs.filterNot { it in stillNeededProvenanceRefs },
+            provenanceRefsToRemove = emptyList(),
             sourceIdsToRemove = retirement.foldedSourceIds.filterNot { it in stillNeededSourceIds },
         ),
     )
 
-    val retiredProposition = propositions.findById(retiredId) ?: return null
+    // The stamp goes between the evidence writes and the restore, which is what makes every crash
+    // window recoverable — see the KDoc's crash matrix. Losing it after the restore would leave a
+    // finished undo still authorized, and an immediate retry could not repair that because the
+    // member would already be back at its prior status.
+    if (undoMarker != null) {
+        collectorRecords?.record(undoMarker.copy(undoneAt = Instant.now()))
+    }
+
     val restored = propositions.save(retiredProposition.withStatus(retirement.priorStatus))
 
     return CollapseUndoResult(survivor = updatedSurvivor, restored = restored)
 }
+
+/**
+ * What the run's audit records permit for this collapse: run it, finish an interrupted one, or
+ * nothing.
+ *
+ * The run header must exist and say the run was not a dry run — a missing header refuses, since the
+ * caller asked for verification and the store cannot give it. The member must have a record under
+ * that run whose outcome is a real transition, and that record's `mergedIntoId` must name this
+ * survivor.
+ *
+ * A record already carrying `undoneAt` normally refuses: that is what stops the same collapse being
+ * reversed twice. The exception is the crash window. Undo stamps *before* it restores the member, so
+ * a stamped record whose member is still retired means the undo died in between, and the restore is
+ * all that is outstanding — see the crash matrix on [undoSingleCollapse].
+ *
+ * Two signals separate that from "undone long ago, member retired again since". The member must sit
+ * exactly where this collapse left it, per the record's `newStatus`; a record without one predates
+ * the mechanism and fails the signal rather than satisfying it vacuously. And no other run may have
+ * *written* the member at or after the stamp — counted over `TRANSITIONED` and `HARD_DELETED`
+ * records from non-dry runs only, since a `SKIPPED` record states that a run deliberately left the
+ * member alone and a dry run changes nothing, and treating either as action would strand a member
+ * whose undo really is half-finished.
+ *
+ * Both timestamps are written by whichever host produced them, so the comparison assumes roughly
+ * synchronized clocks. On several hosts sharing one store, a re-retirement whose clock runs behind
+ * could stamp `at` before `undoneAt` and slip past this check.
+ *
+ * `mergedIntoId` is the whole point, and nothing here infers anything from marks. `MergingSweepPolicy`
+ * merges into the first duplicate mark naming a usable survivor while a proposition may carry marks
+ * naming several, so the mark a reader happens to see says nothing about what ran; a
+ * `StatusTransitionSweepPolicy` retirement and the fallback retirement the runner performs when a
+ * merge target has vanished both transition the member without folding anything, and both leave
+ * `mergedIntoId` null. `DefaultCollectorRunner` writes the field on the member's records only after
+ * the merge has been saved, and writes the same value on every one of them — which is what makes
+ * this answer identical on a store that keeps one row per (proposition, run), as the Drivine store
+ * does, and one that keeps a row per mark, as the in-memory store does.
+ *
+ * The distinct-value check below is therefore defensive rather than load-bearing: a run cannot
+ * currently produce two different applied targets for one member, because it retires each member
+ * once. It stays because the alternative on a broken invariant is silently picking one, and it logs
+ * what it saw.
+ */
+/** Outcomes that mean a run actually wrote to the proposition, rather than previewing or passing. */
+private val WRITING_OUTCOMES = setOf(CollectorOutcome.TRANSITIONED, CollectorOutcome.HARD_DELETED)
+
+private sealed interface UndoAuthorization {
+
+    /** Run the whole undo. [marker] is the record to stamp, or null when no record store was given. */
+    data class Proceed(val marker: CollectorRecord?) : UndoAuthorization
+
+    /** An interrupted undo: the evidence is already off, only the member's restore is outstanding. */
+    data object ResumeRestore : UndoAuthorization
+
+    data object Refuse : UndoAuthorization
+}
+
+private fun CollectorRecordStore.authorize(
+    runId: String,
+    survivorId: String,
+    retiredId: String,
+    retiredProposition: Proposition,
+): UndoAuthorization {
+    val run = findRun(runId) ?: return UndoAuthorization.Refuse
+    if (run.dryRun) return UndoAuthorization.Refuse
+    val forThisRun = findByProposition(retiredId).filter { it.runId == runId }
+    val transitioned = forThisRun.filter { it.outcome == CollectorOutcome.TRANSITIONED }
+    val appliedTargets = transitioned.mapNotNull { it.mergedIntoId }.distinct()
+    if (appliedTargets.size > 1) {
+        undoLogger.warn(
+            "Refusing to undo collapse of {} in run {}: its records disagree about which survivor " +
+                "the sweep merged it into ({})",
+            retiredId, runId, appliedTargets,
+        )
+        return UndoAuthorization.Refuse
+    }
+    if (appliedTargets.singleOrNull() != survivorId) return UndoAuthorization.Refuse
+
+    // A store that appends leaves the original record beside the stamped one, so one stamp anywhere
+    // in the run's records settles it for the whole collapse.
+    val stamped = forThisRun.firstOrNull { it.undoneAt != null }
+        ?: return UndoAuthorization.Proceed(transitioned.first { it.mergedIntoId == survivorId })
+
+    // Stamped, and the caller has already established the member is still retired. Either this undo
+    // died between its stamp and its restore, or it finished long ago and something retired the
+    // member again afterwards. Two things have to hold for the first reading.
+    //
+    // The member must sit exactly where this collapse left it. A record with no newStatus predates
+    // this mechanism and cannot say where that was, so it fails the signal rather than passing it
+    // vacuously — refusing costs a stranded member, accepting would resume against a re-retirement
+    // to any status at all.
+    val undoneAt = stamped.undoneAt
+    val leftHere = stamped.newStatus != null && retiredProposition.status == stamped.newStatus
+
+    // And no other run may have written the member since the stamp. Only records evidencing a real
+    // write count: a SKIPPED record is the literal statement that a run left the member alone, and
+    // a dry run changes nothing by definition, so counting either would strand a member whose undo
+    // is genuinely half-finished. Both timestamps come from whichever host wrote them, so this
+    // assumes roughly synchronized clocks across hosts sharing one store.
+    val actedOnSince = undoneAt != null && findByProposition(retiredId).any { record ->
+        record.runId != runId &&
+            !record.at.isBefore(undoneAt) &&
+            record.outcome in WRITING_OUTCOMES &&
+            findRun(record.runId)?.dryRun == false
+    }
+    if (!leftHere || actedOnSince) {
+        undoLogger.debug(
+            "Collapse of {} in run {} was already undone; its member has since been retired again",
+            retiredId, runId,
+        )
+        return UndoAuthorization.Refuse
+    }
+    undoLogger.info(
+        "Completing an interrupted undo of {} in run {}: evidence already subtracted, restoring the member",
+        retiredId, runId,
+    )
+    return UndoAuthorization.ResumeRestore
+}
+
+/**
+ * Whether [proposition] is folded into its survivor right now, judged by status alone.
+ *
+ * Retiring a member moves it off the status its decision wrote down, and restoring it puts that
+ * status back, so a member still carrying [RetiredProposition.priorStatus] is holding nothing for
+ * the survivor — either the collapse was never applied, or it has already been undone.
+ *
+ * Note what it does *not* say: "still retired *by this collapse*". A member retired again later by
+ * anything at all — a decay sweep, a second collector run folding it somewhere else — satisfies it
+ * just as well. That is why the completion signal on the records path is the `undoneAt` stamp
+ * rather than this, and why a caller without records has nothing stopping an unrelated retirement
+ * from re-arming an undo that already ran.
+ *
+ * The cost of leaning on it is one false refusal. A member that was genuinely retired, whose undo
+ * has not run, and which has since revived to its prior status reads as never retired. Refusing
+ * loses a legitimate undo and leaves the survivor's evidence alone; accepting would subtract
+ * evidence for a collapse that may never have been applied. Silent data loss is the worse outcome,
+ * so refusal wins the tie. A caller that hits this can reinstate the fold and undo it again, or
+ * remove the evidence directly.
+ *
+ * The same predicate decides whether a *sibling* still holds a claim on shared evidence, and there
+ * it is the only signal available: the records say nothing about which siblings have been undone.
+ */
+private fun RetiredProposition.isCurrentlyRetired(proposition: Proposition): Boolean =
+    proposition.status != priorStatus
+
+/**
+ * Whether this sibling's fold still stands, so the survivor must keep holding what it contributed.
+ *
+ * With records, the answer is the sibling's own `undoneAt` for *this* run: once its undo has run it
+ * holds its own copy again, and nothing that happens to it afterwards changes that. Status alone
+ * gets this wrong in a way that pins evidence permanently — a sibling undone and then re-retired by
+ * a later run reads as still participating, so the shared evidence is retained even though both
+ * original folds are reversed and the survivor never returns to its pre-collapse state.
+ *
+ * Without records the fallback is status, which is what a legacy caller gets: it holds while the
+ * sibling sits off its prior status, for whatever reason.
+ *
+ * A sibling that has been deleted counts as still holding its claim either way: the survivor's copy
+ * of its evidence is then the only one left, and dropping it would erase the evidence rather than
+ * return it to anyone.
+ */
+private fun RetiredProposition.stillHoldsAClaim(
+    propositions: PropositionStore,
+    collectorRecords: CollectorRecordStore?,
+    runId: String,
+): Boolean {
+    if (collectorRecords != null && collectorRecords.undoneInRun(propositionId, runId)) return false
+    val current = propositions.findById(propositionId) ?: return true
+    return isCurrentlyRetired(current)
+}
+
+/** Whether this run's fold of [propositionId] has already been reversed. */
+private fun CollectorRecordStore.undoneInRun(propositionId: String, runId: String): Boolean =
+    findByProposition(propositionId).any { it.runId == runId && it.undoneAt != null }
+
+/**
+ * The references undo subtracts from the survivor. Evidence keys, when the trace has them, name
+ * every entry the fold added; the locator keys beside them would only repeat that less precisely.
+ * A trace with no evidence keys was written before they existed, and its locator keys are all
+ * there is — those match revisionless evidence only, so an old trace never reaches a revision it
+ * never saw.
+ */
+private fun RetiredProposition.provenanceRefsForUndo(): List<String> =
+    foldedProvenanceEvidenceKeys.ifEmpty { foldedProvenanceRefs }
 
 /**
  * Groups proposition ids into connected components from scored, non-vetoed edges.

--- a/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
@@ -285,12 +285,15 @@ class CollapseUndoConfigurationException(message: String) : IllegalStateExceptio
  * [RetiredProposition] carries its own folded set rather than the decision carrying one shared
  * union.
  *
- * Evidence comes off the survivor through [ProvenanceSubtractionCapable.subtractProvenance], which
- * names the refs to delete. A persistent backend's ordinary `save` appends provenance and never
- * removes it, so an undo that only saved the reduced proposition would leave the folded evidence on
- * the graph. The subtraction runs first and the survivor's `save` last; the write order below says
- * why. Because the subtraction names what goes and lands in one step, evidence another extraction
- * adds to the survivor while this undo is running survives it.
+ * The whole fold comes off the survivor through
+ * [ProvenanceSubtractionCapable.subtractFoldedEvidence], which names the evidence refs, the
+ * grounding and the source ids to remove and takes them off in one step. A persistent backend's
+ * ordinary `save` appends provenance and never removes it, so an undo that only saved the reduced
+ * proposition would leave the folded evidence on the graph, and a replacing backend's `save` after
+ * the subtraction would write this function's copy back over evidence another writer added since.
+ * So the survivor is never saved; the write order below says why. Because the subtraction names
+ * what goes and lands in one step, evidence another extraction adds to the survivor while this undo
+ * is running survives it.
  *
  * Both propositions are read before anything is written. A missing participant ends the undo with
  * nothing changed, leaving no survivor whose evidence has been subtracted and no member stranded
@@ -356,28 +359,30 @@ class CollapseUndoConfigurationException(message: String) : IllegalStateExceptio
  *   matches them. An entry differing in any of the six fields — a different revision of the same
  *   source, say — is a different key and is untouched.
  * - **No transaction spans the writes**, so the order is chosen to make every interruption
- *   recoverable. It runs: (1) `subtractProvenance` takes the evidence off, (2) `save` carries
- *   grounding and source ids and fires the persistence event, (3) the `undoneAt` stamp, (4) the
- *   member's restore. The stamp sits between the survivor's writes and the restore deliberately — after the
- *   restore, losing it would leave a finished undo still authorized, and a retry could not repair
- *   that because the member would already be back at its prior status.
+ *   recoverable. It runs: (1) `subtractFoldedEvidence` takes the evidence, grounding and source ids
+ *   off the survivor in one step, (2) the `undoneAt` stamp, (3) the member's restore. The stamp
+ *   sits between the survivor's write and the restore deliberately: after the restore, losing it
+ *   would leave a finished undo still authorized, and a retry could not repair that because the
+ *   member would already be back at its prior status.
  *
  *   | Interrupted after | State | What a retry does |
  *   | --- | --- | --- |
  *   | nothing | untouched | the whole undo |
- *   | (1) | evidence off, grounding on | re-derives against current evidence, so the subtraction is a no-op, then finishes |
- *   | (2) | survivor final, member retired, no stamp | same — re-subtracts nothing, stamps, restores |
- *   | (3) | stamped, member still retired | restores only, touching no evidence |
- *   | (4) | complete | nothing; the stamp refuses |
+ *   | (1) | survivor final, member retired, no stamp | re-derives against current evidence, so the subtraction is a no-op, then stamps and restores |
+ *   | (2) | stamped, member still retired | restores only, touching no evidence |
+ *   | (3) | complete | nothing; the stamp refuses |
  *
- *   Steps 1 and 2 are safe to repeat because the subtraction is recomputed from the survivor's
- *   *current* evidence by key, so a ref that is already gone removes nothing.
+ *   Step 1 is safe to repeat because the subtraction is recomputed from the survivor's *current*
+ *   evidence by key, so a ref that is already gone removes nothing. The survivor is never written
+ *   through `save`, so a decorator that publishes from `save` announces the member's restore and
+ *   nothing for the survivor; the survivor's write goes through the capability, unannounced, the
+ *   way the other provenance operations do.
  *
  * @param command the context, the survivor and the retired member this undo is for
  * @param traceQuery where the collapse decision (and its retired members) is looked up
- * @param propositions where the survivor and retired proposition are read and saved, where each
- *   sibling's current status is checked, and where the folded evidence is subtracted from the
- *   survivor by name. Must be [ProvenanceSubtractionCapable].
+ * @param propositions where the survivor and retired proposition are read, where the member is
+ *   restored, where each sibling's current status is checked, and where the whole fold is
+ *   subtracted from the survivor by name. Must be [ProvenanceSubtractionCapable].
  * @param collectorRecords the run's audit records. Required: they are what makes "was this collapse
  *   applied, and has it been reversed already" a recorded fact.
  * @return the updated survivor and restored proposition, or null if nothing was retired under
@@ -468,18 +473,23 @@ fun undoSingleCollapse(
 
     val refsToSubtract = retirement.provenanceRefsForUndo().filterNot { it in stillNeededProvenanceRefs }
 
-    // Evidence goes first and by name. The capability deletes exactly these refs in one atomic
-    // step, so evidence another writer adds while this undo is running survives it. Naming what
-    // stays would replace it away, which is why the store has to promise this before undo will run
-    // at all. The save then carries grounding and source ids over the survivor as the subtraction
-    // left it, and goes last because save is the write a decorator instruments: the event a
-    // listener receives describes the final state.
+    // The whole fold comes off by name in one step: the evidence refs, the grounding and the source
+    // ids the collapse carried, all in the one atomic operation the capability promises. No save
+    // follows it. A save would carry this function's copy of the survivor back over the store, and
+    // on a backend whose save replaces the row that copy would put back evidence another writer
+    // added in the meantime, which is the loss the capability exists to rule out. Naming what goes,
+    // not what stays, is why the store has to promise this before undo will run at all.
     //
     // A null answer means the store has no such proposition, so the survivor went away after this
-    // function read it. The copy read then is all that is left, and saving it back would recreate
+    // function read it. The copy read then is all that is left, and writing it back would recreate
     // what the other writer deleted, folded evidence and all. The deletion wins.
-    val subtracted = subtraction.subtractProvenance(survivorId, refsToSubtract)
-    if (subtracted == null) {
+    val updatedSurvivor = subtraction.subtractFoldedEvidence(
+        propositionId = survivorId,
+        provenanceRefs = refsToSubtract,
+        grounding = retirement.foldedGrounding.filterNot { it in stillNeededGrounding },
+        sourceIds = retirement.foldedSourceIds.filterNot { it in stillNeededSourceIds },
+    )
+    if (updatedSurvivor == null) {
         undoLogger.warn(
             "Abandoning the undo of {} in run {}: survivor {} was already gone when the subtraction " +
                 "ran, so nothing is written and the member stays retired",
@@ -487,13 +497,6 @@ fun undoSingleCollapse(
         )
         return null
     }
-    val updatedSurvivor = propositions.save(
-        subtracted.withoutFoldedEvidence(
-            groundingToRemove = retirement.foldedGrounding.filterNot { it in stillNeededGrounding },
-            provenanceRefsToRemove = emptyList(),
-            sourceIdsToRemove = retirement.foldedSourceIds.filterNot { it in stillNeededSourceIds },
-        ),
-    )
 
     // The stamp goes between the evidence writes and the restore, which is what makes every crash
     // window recoverable — see the KDoc's crash matrix. Losing it after the restore would leave a

--- a/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/spi/CollectorSignals.kt
@@ -158,19 +158,39 @@ interface CollectorTraceStore {
 interface CollectorTraceQuery {
     fun findEdgesByRun(runId: String): List<CollectorCandidateEdge>
     fun findDecisionsByRun(runId: String): List<CollectorDecision>
+
+    /**
+     * The decision where [propositionId] shows up on either side of a merge: as the survivor, or as
+     * one of the retired members. Useful for a caller that just wants "what happened to this
+     * proposition" without caring which side it was on. A caller that specifically wants a
+     * *retirement*, undoing a single collapse say, should use [findDecisionRetiring]: this method
+     * can answer a decision where the id survived, which is the wrong one to undo against.
+     */
     fun findDecisionForProposition(propositionId: String): CollectorDecision?
+
+    /**
+     * The most recent decision that retired [propositionId]. Never one where it merely survived.
+     *
+     * A proposition can survive one collapse and later be retired into a different survivor (fold A
+     * into B, then fold B into C). At that point [findDecisionForProposition] can hand back the
+     * first decision, the one where the id survived, and never reach the one that actually retired
+     * it. This method looks at the retired side only, and when a proposition was retired more than
+     * once, it answers the newest of those decisions.
+     *
+     * @return null if no decision ever retired [propositionId].
+     */
+    fun findDecisionRetiring(propositionId: String): CollectorDecision?
 
     /**
      * The undo-record for one retired member of a collapse: its prior status and exactly the
      * grounding/provenance/source ids a merging sweep folded onto its survivor from it. Looks up
-     * the [CollectorDecision] that retired [retiredId] and picks out its entry — a targeted
-     * alternative to [findDecisionForProposition] for callers that only want this one member's
-     * record, e.g. before undoing a single collapse rather than a whole run.
+     * the [CollectorDecision] that retired [retiredId] via [findDecisionRetiring] and picks out its
+     * entry.
      *
      * @return null if no decision retired [retiredId] (nothing recorded, or it's a survivor id).
      */
     fun findRetirement(retiredId: String): RetiredProposition? =
-        findDecisionForProposition(retiredId)?.retired?.firstOrNull { it.propositionId == retiredId }
+        findDecisionRetiring(retiredId)?.retired?.firstOrNull { it.propositionId == retiredId }
 }
 
 /**
@@ -320,10 +340,12 @@ class CollapseUndoConfigurationException(message: String) : IllegalStateExceptio
  *   the `require` below as a caller error. Refusing is right either way: the folded evidence keys
  *   were computed against B's evidence, so subtracting them from C would remove the wrong set.
  * - *A member revived without a retry.* Covered below under [isCurrentlyRetired].
- * - *A shadowed decision.* [CollectorTraceQuery.findDecisionForProposition] returns an arbitrary
- *   first match on both shipped stores, so a dry-run preview of a collapse recorded before the real
- *   one can shadow the applied decision. The undo then evaluates the preview's run, finds a dry-run
- *   header, and declines. Conservative, and worth knowing if an undo refuses for no visible reason.
+ * - *A shadowed decision.* [CollectorTraceQuery.findDecisionRetiring] looks up by retired member and
+ *   answers the newest one, so a decision where the id survived can no longer shadow the decision
+ *   that actually retired it. What can still shadow it is a dry-run preview recorded after the
+ *   applied collapse: that preview is the newer retirement, so the undo evaluates it, finds the
+ *   dry-run header, and declines. Conservative, and worth knowing if an undo refuses for no visible
+ *   reason.
  *
  * Two things worth knowing before relying on this:
  *
@@ -397,7 +419,7 @@ fun undoSingleCollapse(
                 "evidence atomically",
         )
 
-    val decision = traceQuery.findDecisionForProposition(retiredId) ?: return null
+    val decision = traceQuery.findDecisionRetiring(retiredId) ?: return null
     val retirement = decision.retired.firstOrNull { it.propositionId == retiredId } ?: return null
 
     // Ownership is settled first, on both propositions this undo writes, and ahead of the
@@ -514,7 +536,7 @@ fun undoSingleCollapse(
     survivorId: String,
     retiredId: String,
 ): CollapseUndoResult? {
-    val decision = traceQuery.findDecisionForProposition(retiredId) ?: return null
+    val decision = traceQuery.findDecisionRetiring(retiredId) ?: return null
     require(decision.survivorId == survivorId) {
         "Proposition $retiredId was retired into survivor ${decision.survivorId}, not $survivorId"
     }

--- a/dice/src/main/kotlin/com/embabel/dice/spi/InMemoryCollectorTraceStore.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/spi/InMemoryCollectorTraceStore.kt
@@ -36,6 +36,13 @@ class InMemoryCollectorTraceStore : CollectorTraceStore, CollectorTraceQuery {
     private val decisionsByRun = ConcurrentHashMap<String, MutableList<CollectorDecision>>()
     private val runContexts = ConcurrentHashMap<String, ContextId>()
 
+    /**
+     * Every decision, in the order it was recorded, so [findDecisionRetiring] can answer the
+     * newest one that named a given id as retired. [decisionsByRun] alone can't give that order:
+     * it groups by run, and a proposition can be retired by different runs at different times.
+     */
+    private val decisionsInOrder = Collections.synchronizedList(mutableListOf<CollectorDecision>())
+
     override fun recordRunContext(runId: String, contextId: ContextId) {
         runContexts[runId] = contextId
     }
@@ -53,8 +60,10 @@ class InMemoryCollectorTraceStore : CollectorTraceStore, CollectorTraceQuery {
     override fun recordDecision(runId: String, decision: CollectorDecision) {
         // File the decision under the run id we're told to, and stamp that same id onto the record
         // so a reader always sees the run it belongs to — no matter what the caller put on the field.
+        val stamped = decision.copy(runId = runId)
         decisionsByRun.computeIfAbsent(runId) { Collections.synchronizedList(mutableListOf()) }
-            .add(decision.copy(runId = runId))
+            .add(stamped)
+        decisionsInOrder.add(stamped)
     }
 
     override fun deleteTracesForContext(contextId: ContextId) {
@@ -65,6 +74,7 @@ class InMemoryCollectorTraceStore : CollectorTraceStore, CollectorTraceQuery {
             decisionsByRun.remove(runId)
             runContexts.remove(runId)
         }
+        decisionsInOrder.removeAll { it.runId in runIds }
     }
 
     fun edgesFor(runId: String): List<CollectorCandidateEdge> = edgesByRun[runId]?.toList() ?: emptyList()
@@ -83,5 +93,11 @@ class InMemoryCollectorTraceStore : CollectorTraceStore, CollectorTraceQuery {
     override fun findDecisionForProposition(propositionId: String): CollectorDecision? =
         decisionsByRun.values.asSequence().flatten().firstOrNull { decision ->
             decision.survivorId == propositionId || decision.retired.any { it.propositionId == propositionId }
+        }
+
+    /** Walks the recording order backwards, so the newest decision that retired [propositionId] wins. */
+    override fun findDecisionRetiring(propositionId: String): CollectorDecision? =
+        decisionsInOrder.asReversed().firstOrNull { decision ->
+            decision.retired.any { it.propositionId == propositionId }
         }
 }

--- a/dice/src/test/java/com/embabel/dice/SourceRevisionJavaInteropTest.java
+++ b/dice/src/test/java/com/embabel/dice/SourceRevisionJavaInteropTest.java
@@ -15,19 +15,24 @@
  */
 package com.embabel.dice;
 
+import com.embabel.dice.proposition.PropositionStatus;
 import com.embabel.dice.provenance.ContentAddressedLocator;
 import com.embabel.dice.provenance.ProvenanceEntry;
 import com.embabel.dice.provenance.SourceLocator;
 import com.embabel.dice.provenance.SourceRevisionRef;
+import com.embabel.dice.spi.RetiredProposition;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Java's view of the revision contract. {@code @JvmOverloads} on {@link ProvenanceEntry} means
- * every constructor descriptor a Java caller could already have compiled against survives, and the
- * new revision argument arrives as one extra descriptor on the end.
+ * Java's view of the revision contract. {@code @JvmOverloads} on {@link ProvenanceEntry} and
+ * {@link RetiredProposition} means every constructor descriptor a Java caller could already have
+ * compiled against survives, and each new argument arrives as one extra descriptor on the end.
  */
 class SourceRevisionJavaInteropTest {
 
@@ -51,6 +56,44 @@ class SourceRevisionJavaInteropTest {
                 String.class,
                 String.class
         );
+
+        RetiredProposition.class.getConstructor(
+                String.class,
+                PropositionStatus.class,
+                List.class,
+                List.class,
+                List.class
+        );
+        RetiredProposition.class.getConstructor(
+                String.class,
+                PropositionStatus.class,
+                List.class,
+                List.class,
+                List.class,
+                List.class
+        );
+    }
+
+    @Test
+    void javaCallersBuildAndReadFoldedEvidenceKeys() {
+        RetiredProposition legacy = new RetiredProposition(
+                "retired",
+                PropositionStatus.ACTIVE,
+                List.of("chunk-1"),
+                List.of("uri:https://example.com/source"),
+                List.of("src-1")
+        );
+        assertTrue(legacy.getFoldedProvenanceEvidenceKeys().isEmpty());
+
+        RetiredProposition revisioned = new RetiredProposition(
+                "retired",
+                PropositionStatus.ACTIVE,
+                List.of("chunk-1"),
+                List.of("uri:https://example.com/source"),
+                List.of("src-1"),
+                List.of("dice-provenance:v1:opaque")
+        );
+        assertEquals(List.of("dice-provenance:v1:opaque"), revisioned.getFoldedProvenanceEvidenceKeys());
     }
 
     @Test

--- a/dice/src/test/kotlin/com/embabel/dice/SourceRevisionCompatibilityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/SourceRevisionCompatibilityTest.kt
@@ -16,16 +16,20 @@
 package com.embabel.dice
 
 import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.provenance.ContentAddressedLocator
 import com.embabel.dice.provenance.ProvenanceEntry
 import com.embabel.dice.provenance.SourceRevisionRef
+import com.embabel.dice.spi.RetiredProposition
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
@@ -74,6 +78,28 @@ class SourceRevisionCompatibilityTest {
             revisioned,
             mapper.readValue<Proposition>(mapper.writeValueAsString(revisioned)),
         )
+    }
+
+    @Test
+    fun `collector trace JSON keeps readable refs without exposing storage identities`() {
+        val retired = RetiredProposition(
+            propositionId = "retired",
+            priorStatus = PropositionStatus.ACTIVE,
+            foldedProvenanceRefs = listOf("uri:https://example.com/source"),
+            foldedProvenanceEvidenceKeys = listOf("dice-provenance:v1:opaque"),
+        )
+
+        val json = mapper.writeValueAsString(retired)
+
+        assertTrue(json.contains("uri:https://example.com/source"))
+        assertFalse(json.contains("foldedProvenanceEvidenceKeys"))
+        assertFalse(json.contains("dice-provenance:v1:opaque"))
+
+        // The consequence, stated as an assertion: a trace that goes through JSON comes back with
+        // its locator refs and no evidence keys, so it undoes at locator granularity.
+        val readBack = mapper.readValue<RetiredProposition>(json)
+        assertEquals(listOf("uri:https://example.com/source"), readBack.foldedProvenanceRefs)
+        assertEquals(emptyList<String>(), readBack.foldedProvenanceEvidenceKeys)
     }
 
     @Test

--- a/dice/src/test/kotlin/com/embabel/dice/projection/memory/collector/MultiSignalCollectorStrategyTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/projection/memory/collector/MultiSignalCollectorStrategyTest.kt
@@ -22,6 +22,9 @@ import com.embabel.dice.proposition.EntityMention
 import com.embabel.dice.proposition.MentionRole
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.store.InMemoryPropositionRepository
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
+import com.embabel.dice.provenance.UriLocator
 import com.embabel.dice.spi.CollectorCandidateEdge
 import com.embabel.dice.spi.CollectorComponent
 import com.embabel.dice.spi.CollectorDecision
@@ -61,6 +64,7 @@ class MultiSignalCollectorStrategyTest {
         confidence: Double = 0.8,
         reinforceCount: Int = 0,
         mentions: List<EntityMention> = emptyList(),
+        provenanceEntries: List<ProvenanceEntry> = emptyList(),
     ): Proposition =
         Proposition(
             contextId = contextId,
@@ -69,6 +73,7 @@ class MultiSignalCollectorStrategyTest {
             confidence = confidence,
             decay = 0.0,
             reinforceCount = reinforceCount,
+            provenanceEntries = provenanceEntries,
         )
 
     private fun mention(resolvedId: String): EntityMention =
@@ -187,6 +192,40 @@ class MultiSignalCollectorStrategyTest {
         assertEquals(weak.status, retired.priorStatus)
         assertEquals(weak.grounding, retired.foldedGrounding)
         assertEquals(weak.sourceIds, retired.foldedSourceIds)
+    }
+
+    @Test
+    fun `records only the distinct evidence a fold actually adds`() {
+        // The survivor already cites r1 of this document; the loser cites r1 and r2, twice each.
+        // Recorded by locator key alone, the fold would look like it added nothing and r2 would sit
+        // on the survivor forever after an undo.
+        setEmbedding("strong statement", floatArrayOf(1f, 0f, 0f))
+        setEmbedding("weak statement", floatArrayOf(0.99f, 0.1f, 0f))
+        val locator = UriLocator("https://example.com/source")
+        val revisionOne = ProvenanceEntry(locator = locator, sourceRevision = "r1")
+        val revisionTwo = ProvenanceEntry(locator = locator, sourceRevision = "r2")
+        val strong = repo.save(
+            proposition("strong statement", confidence = 0.9, provenanceEntries = listOf(revisionOne)),
+        )
+        val weak = repo.save(
+            proposition(
+                "weak statement",
+                confidence = 0.3,
+                provenanceEntries = listOf(revisionOne, revisionOne, revisionTwo, revisionTwo),
+            ),
+        )
+        val traceStore = InMemoryCollectorTraceStore()
+
+        vectorOnlyStrategy(traceStore).mark(
+            listOf(strong, weak),
+            repo,
+            CollectorRunContext("revision-trace-run", contextId),
+        )
+
+        val retired = traceStore.decisionsFor("revision-trace-run").single().retired.single()
+        assertEquals(weak.id, retired.propositionId)
+        assertEquals(emptyList<String>(), retired.foldedProvenanceRefs)
+        assertEquals(listOf(ProvenanceEvidenceKey.encode(revisionTwo)), retired.foldedProvenanceEvidenceKeys)
     }
 
     @Test

--- a/dice/src/test/kotlin/com/embabel/dice/proposition/PropositionRepositoryDelegationTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/proposition/PropositionRepositoryDelegationTest.kt
@@ -71,11 +71,27 @@ class PropositionRepositoryDelegationTest {
     }
 
     /**
-     * A backend that opts in to [SourceRevisionQueryCapable] and implements only the plain-String
-     * finders. That is the implementation point a Java backend can actually reach, since the
-     * ContextId-typed methods compile to mangled JVM names.
+     * A backend that opts in to [ProvenanceSubtractionCapable] and implements subtraction
+     * over a test store.
      */
-    private inner class StringSourceOverrideRepository : MinimalRepository(), SourceRevisionQueryCapable {
+    private inner class ProvenanceSubtractingRepository : MinimalRepository(), ProvenanceSubtractionCapable {
+        override fun subtractFoldedEvidence(
+            propositionId: String,
+            provenanceRefs: List<String>,
+            grounding: Collection<String>,
+            sourceIds: Collection<String>,
+        ): Proposition? {
+            // Stub implementation for testing
+            return findById(propositionId)
+        }
+    }
+
+    /**
+     * A backend that opts in to both [SourceRevisionQueryCapable] and [ProvenanceSubtractionCapable],
+     * implementing only the plain-String finders for source revision. That is the implementation point
+     * a Java backend can actually reach, since the ContextId-typed methods compile to mangled JVM names.
+     */
+    private inner class StringSourceOverrideRepository : MinimalRepository(), SourceRevisionQueryCapable, ProvenanceSubtractionCapable {
         val sourceKeyResult = listOf(proposition(contextId, "source-key"))
         val sourceRevisionResult = listOf(proposition(contextId, "source-revision"))
         val revisionlessResult = listOf(proposition(contextId, "revisionless"))
@@ -107,6 +123,16 @@ class PropositionRepositoryDelegationTest {
             revisionlessCalls++
             receivedContexts += contextIdValue
             return revisionlessResult
+        }
+
+        override fun subtractFoldedEvidence(
+            propositionId: String,
+            provenanceRefs: List<String>,
+            grounding: Collection<String>,
+            sourceIds: Collection<String>,
+        ): Proposition? {
+            // Stub implementation for testing
+            return findById(propositionId)
         }
     }
 
@@ -200,26 +226,45 @@ class PropositionRepositoryDelegationTest {
 
     /**
      * The event-emitting decorator wraps a plain [PropositionRepository], and only implements
-     * [SourceRevisionQueryCapable] when [EventEmittingPropositionRepository.wrapping] was handed a
-     * delegate that does. A wrapper built over a capable delegate answers `as?` with itself and
-     * forwards to the delegate; a wrapper built over a plain repository answers `as?` with null,
-     * the same honest absence the delegate itself would report.
+     * [SourceRevisionQueryCapable] and [ProvenanceSubtractionCapable] when
+     * [EventEmittingPropositionRepository.wrapping] was handed a delegate that does. A wrapper built
+     * over a capable delegate answers `as?` with itself and forwards to the delegate; a wrapper built
+     * over a plain repository answers `as?` with null, the same honest absence the delegate itself
+     * would report.
      */
     @Test
     fun `the decorator carries the capability only when its delegate does`() {
-        val capableDelegate = StringSourceOverrideRepository()
-        val capableWrapper = EventEmittingPropositionRepository.wrapping(capableDelegate, DiceEventListener.DEV_NULL)
-        val capableRevisionQueries = capableWrapper as? SourceRevisionQueryCapable
-        assertNotNull(capableRevisionQueries, "a wrapper over a capable delegate must carry the capability")
+        // Both capabilities
+        val bothCapable = StringSourceOverrideRepository()
+        val bothWrapper = EventEmittingPropositionRepository.wrapping(bothCapable, DiceEventListener.DEV_NULL)
+        val revisionQueries = bothWrapper as? SourceRevisionQueryCapable
+        assertNotNull(revisionQueries, "a wrapper over a source-revision-capable delegate must carry the capability")
         assertEquals(
-            capableDelegate.sourceKeyResult,
-            capableRevisionQueries!!.findBySourceKey(contextId, "uri:https://example.com/source"),
+            bothCapable.sourceKeyResult,
+            revisionQueries!!.findBySourceKey(contextId, "uri:https://example.com/source"),
+        )
+        val subtractionCapable = bothWrapper as? ProvenanceSubtractionCapable
+        assertNotNull(subtractionCapable, "a wrapper over a provenance-subtracting delegate must carry the capability")
+
+        // Provenance subtraction only
+        val subtractionOnlyDelegate = ProvenanceSubtractingRepository()
+        val subtractionOnlyWrapper = EventEmittingPropositionRepository.wrapping(subtractionOnlyDelegate, DiceEventListener.DEV_NULL)
+        val subtractionOnly = subtractionOnlyWrapper as? ProvenanceSubtractionCapable
+        assertNotNull(subtractionOnly, "a wrapper over a provenance-subtracting delegate must carry the capability")
+        assertNull(
+            subtractionOnlyWrapper as? SourceRevisionQueryCapable,
+            "a wrapper over a delegate with only provenance subtraction must not satisfy source-revision probe",
         )
 
+        // Neither capability
         val plainWrapper = EventEmittingPropositionRepository.wrapping(MinimalRepository(), DiceEventListener.DEV_NULL)
         assertNull(
             plainWrapper as? SourceRevisionQueryCapable,
             "a wrapper over a plain repository must not satisfy the capability probe",
+        )
+        assertNull(
+            plainWrapper as? ProvenanceSubtractionCapable,
+            "a wrapper over a plain repository must not satisfy the subtraction probe",
         )
     }
 }

--- a/dice/src/test/kotlin/com/embabel/dice/proposition/ProvenanceSubtractionAtomicityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/proposition/ProvenanceSubtractionAtomicityTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.proposition
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.proposition.store.InMemoryPropositionRepository
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
+import com.embabel.dice.provenance.UriLocator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * What [ProvenanceSubtractionCapable] promises, checked against the in-memory store that
+ * implements it: the named evidence goes, everything else stays, a concurrent addition survives,
+ * and a deleted proposition is never put back.
+ *
+ * The concurrency test is what the capability exists for. Reversing a collapse used to read a
+ * proposition's entries, work out which should remain, and write those back, so an extraction
+ * landing between the read and the write was replaced away with nothing left to recover it from.
+ */
+class ProvenanceSubtractionAtomicityTest {
+
+    private val contextId = ContextId("ctx-subtraction")
+    private val anchor = ProvenanceEntry(UriLocator("https://example.com/anchor"))
+    private val folded = ProvenanceEntry(UriLocator("https://example.com/folded"))
+
+    @Test
+    fun `evidence added while a subtraction is running survives it`() {
+        // Two real threads released together on one proposition: one takes the folded evidence off,
+        // the other adds a fresh entry. Whichever lands first, both effects have to be there at the
+        // end. A read-modify-write implementation loses the addition whenever the subtraction's
+        // read happens first, so this is repeated to give the interleaving room to show up.
+        val store = InMemoryPropositionRepository()
+        val executor = Executors.newFixedThreadPool(2)
+        val rounds = 200
+        try {
+            repeat(rounds) { round ->
+                val id = "survivor-$round"
+                val fresh = ProvenanceEntry(UriLocator("https://example.com/fresh-$round"))
+                store.save(proposition(id, listOf(anchor, folded)))
+                val start = CountDownLatch(1)
+
+                val subtraction = executor.submit<Proposition?> {
+                    start.await()
+                    store.subtractProvenance(id, listOf(ProvenanceEvidenceKey.encode(folded)))
+                }
+                val addition = executor.submit<Proposition?> {
+                    start.await()
+                    store.addProvenance(id, listOf(fresh))
+                }
+                start.countDown()
+                subtraction.get(30, TimeUnit.SECONDS)
+                addition.get(30, TimeUnit.SECONDS)
+
+                val entries = store.findById(id)!!.provenanceEntries
+                assertTrue(fresh in entries, "round $round lost the concurrent addition: $entries")
+                assertFalse(folded in entries, "round $round left the subtracted evidence behind: $entries")
+                assertTrue(anchor in entries, "round $round dropped evidence nobody named: $entries")
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `subtracting from a proposition another writer deleted answers null and leaves it deleted`() {
+        // The last entry coming off a proposition that has since been deleted must not put it back.
+        // Undo reads this null as "somebody deleted the survivor" and stops there.
+        val store = InMemoryPropositionRepository()
+        val saved = store.save(proposition("deleted-midway", listOf(anchor)))
+        assertTrue(store.delete(saved.id))
+
+        assertNull(store.subtractProvenance(saved.id, listOf(ProvenanceEvidenceKey.encode(anchor))))
+
+        assertNull(store.findById(saved.id))
+        assertEquals(0, store.count())
+        assertNull(store.subtractProvenance("never-existed", listOf(ProvenanceEvidenceKey.encode(anchor))))
+    }
+
+    @Test
+    fun `a subtraction takes exactly the evidence it names`() {
+        val store = InMemoryPropositionRepository()
+        val revisionOne = ProvenanceEntry(UriLocator("https://example.com/doc"), sourceRevision = "r1")
+        val revisionTwo = ProvenanceEntry(UriLocator("https://example.com/doc"), sourceRevision = "r2")
+        val saved = store.save(proposition("exact", listOf(anchor, revisionOne, revisionTwo)))
+
+        val updated = store.subtractProvenance(saved.id, listOf(ProvenanceEvidenceKey.encode(revisionTwo)))
+
+        assertEquals(listOf(anchor, revisionOne), updated?.provenanceEntries)
+        assertEquals(listOf(anchor, revisionOne), store.findById(saved.id)?.provenanceEntries)
+    }
+
+    @Test
+    fun `a subtraction that names nothing reads the proposition and writes nothing`() {
+        val store = InMemoryPropositionRepository()
+        val saved = store.save(proposition("untouched", listOf(anchor, folded)))
+
+        assertEquals(saved, store.subtractProvenance(saved.id, emptyList()))
+        assertEquals(listOf(anchor, folded), store.findById(saved.id)?.provenanceEntries)
+
+        val unmatched = ProvenanceEvidenceKey.encode(ProvenanceEntry(UriLocator("https://example.com/other")))
+        assertEquals(saved, store.subtractProvenance(saved.id, listOf(unmatched)))
+        assertEquals(listOf(anchor, folded), store.findById(saved.id)?.provenanceEntries)
+    }
+
+    private fun proposition(id: String, provenance: List<ProvenanceEntry>) = Proposition(
+        id = id,
+        contextId = contextId,
+        text = "$id proposition",
+        mentions = emptyList(),
+        confidence = 0.9,
+        provenanceEntries = provenance,
+    )
+}

--- a/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
@@ -34,11 +34,13 @@ import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.proposition.PropositionStore
+import com.embabel.dice.proposition.ProvenanceSubtractionCapable
 import com.embabel.dice.proposition.store.InMemoryPropositionRepository
 import com.embabel.dice.provenance.ProvenanceEntry
 import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import com.embabel.dice.provenance.UriLocator
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -47,20 +49,63 @@ import java.time.Instant
 
 /**
  * What `undoSingleCollapse` owes a store: evidence really comes off the survivor, a fold of
- * revisioned evidence is reversed exactly, and a collapse whose participants have since gone
- * leaves nothing half-written.
+ * revisioned evidence is reversed exactly, a collapse whose participants have since gone leaves
+ * nothing half-written, and an undo the caller has no standing to ask for refuses without writing.
  */
 class CollectorUndoCapabilityTest {
 
     private val contextId = ContextId("ctx-undo-capability")
+    private val otherContextId = ContextId("ctx-somebody-else")
     private val locator = UriLocator("https://example.com/source")
     private val revisionOne = ProvenanceEntry(locator = locator, sourceRevision = "r1")
     private val revisionTwo = ProvenanceEntry(locator = locator, sourceRevision = "r2")
+
+    /**
+     * Calls the real entry point with a command for [context]. Every test goes through here, so the
+     * context and the record store are as visible in a test as they are to a caller.
+     */
+    private fun undo(
+        trace: CollectorTraceQuery,
+        store: PropositionStore,
+        survivorId: String,
+        retiredId: String,
+        records: CollectorRecordStore?,
+        context: ContextId = contextId,
+    ): CollapseUndoResult? = undoSingleCollapse(
+        command = CollapseUndoCommand(contextId = context, survivorId = survivorId, retiredId = retiredId),
+        traceQuery = trace,
+        propositions = store,
+        collectorRecords = records,
+    )
+
+    /** The audit trail a real merging sweep would leave: a live run header and an applied merge. */
+    private fun authorize(
+        records: InMemoryCollectorRecordStore,
+        runId: String,
+        memberId: String,
+        survivorId: String,
+        newStatus: PropositionStatus = PropositionStatus.STALE,
+    ) {
+        records.recordRun(CollectorRun(runId = runId, startedAt = Instant.now(), dryRun = false))
+        records.record(
+            CollectorRecord(
+                propositionId = memberId,
+                reason = MarkReason.Duplicate(survivorId = survivorId),
+                outcome = CollectorOutcome.TRANSITIONED,
+                strategyName = "multi-signal",
+                runId = runId,
+                previousStatus = PropositionStatus.ACTIVE,
+                newStatus = newStatus,
+                mergedIntoId = survivorId,
+            ),
+        )
+    }
 
     @Test
     fun `undo uses authoritative provenance replacement through a base store decorator`() {
         val store = AppendPreservingStore()
         val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
         val keep = ProvenanceEntry(UriLocator("https://example.com/keep"))
         val folded = ProvenanceEntry(UriLocator("https://example.com/folded"))
         val survivor = store.save(proposition("survivor", listOf(keep, folded)))
@@ -68,6 +113,7 @@ class CollectorUndoCapabilityTest {
             proposition("retired", listOf(folded), status = PropositionStatus.STALE),
         )
         val runId = "run-base-store-undo"
+        authorize(records, runId, retired.id, survivor.id)
         trace.recordRunContext(runId, contextId)
         trace.recordDecision(
             runId,
@@ -82,7 +128,7 @@ class CollectorUndoCapabilityTest {
             ),
         )
 
-        val result = undoSingleCollapse(trace, store, survivor.id, retired.id)
+        val result = undo(trace, store, survivor.id, retired.id, records)
 
         assertEquals(listOf(keep), result?.survivor?.provenanceEntries)
         assertEquals(listOf(keep), store.findById(survivor.id)?.provenanceEntries)
@@ -93,6 +139,7 @@ class CollectorUndoCapabilityTest {
     fun `folding a revisioned loser and undoing leaves the survivor's evidence as it was`() {
         val store = InMemoryPropositionRepository()
         val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
         val survivor = store.save(
             proposition("survivor-revision", listOf(revisionOne), text = "Acme signed the agreement"),
         )
@@ -101,7 +148,7 @@ class CollectorUndoCapabilityTest {
         )
         val evidenceBeforeTheFold = survivor.provenanceEntries
 
-        collapse(store, trace, "run-revision-undo", survivor, loser)
+        collapse(store, trace, records, "run-revision-undo", survivor, loser)
 
         // The fold under test: the survivor now also carries r2, and the trace names it exactly.
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
@@ -110,7 +157,7 @@ class CollectorUndoCapabilityTest {
             trace.findRetirement(loser.id)?.foldedProvenanceEvidenceKeys,
         )
 
-        val result = undoSingleCollapse(trace, store, survivor.id, loser.id)
+        val result = undo(trace, store, survivor.id, loser.id, records)
 
         assertEquals(evidenceBeforeTheFold, result?.survivor?.provenanceEntries)
         assertEquals(evidenceBeforeTheFold, store.findById(survivor.id)?.provenanceEntries)
@@ -124,11 +171,13 @@ class CollectorUndoCapabilityTest {
         // and never touches a revision it never saw.
         val store = InMemoryPropositionRepository()
         val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
         val survivor = store.save(proposition("survivor-legacy", listOf(revisionOne, revisionTwo)))
         val retired = store.save(
             proposition("retired-legacy", listOf(revisionTwo), status = PropositionStatus.STALE),
         )
         val runId = "run-legacy-trace"
+        authorize(records, runId, retired.id, survivor.id)
         trace.recordRunContext(runId, contextId)
         trace.recordDecision(
             runId,
@@ -143,7 +192,7 @@ class CollectorUndoCapabilityTest {
             ),
         )
 
-        undoSingleCollapse(trace, store, survivor.id, retired.id)
+        undo(trace, store, survivor.id, retired.id, records)
 
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
     }
@@ -155,12 +204,15 @@ class CollectorUndoCapabilityTest {
         // must take it, because by then nobody is.
         val store = InMemoryPropositionRepository()
         val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
         val evidenceBeforeTheCollapse = listOf(revisionOne)
         val survivor = store.save(proposition("survivor-siblings", listOf(revisionOne, revisionTwo)))
         store.save(proposition("loser-a", listOf(revisionTwo), status = PropositionStatus.STALE))
         store.save(proposition("loser-b", listOf(revisionTwo), status = PropositionStatus.STALE))
         val sharedRevision = ProvenanceEvidenceKey.encode(revisionTwo)
         val runId = "run-siblings"
+        authorize(records, runId, "loser-a", survivor.id)
+        authorize(records, runId, "loser-b", survivor.id)
         trace.recordRunContext(runId, contextId)
         trace.recordDecision(
             runId,
@@ -184,19 +236,19 @@ class CollectorUndoCapabilityTest {
             ),
         )
 
-        undoSingleCollapse(trace, store, survivor.id, "loser-a")
+        undo(trace, store, survivor.id, "loser-a", records)
 
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
         assertEquals(PropositionStatus.ACTIVE, store.findById("loser-a")?.status)
         assertEquals(PropositionStatus.STALE, store.findById("loser-b")?.status)
 
-        undoSingleCollapse(trace, store, survivor.id, "loser-b")
+        undo(trace, store, survivor.id, "loser-b", records)
 
         assertEquals(evidenceBeforeTheCollapse, store.findById(survivor.id)?.provenanceEntries)
         assertEquals(PropositionStatus.ACTIVE, store.findById("loser-b")?.status)
 
         // Undoing an already-restored member is a no-op, not a second subtraction.
-        assertNull(undoSingleCollapse(trace, store, survivor.id, "loser-a"))
+        assertNull(undo(trace, store, survivor.id, "loser-a", records))
         assertEquals(evidenceBeforeTheCollapse, store.findById(survivor.id)?.provenanceEntries)
     }
 
@@ -204,9 +256,10 @@ class CollectorUndoCapabilityTest {
     fun `a dry-run fold leaves the survivor untouched when undone`() {
         // The strategy records its trace during the mark phase, before the runner decides whether
         // to apply anything. A dry run therefore leaves a decision that looks exactly like an
-        // applied fold. The loser's status is what says otherwise: nothing retired it.
+        // applied fold. The run header's dryRun flag is what says nothing happened.
         val store = InMemoryPropositionRepository()
         val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
         val survivor = store.save(
             proposition("survivor-dry-run", listOf(revisionOne), text = "Acme signed the agreement"),
         )
@@ -219,6 +272,7 @@ class CollectorUndoCapabilityTest {
             store,
             CollectorRunContext("run-dry", contextId, dryRun = true),
         )
+        records.recordRun(CollectorRun(runId = "run-dry", startedAt = Instant.now(), dryRun = true))
 
         // The trace is there, and it names the evidence a real fold would have moved.
         assertEquals(
@@ -229,7 +283,7 @@ class CollectorUndoCapabilityTest {
         // Nothing was applied, and later the survivor is extracted with that revision on its own.
         store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
 
-        val result = undoSingleCollapse(trace, store, survivor.id, loser.id)
+        val result = undo(trace, store, survivor.id, loser.id, records)
 
         assertNull(result)
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
@@ -240,6 +294,8 @@ class CollectorUndoCapabilityTest {
     fun `a collapse whose retired member is gone writes nothing`() {
         val store = CountingStore()
         val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        authorize(records, "run-missing-retired", "gone-retired", "survivor-orphaned")
         store.seed(proposition("survivor-orphaned", listOf(revisionOne, revisionTwo)))
         trace.recordRunContext("run-missing-retired", contextId)
         trace.recordDecision(
@@ -247,7 +303,7 @@ class CollectorUndoCapabilityTest {
             decisionWith("component-missing-retired", "survivor-orphaned", foldedRevisionTwo("gone-retired")),
         )
 
-        val result = undoSingleCollapse(trace, store, "survivor-orphaned", "gone-retired")
+        val result = undo(trace, store, "survivor-orphaned", "gone-retired", records)
 
         assertNull(result)
         assertEquals(0, store.writes)
@@ -258,6 +314,8 @@ class CollectorUndoCapabilityTest {
     fun `a collapse whose survivor is gone writes nothing`() {
         val store = CountingStore()
         val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        authorize(records, "run-missing-survivor", "retired-orphaned", "gone-survivor")
         store.seed(proposition("retired-orphaned", listOf(revisionTwo), status = PropositionStatus.STALE))
         trace.recordRunContext("run-missing-survivor", contextId)
         trace.recordDecision(
@@ -265,7 +323,7 @@ class CollectorUndoCapabilityTest {
             decisionWith("component-missing-survivor", "gone-survivor", foldedRevisionTwo("retired-orphaned")),
         )
 
-        val result = undoSingleCollapse(trace, store, "gone-survivor", "retired-orphaned")
+        val result = undo(trace, store, "gone-survivor", "retired-orphaned", records)
 
         assertNull(result)
         assertEquals(0, store.writes)
@@ -278,12 +336,12 @@ class CollectorUndoCapabilityTest {
         // lands, and the store then answers null. Continuing from the copy read earlier would save
         // that copy back and recreate a proposition somebody else deleted, folded evidence and all.
         //
-        // Which branch this exercises, precisely: InMemoryPropositionRepository overrides neither
-        // `subtractProvenance` nor `setProvenance`, so the subtraction here is the base contract's
-        // default, and the deletion lands before its opening `findById`. That read misses and the default answers null on the spot.
-        // Deletions arriving later are a different matter on each store — the default can recreate
-        // the survivor inside its own read-modify-write, and either store's answer is followed by
-        // the undo's `save`, which upserts. The design note scopes both; neither is pinned here.
+        // Which branch this exercises, precisely: the deletion lands before the in-memory store's
+        // atomic subtraction reaches the map, so its `compute` finds no entry and answers null
+        // without writing one. `ProvenanceSubtractionCapable` requires exactly that of every
+        // implementation, so a store cannot resurrect a proposition inside its own subtraction.
+        // A deletion arriving after the subtraction's answer is a different matter: the undo's
+        // `save` upserts, so it recreates the survivor. The design note scopes that residual.
         val store = InMemoryPropositionRepository()
         val trace = InMemoryCollectorTraceStore()
         val records = InMemoryCollectorRecordStore()
@@ -297,7 +355,7 @@ class CollectorUndoCapabilityTest {
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
 
         val racing = DeletingOnSubtract(store, deletes = survivor.id)
-        val result = undoSingleCollapse(trace, racing, survivor.id, loser.id, records)
+        val result = undo(trace, racing, survivor.id, loser.id, records)
 
         assertNull(store.findById(survivor.id), "the deletion wins; the undo must not put the survivor back")
         assertNull(result, "an undo that could not subtract anything must not report a survivor")
@@ -346,7 +404,7 @@ class CollectorUndoCapabilityTest {
         store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
         store.save(store.findById(loser.id)!!.withStatus(PropositionStatus.STALE))
 
-        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        val result = undo(trace, store, survivor.id, loser.id, records)
 
         assertNull(result)
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
@@ -376,7 +434,7 @@ class CollectorUndoCapabilityTest {
             records.findByProposition(loser.id).filter { it.runId == runId }.map { it.mergedIntoId },
         )
 
-        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        val result = undo(trace, store, survivor.id, loser.id, records)
 
         assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
         assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
@@ -398,13 +456,13 @@ class CollectorUndoCapabilityTest {
         )
         sweep(store, trace, records, survivor.id)
 
-        undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        undo(trace, store, survivor.id, loser.id, records)
         assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
 
         // The survivor is later extracted with that revision again, on its own account.
         store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
 
-        val retry = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        val retry = undo(trace, store, survivor.id, loser.id, records)
 
         assertNull(retry)
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
@@ -455,13 +513,13 @@ class CollectorUndoCapabilityTest {
             )
         }
 
-        undoSingleCollapse(trace, store, survivor.id, "loser-a", records)
+        undo(trace, store, survivor.id, "loser-a", records)
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
 
         // A later run retires A again, for reasons of its own.
         retireAgain(store, records, "loser-a")
 
-        undoSingleCollapse(trace, store, survivor.id, "loser-b", records)
+        undo(trace, store, survivor.id, "loser-b", records)
 
         assertEquals(evidenceBeforeTheCollapse, store.findById(survivor.id)?.provenanceEntries)
         assertEquals(PropositionStatus.ACTIVE, store.findById("loser-b")?.status)
@@ -485,7 +543,7 @@ class CollectorUndoCapabilityTest {
         )
         val runId = sweep(store, trace, records, survivor.id)
 
-        undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        undo(trace, store, survivor.id, loser.id, records)
         assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
         assertTrue(
             records.findByProposition(loser.id).any { it.runId == runId && it.undoneAt != null },
@@ -497,7 +555,7 @@ class CollectorUndoCapabilityTest {
         store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
         retireAgain(store, records, loser.id)
 
-        val retry = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        val retry = undo(trace, store, survivor.id, loser.id, records)
 
         assertNull(retry)
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
@@ -520,7 +578,7 @@ class CollectorUndoCapabilityTest {
         val runId = sweep(store, trace, records, survivor.id)
         val original = records.findByProposition(loser.id).first { it.runId == runId }
 
-        undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        undo(trace, store, survivor.id, loser.id, records)
 
         records.record(original)
         assertTrue(
@@ -531,7 +589,7 @@ class CollectorUndoCapabilityTest {
         store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
         retireAgain(store, records, loser.id)
 
-        assertNull(undoSingleCollapse(trace, store, survivor.id, loser.id, records))
+        assertNull(undo(trace, store, survivor.id, loser.id, records))
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
     }
 
@@ -575,7 +633,7 @@ class CollectorUndoCapabilityTest {
         val failing = FailingRecordStore(records)
 
         assertThrows(IllegalStateException::class.java) {
-            undoSingleCollapse(trace, store, survivor.id, loser.id, failing)
+            undo(trace, store, survivor.id, loser.id, failing)
         }
 
         // The survivor's evidence is already off; the member is still retired; nothing is stamped.
@@ -583,7 +641,7 @@ class CollectorUndoCapabilityTest {
         assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
         assertTrue(records.findByProposition(loser.id).none { it.undoneAt != null })
 
-        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        val result = undo(trace, store, survivor.id, loser.id, records)
 
         assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
         assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
@@ -608,7 +666,7 @@ class CollectorUndoCapabilityTest {
         // Stand in for the crash: run the undo far enough to stamp, then stop before the restore.
         val stoppingBeforeRestore = FailingPropositionStore(store, failOnSaveOf = loser.id)
         assertThrows(IllegalStateException::class.java) {
-            undoSingleCollapse(trace, stoppingBeforeRestore, survivor.id, loser.id, records)
+            undo(trace, stoppingBeforeRestore, survivor.id, loser.id, records)
         }
         assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
         assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
@@ -616,7 +674,7 @@ class CollectorUndoCapabilityTest {
         // The survivor legitimately re-gains that revision before anyone retries.
         store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
 
-        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        val result = undo(trace, store, survivor.id, loser.id, records)
 
         assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
         assertEquals(
@@ -644,7 +702,7 @@ class CollectorUndoCapabilityTest {
 
         val stoppingBeforeRestore = FailingPropositionStore(store, failOnSaveOf = loser.id)
         assertThrows(IllegalStateException::class.java) {
-            undoSingleCollapse(trace, stoppingBeforeRestore, survivor.id, loser.id, records)
+            undo(trace, stoppingBeforeRestore, survivor.id, loser.id, records)
         }
 
         // Inside the crash window: a later real run skips the member, and a dry run previews it.
@@ -671,7 +729,7 @@ class CollectorUndoCapabilityTest {
             ),
         )
 
-        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        val result = undo(trace, store, survivor.id, loser.id, records)
 
         assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
         assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
@@ -716,7 +774,7 @@ class CollectorUndoCapabilityTest {
             ),
         )
 
-        val result = undoSingleCollapse(trace, store, survivor.id, "loser-legacy-stamp", records)
+        val result = undo(trace, store, survivor.id, "loser-legacy-stamp", records)
 
         assertNull(result)
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
@@ -742,7 +800,7 @@ class CollectorUndoCapabilityTest {
 
         store.save(store.findById(loser.id)!!.withStatus(PropositionStatus.ACTIVE))
 
-        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        val result = undo(trace, store, survivor.id, loser.id, records)
 
         assertNull(result)
         assertEquals(foldedEvidence, store.findById(survivor.id)?.provenanceEntries)
@@ -772,7 +830,7 @@ class CollectorUndoCapabilityTest {
         // The survivor picks that revision up on its own afterwards.
         store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
 
-        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        val result = undo(trace, store, survivor.id, loser.id, records)
 
         assertNull(result)
         assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
@@ -856,10 +914,274 @@ class CollectorUndoCapabilityTest {
             records.findByProposition(loser.id).filter { it.runId == runId }.map { it.mergedIntoId },
         )
 
-        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        val result = undo(trace, store, survivor.id, loser.id, records)
 
         assertNull(result)
         assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
+    }
+
+    @Test
+    fun `an undo with no record store refuses, and writes nothing`() {
+        // Without records nothing distinguishes an applied merge from a preview of one, so the
+        // undo declines to guess. It declines before it reads, so the store is never approached.
+        val fold = appliedFold("no-records")
+
+        val thrown = assertThrows(CollapseUndoConfigurationException::class.java) {
+            undo(fold.trace, fold.store, fold.survivorId, fold.retiredId, records = null)
+        }
+
+        assertTrue(
+            thrown.message!!.contains("CollectorRecordStore"),
+            "the refusal has to name the store that is missing: ${thrown.message}",
+        )
+        assertEquals(listOf(revisionOne, revisionTwo), fold.store.findById(fold.survivorId)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, fold.store.findById(fold.retiredId)?.status)
+    }
+
+    @Test
+    fun `an undo backed only by a dry-run record refuses, and writes nothing`() {
+        // A dry run writes preview records carrying mergedIntoId and everything else a real merge
+        // would, and then changes nothing at all. The run header's dryRun flag is the marking that
+        // separates the two, and it is what the undo gates on. Same world state as the live-record
+        // test below; only the header differs.
+        val fold = appliedFold("dry-record")
+        val records = InMemoryCollectorRecordStore()
+        records.recordRun(CollectorRun(runId = fold.runId, startedAt = Instant.now(), dryRun = true))
+        records.record(
+            CollectorRecord(
+                propositionId = fold.retiredId,
+                reason = MarkReason.Duplicate(survivorId = fold.survivorId),
+                outcome = CollectorOutcome.TRANSITIONED,
+                strategyName = "multi-signal",
+                runId = fold.runId,
+                previousStatus = PropositionStatus.ACTIVE,
+                newStatus = PropositionStatus.STALE,
+                mergedIntoId = fold.survivorId,
+            ),
+        )
+
+        val result = undo(fold.trace, fold.store, fold.survivorId, fold.retiredId, records)
+
+        assertNull(result)
+        assertEquals(listOf(revisionOne, revisionTwo), fold.store.findById(fold.survivorId)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, fold.store.findById(fold.retiredId)?.status)
+        assertTrue(records.all().none { it.undoneAt != null }, "a refused undo stamps nothing")
+    }
+
+    @Test
+    fun `an undo backed by a live record for the same collapse proceeds`() {
+        // The third of the discriminating trio: identical world state, a real run header, and the
+        // undo goes through.
+        val fold = appliedFold("live-record")
+        val records = InMemoryCollectorRecordStore()
+        authorize(records, fold.runId, fold.retiredId, fold.survivorId)
+
+        val result = undo(fold.trace, fold.store, fold.survivorId, fold.retiredId, records)
+
+        assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
+        assertEquals(listOf(revisionOne), fold.store.findById(fold.survivorId)?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, fold.store.findById(fold.retiredId)?.status)
+        assertTrue(records.findByProposition(fold.retiredId).any { it.undoneAt != null })
+    }
+
+    @Test
+    fun `an undo against a store that cannot subtract atomically refuses, and writes nothing`() {
+        // Undo has to take evidence off by name. A store without that operation would leave the
+        // caller replacing the survivor's evidence wholesale, which silently drops whatever another
+        // extraction added since the read. Refusing is the only safe answer.
+        val fold = appliedFold("no-subtraction")
+        val records = InMemoryCollectorRecordStore()
+        authorize(records, fold.runId, fold.retiredId, fold.survivorId)
+
+        val thrown = assertThrows(CollapseUndoConfigurationException::class.java) {
+            undo(fold.trace, NoSubtractionStore(fold.store), fold.survivorId, fold.retiredId, records)
+        }
+
+        assertTrue(
+            thrown.message!!.contains("ProvenanceSubtractionCapable"),
+            "the refusal has to name the capability the store lacks: ${thrown.message}",
+        )
+        assertEquals(listOf(revisionOne, revisionTwo), fold.store.findById(fold.survivorId)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, fold.store.findById(fold.retiredId)?.status)
+        assertTrue(records.all().none { it.undoneAt != null })
+    }
+
+    @Test
+    fun `a decorator carries its delegate's subtraction, and reports honestly when it has none`() {
+        // Kotlin's interface delegation only covers PropositionRepository, so a decorator has to
+        // carry the capability itself. Wrapping a capable store and losing the capability would
+        // turn every undo behind that decorator into a refusal.
+        val capable = appliedFold("decorated-capable")
+        val capableRecords = InMemoryCollectorRecordStore()
+        authorize(capableRecords, capable.runId, capable.retiredId, capable.survivorId)
+        val decorated = EventEmittingPropositionRepository(capable.store, DiceEventListener.DEV_NULL)
+        assertTrue(decorated.supportsProvenanceSubtraction)
+
+        val result = undo(capable.trace, decorated, capable.survivorId, capable.retiredId, capableRecords)
+
+        assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
+        assertEquals(listOf(revisionOne), capable.store.findById(capable.survivorId)?.provenanceEntries)
+
+        val incapable = appliedFold("decorated-incapable")
+        val incapableRecords = InMemoryCollectorRecordStore()
+        authorize(incapableRecords, incapable.runId, incapable.retiredId, incapable.survivorId)
+        val overIncapable = EventEmittingPropositionRepository(
+            NoSubtractionStore(incapable.store),
+            DiceEventListener.DEV_NULL,
+        )
+        assertFalse(overIncapable.supportsProvenanceSubtraction)
+
+        assertThrows(CollapseUndoConfigurationException::class.java) {
+            undo(incapable.trace, overIncapable, incapable.survivorId, incapable.retiredId, incapableRecords)
+        }
+        assertEquals(
+            listOf(revisionOne, revisionTwo),
+            incapable.store.findById(incapable.survivorId)?.provenanceEntries,
+        )
+    }
+
+    @Test
+    fun `an undo issued for one context refuses ids belonging to another, and leaves it untouched`() {
+        // The whole collapse lives in someone else's context, and the caller supplies its ids while
+        // acting in its own. Every check downstream would pass — the trace is there, the records
+        // authorize it, the member is retired — so ownership is the only thing standing in the way.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val runId = "run-other-context"
+        val survivor = store.save(
+            proposition("survivor-elsewhere", listOf(revisionOne, revisionTwo), context = otherContextId),
+        )
+        val loser = store.save(
+            proposition(
+                "loser-elsewhere",
+                listOf(revisionTwo),
+                status = PropositionStatus.STALE,
+                context = otherContextId,
+            ),
+        )
+        trace.recordRunContext(runId, otherContextId)
+        trace.recordDecision(runId, decisionWith("component-elsewhere", survivor.id, foldedRevisionTwo(loser.id)))
+        authorize(records, runId, loser.id, survivor.id)
+
+        val thrown = assertThrows(CollapseUndoContextMismatchException::class.java) {
+            undo(trace, store, survivor.id, loser.id, records, context = contextId)
+        }
+
+        // The retired member is checked first, so it is the one named. The order is deliberate: see
+        // `a foreign member with a guessed survivor is refused before the mismatch names anything`.
+        assertEquals(loser.id, thrown.propositionId)
+        assertEquals(otherContextId, thrown.actualContextId)
+        assertEquals(contextId, thrown.commandedContextId)
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+        assertTrue(records.all().none { it.undoneAt != null })
+
+        // The same collapse reverses cleanly once the command names the context that owns it, so
+        // the refusal above is about ownership alone.
+        val result = undo(trace, store, survivor.id, loser.id, records, context = otherContextId)
+
+        assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
+    }
+
+    @Test
+    fun `a member from another context cannot be restored into this context's survivor`() {
+        // The mixed case: the survivor is the caller's, the member is not. Both propositions get
+        // the check, so naming a foreign member stops the undo before the survivor is written.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val runId = "run-mixed-contexts"
+        val survivor = store.save(proposition("survivor-here", listOf(revisionOne, revisionTwo)))
+        val loser = store.save(
+            proposition(
+                "loser-there",
+                listOf(revisionTwo),
+                status = PropositionStatus.STALE,
+                context = otherContextId,
+            ),
+        )
+        trace.recordRunContext(runId, contextId)
+        trace.recordDecision(runId, decisionWith("component-mixed", survivor.id, foldedRevisionTwo(loser.id)))
+        authorize(records, runId, loser.id, survivor.id)
+
+        val thrown = assertThrows(CollapseUndoContextMismatchException::class.java) {
+            undo(trace, store, survivor.id, loser.id, records)
+        }
+
+        assertEquals(loser.id, thrown.propositionId)
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+        assertTrue(records.all().none { it.undoneAt != null })
+    }
+
+    @Test
+    fun `a foreign member with a guessed survivor is refused before the mismatch names anything`() {
+        // Probing shape: the caller has a member id from another context and guesses at a survivor.
+        // The survivor-mismatch check would answer that guess by quoting the survivor the decision
+        // really names — the other context's — so ownership is settled first and the caller is told
+        // only that the member is somebody else's.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val runId = "run-probe"
+        val survivor = store.save(
+            proposition("survivor-secret", listOf(revisionOne, revisionTwo), context = otherContextId),
+        )
+        val loser = store.save(
+            proposition(
+                "loser-borrowed",
+                listOf(revisionTwo),
+                status = PropositionStatus.STALE,
+                context = otherContextId,
+            ),
+        )
+        trace.recordRunContext(runId, otherContextId)
+        trace.recordDecision(runId, decisionWith("component-probe", survivor.id, foldedRevisionTwo(loser.id)))
+        authorize(records, runId, loser.id, survivor.id)
+
+        val thrown = assertThrows(CollapseUndoContextMismatchException::class.java) {
+            undo(trace, store, survivorId = "a-guess", retiredId = loser.id, records = records, context = contextId)
+        }
+
+        assertEquals(loser.id, thrown.propositionId)
+        assertFalse(
+            thrown.message!!.contains(survivor.id),
+            "the refusal must leak no id from the context that owns the collapse: ${thrown.message}",
+        )
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+        assertTrue(records.all().none { it.undoneAt != null })
+    }
+
+    /** One collapse already applied in the store, with its trace, and no audit records yet. */
+    private class AppliedFold(
+        val store: InMemoryPropositionRepository,
+        val trace: InMemoryCollectorTraceStore,
+        val survivorId: String,
+        val retiredId: String,
+        val runId: String,
+    )
+
+    /**
+     * Seeds a survivor holding both revisions, a member retired into it, and the trace decision
+     * that describes the fold. The audit records are left to the caller, because what they say is
+     * exactly what the fail-closed tests vary.
+     */
+    private fun appliedFold(suffix: String): AppliedFold {
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val survivor = store.save(proposition("survivor-$suffix", listOf(revisionOne, revisionTwo)))
+        val retiredId = "loser-$suffix"
+        store.save(proposition(retiredId, listOf(revisionTwo), status = PropositionStatus.STALE))
+        val runId = "run-$suffix"
+        trace.recordRunContext(runId, contextId)
+        trace.recordDecision(
+            runId,
+            decisionWith("component-$suffix", survivor.id, foldedRevisionTwo(retiredId)),
+        )
+        return AppliedFold(store, trace, survivor.id, retiredId, runId)
     }
 
     /**
@@ -881,10 +1203,15 @@ class CollectorUndoCapabilityTest {
         listener = DiceEventListener.DEV_NULL,
     ).run(contextId, dryRun = dryRun).runId
 
-    /** Runs the real strategy over one pair, then applies the fold the way a sweep does. */
+    /**
+     * Runs the real strategy over one pair, applies the fold the way a sweep does, and writes the
+     * audit trail that fold would have left. Undo needs all three: the decision to know what moved,
+     * the store to hold the result, and a live record to say the merge really happened.
+     */
     private fun collapse(
         store: InMemoryPropositionRepository,
         trace: InMemoryCollectorTraceStore,
+        records: InMemoryCollectorRecordStore,
         runId: String,
         survivor: Proposition,
         loser: Proposition,
@@ -893,6 +1220,7 @@ class CollectorUndoCapabilityTest {
 
         store.save(store.findById(survivor.id)!!.absorbEvidence(loser))
         store.save(store.findById(loser.id)!!.withStatus(PropositionStatus.STALE))
+        authorize(records, runId, loser.id, survivor.id)
     }
 
     /** A deterministic one-pair strategy, so a trace under test comes from the real mark path. */
@@ -933,9 +1261,10 @@ class CollectorUndoCapabilityTest {
         provenance: List<ProvenanceEntry>,
         text: String = "$id proposition",
         status: PropositionStatus = PropositionStatus.ACTIVE,
+        context: ContextId = contextId,
     ) = Proposition(
         id = id,
-        contextId = contextId,
+        contextId = context,
         text = text,
         mentions = emptyList(),
         confidence = 0.9,
@@ -946,7 +1275,10 @@ class CollectorUndoCapabilityTest {
     /** Models a persistent backend whose ordinary save path never removes unloaded evidence. */
     private class AppendPreservingStore(
         private val delegate: InMemoryPropositionRepository = InMemoryPropositionRepository(),
-    ) : PropositionRepository by delegate {
+    ) : PropositionRepository by delegate, ProvenanceSubtractionCapable {
+
+        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? =
+            delegate.subtractProvenance(propositionId, provenanceRefs)
 
         override fun save(proposition: Proposition): Proposition {
             val existing = delegate.findById(proposition.id) ?: return delegate.save(proposition)
@@ -985,7 +1317,7 @@ class CollectorUndoCapabilityTest {
     private class DeletingOnSubtract(
         private val delegate: InMemoryPropositionRepository,
         private val deletes: String,
-    ) : PropositionRepository by delegate {
+    ) : PropositionRepository by delegate, ProvenanceSubtractionCapable {
 
         override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {
             delegate.delete(deletes)
@@ -997,18 +1329,30 @@ class CollectorUndoCapabilityTest {
     private class FailingPropositionStore(
         private val delegate: InMemoryPropositionRepository,
         private val failOnSaveOf: String,
-    ) : PropositionRepository by delegate {
+    ) : PropositionRepository by delegate, ProvenanceSubtractionCapable {
 
         override fun save(proposition: Proposition): Proposition {
             if (proposition.id == failOnSaveOf) error("simulated crash before the member was restored")
             return delegate.save(proposition)
         }
+
+        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? =
+            delegate.subtractProvenance(propositionId, provenanceRefs)
     }
+
+    /**
+     * A store with no atomic subtraction at all. Kotlin's interface delegation covers
+     * [PropositionRepository], which no longer carries the operation, so this class simply is not
+     * [ProvenanceSubtractionCapable] — which is the state the undo has to refuse on.
+     */
+    private class NoSubtractionStore(
+        delegate: InMemoryPropositionRepository,
+    ) : PropositionRepository by delegate
 
     /** Counts every write an undo attempts, so "nothing was written" is an assertion. */
     private class CountingStore(
         private val delegate: InMemoryPropositionRepository = InMemoryPropositionRepository(),
-    ) : PropositionStore by delegate {
+    ) : PropositionStore by delegate, ProvenanceSubtractionCapable {
 
         var writes = 0
             private set

--- a/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
@@ -1208,6 +1208,30 @@ class CollectorUndoCapabilityTest {
      * audit trail that fold would have left. Undo needs all three: the decision to know what moved,
      * the store to hold the result, and a live record to say the merge really happened.
      */
+    /**
+     * The four-argument form stays callable for one release: it restores the member and takes the
+     * folded refs back off the survivor on the trace's word alone, exactly as it shipped.
+     */
+    @Suppress("DEPRECATION")
+    @Test
+    fun `the deprecated four-argument undo still restores a member and subtracts its folded refs`() {
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val other = ProvenanceEntry(locator = UriLocator("https://example.com/other"))
+        val survivor = store.save(proposition("survivor-legacy", listOf(revisionOne)))
+        val loser = store.save(proposition("loser-legacy", listOf(other)))
+
+        collapse(store, trace, records, "run-legacy-undo", survivor, loser)
+        assertEquals(listOf(revisionOne, other), store.findById(survivor.id)?.provenanceEntries)
+
+        val result = undoSingleCollapse(trace, store, survivor.id, loser.id)
+
+        assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
+        assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
+    }
+
     private fun collapse(
         store: InMemoryPropositionRepository,
         trace: InMemoryCollectorTraceStore,

--- a/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
@@ -273,6 +273,46 @@ class CollectorUndoCapabilityTest {
     }
 
     @Test
+    fun `a survivor deleted before the subtraction is not recreated by the undo`() {
+        // The survivor is read once, up front. Another writer can delete it before the subtraction
+        // lands, and the store then answers null. Continuing from the copy read earlier would save
+        // that copy back and recreate a proposition somebody else deleted, folded evidence and all.
+        //
+        // Which branch this exercises, precisely: InMemoryPropositionRepository overrides neither
+        // `subtractProvenance` nor `setProvenance`, so the subtraction here is the base contract's
+        // default, and the deletion lands before its opening `findById`. That read misses and the default answers null on the spot.
+        // Deletions arriving later are a different matter on each store — the default can recreate
+        // the survivor inside its own read-modify-write, and either store's answer is followed by
+        // the undo's `save`, which upserts. The design note scopes both; neither is pinned here.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(
+            proposition("survivor-deleted-midway", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-deleted-midway", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+        val runId = sweep(store, trace, records, survivor.id)
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+
+        val racing = DeletingOnSubtract(store, deletes = survivor.id)
+        val result = undoSingleCollapse(trace, racing, survivor.id, loser.id, records)
+
+        assertNull(store.findById(survivor.id), "the deletion wins; the undo must not put the survivor back")
+        assertNull(result, "an undo that could not subtract anything must not report a survivor")
+        assertEquals(
+            PropositionStatus.STALE,
+            store.findById(loser.id)?.status,
+            "no restore was performed, so the member stays retired",
+        )
+        assertTrue(
+            records.findByProposition(loser.id).none { it.runId == runId && it.undoneAt != null },
+            "an undo that did nothing must not stamp itself as done",
+        )
+    }
+
+    @Test
     fun `a dry-run trace and an unrelated status transition do not authorize an undo`() {
         // The status proxy alone cannot tell a retirement from a decay sweep. With the run's audit
         // records in hand it does not have to: the run says it changed nothing.
@@ -936,6 +976,23 @@ class CollectorUndoCapabilityTest {
         }
     }
 
+    /**
+     * Another writer deleting a proposition inside the window the undo cannot see: after the undo
+     * read the survivor, before its subtraction reaches the store. Landing it on the call itself is
+     * the latest point the subtraction can still report the deletion, which is what the guard under
+     * test reads. A deletion arriving after that answer is a different, still-open race.
+     */
+    private class DeletingOnSubtract(
+        private val delegate: InMemoryPropositionRepository,
+        private val deletes: String,
+    ) : PropositionRepository by delegate {
+
+        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {
+            delegate.delete(deletes)
+            return delegate.subtractProvenance(propositionId, provenanceRefs)
+        }
+    }
+
     /** Stops the undo at one proposition's save, standing in for a crash before the restore. */
     private class FailingPropositionStore(
         private val delegate: InMemoryPropositionRepository,
@@ -967,6 +1024,11 @@ class CollectorUndoCapabilityTest {
         override fun setProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? {
             writes++
             return delegate.setProvenance(propositionId, entries)
+        }
+
+        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {
+            writes++
+            return delegate.subtractProvenance(propositionId, provenanceRefs)
         }
     }
 }

--- a/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
@@ -1,0 +1,972 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.spi
+
+import com.embabel.agent.core.ContextId
+import com.embabel.dice.common.DiceEvent
+import com.embabel.dice.common.DiceEventListener
+import com.embabel.dice.common.PropositionPersisted
+import com.embabel.dice.projection.lineage.CollectorOutcome
+import com.embabel.dice.projection.lineage.CollectorRecord
+import com.embabel.dice.projection.lineage.CollectorRecordStore
+import com.embabel.dice.projection.lineage.CollectorRun
+import com.embabel.dice.projection.lineage.InMemoryCollectorRecordStore
+import com.embabel.dice.projection.memory.DefaultCollectorRunner
+import com.embabel.dice.projection.memory.RunAwareCollectorStrategy
+import com.embabel.dice.projection.memory.collector.CollectorRunContext
+import com.embabel.dice.projection.memory.collector.CollectorSurvivorPolicy
+import com.embabel.dice.projection.memory.collector.MultiSignalCollectorStrategy
+import com.embabel.dice.proposition.EventEmittingPropositionRepository
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionRepository
+import com.embabel.dice.proposition.PropositionStatus
+import com.embabel.dice.proposition.PropositionStore
+import com.embabel.dice.proposition.store.InMemoryPropositionRepository
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
+import com.embabel.dice.provenance.UriLocator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * What `undoSingleCollapse` owes a store: evidence really comes off the survivor, a fold of
+ * revisioned evidence is reversed exactly, and a collapse whose participants have since gone
+ * leaves nothing half-written.
+ */
+class CollectorUndoCapabilityTest {
+
+    private val contextId = ContextId("ctx-undo-capability")
+    private val locator = UriLocator("https://example.com/source")
+    private val revisionOne = ProvenanceEntry(locator = locator, sourceRevision = "r1")
+    private val revisionTwo = ProvenanceEntry(locator = locator, sourceRevision = "r2")
+
+    @Test
+    fun `undo uses authoritative provenance replacement through a base store decorator`() {
+        val store = AppendPreservingStore()
+        val trace = InMemoryCollectorTraceStore()
+        val keep = ProvenanceEntry(UriLocator("https://example.com/keep"))
+        val folded = ProvenanceEntry(UriLocator("https://example.com/folded"))
+        val survivor = store.save(proposition("survivor", listOf(keep, folded)))
+        val retired = store.save(
+            proposition("retired", listOf(folded), status = PropositionStatus.STALE),
+        )
+        val runId = "run-base-store-undo"
+        trace.recordRunContext(runId, contextId)
+        trace.recordDecision(
+            runId,
+            decisionWith(
+                componentId = "component-base-store-undo",
+                survivorId = survivor.id,
+                retired = RetiredProposition(
+                    propositionId = retired.id,
+                    priorStatus = PropositionStatus.ACTIVE,
+                    foldedProvenanceRefs = listOf(folded.locator.key()),
+                ),
+            ),
+        )
+
+        val result = undoSingleCollapse(trace, store, survivor.id, retired.id)
+
+        assertEquals(listOf(keep), result?.survivor?.provenanceEntries)
+        assertEquals(listOf(keep), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, result?.restored?.status)
+    }
+
+    @Test
+    fun `folding a revisioned loser and undoing leaves the survivor's evidence as it was`() {
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val survivor = store.save(
+            proposition("survivor-revision", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-revision", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+        val evidenceBeforeTheFold = survivor.provenanceEntries
+
+        collapse(store, trace, "run-revision-undo", survivor, loser)
+
+        // The fold under test: the survivor now also carries r2, and the trace names it exactly.
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(
+            listOf(ProvenanceEvidenceKey.encode(revisionTwo)),
+            trace.findRetirement(loser.id)?.foldedProvenanceEvidenceKeys,
+        )
+
+        val result = undoSingleCollapse(trace, store, survivor.id, loser.id)
+
+        assertEquals(evidenceBeforeTheFold, result?.survivor?.provenanceEntries)
+        assertEquals(evidenceBeforeTheFold, store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
+    }
+
+    @Test
+    fun `a legacy locator-key trace leaves revisioned evidence on the survivor`() {
+        // A trace recorded before evidence keys existed names its evidence by locator key, which
+        // reaches revisionless entries only. So an old undo removes exactly what it always removed
+        // and never touches a revision it never saw.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val survivor = store.save(proposition("survivor-legacy", listOf(revisionOne, revisionTwo)))
+        val retired = store.save(
+            proposition("retired-legacy", listOf(revisionTwo), status = PropositionStatus.STALE),
+        )
+        val runId = "run-legacy-trace"
+        trace.recordRunContext(runId, contextId)
+        trace.recordDecision(
+            runId,
+            decisionWith(
+                componentId = "component-legacy",
+                survivorId = survivor.id,
+                retired = RetiredProposition(
+                    propositionId = retired.id,
+                    priorStatus = PropositionStatus.ACTIVE,
+                    foldedProvenanceRefs = listOf(locator.key()),
+                ),
+            ),
+        )
+
+        undoSingleCollapse(trace, store, survivor.id, retired.id)
+
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+    }
+
+    @Test
+    fun `undoing both members of a shared fold drains the survivor back to its pre-collapse evidence`() {
+        // Two losers folded the same revision. The first undo must leave it — the second loser is
+        // still retired and the survivor is holding that evidence on its behalf. The second undo
+        // must take it, because by then nobody is.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val evidenceBeforeTheCollapse = listOf(revisionOne)
+        val survivor = store.save(proposition("survivor-siblings", listOf(revisionOne, revisionTwo)))
+        store.save(proposition("loser-a", listOf(revisionTwo), status = PropositionStatus.STALE))
+        store.save(proposition("loser-b", listOf(revisionTwo), status = PropositionStatus.STALE))
+        val sharedRevision = ProvenanceEvidenceKey.encode(revisionTwo)
+        val runId = "run-siblings"
+        trace.recordRunContext(runId, contextId)
+        trace.recordDecision(
+            runId,
+            CollectorDecision(
+                runId = runId,
+                componentId = "component-siblings",
+                survivorId = survivor.id,
+                action = "duplicate-merge",
+                retired = listOf(
+                    RetiredProposition(
+                        propositionId = "loser-a",
+                        priorStatus = PropositionStatus.ACTIVE,
+                        foldedProvenanceEvidenceKeys = listOf(sharedRevision),
+                    ),
+                    RetiredProposition(
+                        propositionId = "loser-b",
+                        priorStatus = PropositionStatus.ACTIVE,
+                        foldedProvenanceEvidenceKeys = listOf(sharedRevision),
+                    ),
+                ),
+            ),
+        )
+
+        undoSingleCollapse(trace, store, survivor.id, "loser-a")
+
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, store.findById("loser-a")?.status)
+        assertEquals(PropositionStatus.STALE, store.findById("loser-b")?.status)
+
+        undoSingleCollapse(trace, store, survivor.id, "loser-b")
+
+        assertEquals(evidenceBeforeTheCollapse, store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, store.findById("loser-b")?.status)
+
+        // Undoing an already-restored member is a no-op, not a second subtraction.
+        assertNull(undoSingleCollapse(trace, store, survivor.id, "loser-a"))
+        assertEquals(evidenceBeforeTheCollapse, store.findById(survivor.id)?.provenanceEntries)
+    }
+
+    @Test
+    fun `a dry-run fold leaves the survivor untouched when undone`() {
+        // The strategy records its trace during the mark phase, before the runner decides whether
+        // to apply anything. A dry run therefore leaves a decision that looks exactly like an
+        // applied fold. The loser's status is what says otherwise: nothing retired it.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val survivor = store.save(
+            proposition("survivor-dry-run", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-dry-run", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+
+        strategyFor(survivor.id, trace).mark(
+            listOf(survivor, loser),
+            store,
+            CollectorRunContext("run-dry", contextId, dryRun = true),
+        )
+
+        // The trace is there, and it names the evidence a real fold would have moved.
+        assertEquals(
+            listOf(ProvenanceEvidenceKey.encode(revisionTwo)),
+            trace.findRetirement(loser.id)?.foldedProvenanceEvidenceKeys,
+        )
+
+        // Nothing was applied, and later the survivor is extracted with that revision on its own.
+        store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
+
+        val result = undoSingleCollapse(trace, store, survivor.id, loser.id)
+
+        assertNull(result)
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
+    }
+
+    @Test
+    fun `a collapse whose retired member is gone writes nothing`() {
+        val store = CountingStore()
+        val trace = InMemoryCollectorTraceStore()
+        store.seed(proposition("survivor-orphaned", listOf(revisionOne, revisionTwo)))
+        trace.recordRunContext("run-missing-retired", contextId)
+        trace.recordDecision(
+            "run-missing-retired",
+            decisionWith("component-missing-retired", "survivor-orphaned", foldedRevisionTwo("gone-retired")),
+        )
+
+        val result = undoSingleCollapse(trace, store, "survivor-orphaned", "gone-retired")
+
+        assertNull(result)
+        assertEquals(0, store.writes)
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById("survivor-orphaned")?.provenanceEntries)
+    }
+
+    @Test
+    fun `a collapse whose survivor is gone writes nothing`() {
+        val store = CountingStore()
+        val trace = InMemoryCollectorTraceStore()
+        store.seed(proposition("retired-orphaned", listOf(revisionTwo), status = PropositionStatus.STALE))
+        trace.recordRunContext("run-missing-survivor", contextId)
+        trace.recordDecision(
+            "run-missing-survivor",
+            decisionWith("component-missing-survivor", "gone-survivor", foldedRevisionTwo("retired-orphaned")),
+        )
+
+        val result = undoSingleCollapse(trace, store, "gone-survivor", "retired-orphaned")
+
+        assertNull(result)
+        assertEquals(0, store.writes)
+        assertEquals(PropositionStatus.STALE, store.findById("retired-orphaned")?.status)
+    }
+
+    @Test
+    fun `a dry-run trace and an unrelated status transition do not authorize an undo`() {
+        // The status proxy alone cannot tell a retirement from a decay sweep. With the run's audit
+        // records in hand it does not have to: the run says it changed nothing.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val runId = "run-dry-then-decay"
+        val survivor = store.save(
+            proposition("survivor-decay", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-decay", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+        strategyFor(survivor.id, trace).mark(
+            listOf(survivor, loser),
+            store,
+            CollectorRunContext(runId, contextId, dryRun = true),
+        )
+        records.recordRun(CollectorRun(runId = runId, startedAt = Instant.now(), dryRun = true))
+        records.record(
+            CollectorRecord(
+                propositionId = loser.id,
+                reason = MarkReason.Duplicate(survivorId = survivor.id),
+                outcome = CollectorOutcome.MARKED,
+                strategyName = "multi-signal",
+                runId = runId,
+            ),
+        )
+        // The survivor picks up that revision on its own, and a later decay sweep — nothing to do
+        // with the collector — moves the loser off ACTIVE.
+        store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
+        store.save(store.findById(loser.id)!!.withStatus(PropositionStatus.STALE))
+
+        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+
+        assertNull(result)
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+    }
+
+    @Test
+    fun `a collapse the real collector applied is undone`() {
+        // End to end through DefaultCollectorRunner: mark, MergingSweepPolicy, sweep, record.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(
+            proposition("survivor-applied", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-applied", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+
+        val runId = sweep(store, trace, records, survivor.id)
+
+        // The runner folded the loser's evidence on and wrote down where it went.
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+        assertEquals(
+            listOf(survivor.id),
+            records.findByProposition(loser.id).filter { it.runId == runId }.map { it.mergedIntoId },
+        )
+
+        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+
+        assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
+        assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
+    }
+
+    @Test
+    fun `retrying an undo that already succeeded takes nothing further from the survivor`() {
+        // The records are append-only: the run's record still names the merge target after the undo
+        // has run. Only the member's own status says the work is done.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(
+            proposition("survivor-retry", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-retry", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+        sweep(store, trace, records, survivor.id)
+
+        undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
+
+        // The survivor is later extracted with that revision again, on its own account.
+        store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
+
+        val retry = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+
+        assertNull(retry)
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+    }
+
+    @Test
+    fun `a sibling re-retired after its own undo stops holding the shared evidence`() {
+        // A and B both folded the same revision. A is undone, then a later run retires A again. On
+        // status alone A reads as still participating in the original collapse, so B's undo keeps
+        // the shared evidence and the survivor never gets back to where it started. A's undoneAt
+        // for this run is what says its fold is reversed, whatever happened to it since.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val evidenceBeforeTheCollapse = listOf(revisionOne)
+        val survivor = store.save(proposition("survivor-shared", listOf(revisionOne, revisionTwo)))
+        store.save(proposition("loser-a", listOf(revisionTwo), status = PropositionStatus.STALE))
+        store.save(proposition("loser-b", listOf(revisionTwo), status = PropositionStatus.STALE))
+        val sharedRevision = ProvenanceEvidenceKey.encode(revisionTwo)
+        val runId = "run-shared-siblings"
+        trace.recordRunContext(runId, contextId)
+        trace.recordDecision(
+            runId,
+            CollectorDecision(
+                runId = runId,
+                componentId = "component-shared-siblings",
+                survivorId = survivor.id,
+                action = "duplicate-merge",
+                retired = listOf(
+                    RetiredProposition("loser-a", PropositionStatus.ACTIVE, foldedProvenanceEvidenceKeys = listOf(sharedRevision)),
+                    RetiredProposition("loser-b", PropositionStatus.ACTIVE, foldedProvenanceEvidenceKeys = listOf(sharedRevision)),
+                ),
+            ),
+        )
+        records.recordRun(CollectorRun(runId = runId, startedAt = Instant.now(), dryRun = false))
+        listOf("loser-a", "loser-b").forEach { memberId ->
+            records.record(
+                CollectorRecord(
+                    propositionId = memberId,
+                    reason = MarkReason.Duplicate(survivorId = survivor.id),
+                    outcome = CollectorOutcome.TRANSITIONED,
+                    strategyName = "multi-signal",
+                    runId = runId,
+                    previousStatus = PropositionStatus.ACTIVE,
+                    newStatus = PropositionStatus.STALE,
+                    mergedIntoId = survivor.id,
+                ),
+            )
+        }
+
+        undoSingleCollapse(trace, store, survivor.id, "loser-a", records)
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+
+        // A later run retires A again, for reasons of its own.
+        retireAgain(store, records, "loser-a")
+
+        undoSingleCollapse(trace, store, survivor.id, "loser-b", records)
+
+        assertEquals(evidenceBeforeTheCollapse, store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, store.findById("loser-b")?.status)
+        assertEquals(PropositionStatus.STALE, store.findById("loser-a")?.status, "A's later retirement stands")
+    }
+
+    @Test
+    fun `a later unrelated retirement cannot re-arm an undo that already ran`() {
+        // The audit records never expire, so "was this applied" stays true forever. If completion
+        // were judged by status alone, any later retirement — a decay sweep, another collector run —
+        // would put the member back off its prior status and re-arm run 1's undo, which would then
+        // subtract run 1's evidence a second time. The undoneAt stamp is what closes that.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(
+            proposition("survivor-rearm", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-rearm", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+        val runId = sweep(store, trace, records, survivor.id)
+
+        undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+        assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
+        assertTrue(
+            records.findByProposition(loser.id).any { it.runId == runId && it.undoneAt != null },
+            "finishing the undo must stamp the run's record",
+        )
+
+        // Life goes on: the survivor picks that revision up again, and a later decay sweep retires
+        // the member a second time.
+        store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
+        retireAgain(store, records, loser.id)
+
+        val retry = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+
+        assertNull(retry)
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+    }
+
+    @Test
+    fun `replaying the original outcome after an undo does not clear its stamp`() {
+        // Replaying a collector outcome is supported, and a replayed record carries no stamp. If
+        // that cleared the stored one, the collapse would be authorized again.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(
+            proposition("survivor-replay", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-replay", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+        val runId = sweep(store, trace, records, survivor.id)
+        val original = records.findByProposition(loser.id).first { it.runId == runId }
+
+        undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+
+        records.record(original)
+        assertTrue(
+            records.findByProposition(loser.id).any { it.runId == runId && it.undoneAt != null },
+            "a replayed outcome must not erase the undo stamp",
+        )
+
+        store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
+        retireAgain(store, records, loser.id)
+
+        assertNull(undoSingleCollapse(trace, store, survivor.id, loser.id, records))
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+    }
+
+    /** A later, unrelated sweep retiring the member again — status change plus its own audit record. */
+    private fun retireAgain(
+        store: InMemoryPropositionRepository,
+        records: InMemoryCollectorRecordStore,
+        memberId: String,
+        runId: String = "run-later-decay",
+    ) {
+        store.save(store.findById(memberId)!!.withStatus(PropositionStatus.STALE))
+        records.recordRun(CollectorRun(runId = runId, startedAt = Instant.now(), dryRun = false))
+        records.record(
+            CollectorRecord(
+                propositionId = memberId,
+                reason = MarkReason.Stale,
+                outcome = CollectorOutcome.TRANSITIONED,
+                strategyName = "decay",
+                runId = runId,
+                previousStatus = PropositionStatus.ACTIVE,
+                newStatus = PropositionStatus.STALE,
+            ),
+        )
+    }
+
+    @Test
+    fun `an undo interrupted before its stamp is completed by a retry`() {
+        // Crash window (2): the survivor's writes landed, the stamp did not. The member is still
+        // retired and nothing is stamped, so a retry re-runs the whole undo — and the evidence
+        // subtraction is a no-op because it is recomputed from what the survivor holds now.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(
+            proposition("survivor-crash-stamp", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-crash-stamp", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+        val runId = sweep(store, trace, records, survivor.id)
+        val failing = FailingRecordStore(records)
+
+        assertThrows(IllegalStateException::class.java) {
+            undoSingleCollapse(trace, store, survivor.id, loser.id, failing)
+        }
+
+        // The survivor's evidence is already off; the member is still retired; nothing is stamped.
+        assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+        assertTrue(records.findByProposition(loser.id).none { it.undoneAt != null })
+
+        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+
+        assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
+        assertTrue(records.findByProposition(loser.id).any { it.runId == runId && it.undoneAt != null })
+    }
+
+    @Test
+    fun `an undo interrupted after its stamp completes only the restore`() {
+        // Crash window (3): stamped, but the member never got restored. A retry must finish the
+        // restore and touch no evidence — the survivor may have re-gained that revision since.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(
+            proposition("survivor-crash-restore", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-crash-restore", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+        sweep(store, trace, records, survivor.id)
+
+        // Stand in for the crash: run the undo far enough to stamp, then stop before the restore.
+        val stoppingBeforeRestore = FailingPropositionStore(store, failOnSaveOf = loser.id)
+        assertThrows(IllegalStateException::class.java) {
+            undoSingleCollapse(trace, stoppingBeforeRestore, survivor.id, loser.id, records)
+        }
+        assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+
+        // The survivor legitimately re-gains that revision before anyone retries.
+        store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
+
+        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+
+        assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
+        assertEquals(
+            listOf(revisionOne, revisionTwo),
+            store.findById(survivor.id)?.provenanceEntries,
+            "resuming must restore the member without touching evidence",
+        )
+    }
+
+    @Test
+    fun `a later run that skipped the member does not strand an interrupted undo`() {
+        // A SKIPPED record is the literal statement that a run left the member alone, and a dry run
+        // changes nothing. Counting either as "someone acted since the stamp" would refuse the
+        // resumption forever, leaving the member retired with its evidence already off the survivor.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(
+            proposition("survivor-skip", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-skip", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+        sweep(store, trace, records, survivor.id)
+
+        val stoppingBeforeRestore = FailingPropositionStore(store, failOnSaveOf = loser.id)
+        assertThrows(IllegalStateException::class.java) {
+            undoSingleCollapse(trace, stoppingBeforeRestore, survivor.id, loser.id, records)
+        }
+
+        // Inside the crash window: a later real run skips the member, and a dry run previews it.
+        records.recordRun(CollectorRun(runId = "run-skipper", startedAt = Instant.now(), dryRun = false))
+        records.record(
+            CollectorRecord(
+                propositionId = loser.id,
+                reason = MarkReason.Stale,
+                outcome = CollectorOutcome.SKIPPED,
+                strategyName = "decay",
+                runId = "run-skipper",
+            ),
+        )
+        records.recordRun(CollectorRun(runId = "run-preview", startedAt = Instant.now(), dryRun = true))
+        records.record(
+            CollectorRecord(
+                propositionId = loser.id,
+                reason = MarkReason.Stale,
+                outcome = CollectorOutcome.TRANSITIONED,
+                strategyName = "decay",
+                runId = "run-preview",
+                previousStatus = PropositionStatus.ACTIVE,
+                newStatus = PropositionStatus.STALE,
+            ),
+        )
+
+        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+
+        assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
+        assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
+    }
+
+    @Test
+    fun `a stamped record that never recorded where it left the member does not resume`() {
+        // A record with no newStatus predates the mechanism, so it cannot say where the collapse
+        // left the member. Treating that as "sitting where we left it" would resume against a
+        // re-retirement to any status at all, so it refuses instead.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val runId = "run-legacy-stamp"
+        val survivor = store.save(proposition("survivor-legacy-stamp", listOf(revisionOne, revisionTwo)))
+        store.save(
+            proposition("loser-legacy-stamp", listOf(revisionTwo), status = PropositionStatus.STALE),
+        )
+        trace.recordRunContext(runId, contextId)
+        trace.recordDecision(
+            runId,
+            decisionWith(
+                componentId = "component-legacy-stamp",
+                survivorId = survivor.id,
+                retired = RetiredProposition(
+                    propositionId = "loser-legacy-stamp",
+                    priorStatus = PropositionStatus.ACTIVE,
+                    foldedProvenanceEvidenceKeys = listOf(ProvenanceEvidenceKey.encode(revisionTwo)),
+                ),
+            ),
+        )
+        records.recordRun(CollectorRun(runId = runId, startedAt = Instant.now(), dryRun = false))
+        records.record(
+            CollectorRecord(
+                propositionId = "loser-legacy-stamp",
+                reason = MarkReason.Duplicate(survivorId = survivor.id),
+                outcome = CollectorOutcome.TRANSITIONED,
+                strategyName = "multi-signal",
+                runId = runId,
+                mergedIntoId = survivor.id,
+                undoneAt = Instant.now(),
+            ),
+        )
+
+        val result = undoSingleCollapse(trace, store, survivor.id, "loser-legacy-stamp", records)
+
+        assertNull(result)
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, store.findById("loser-legacy-stamp")?.status)
+    }
+
+    @Test
+    fun `an applied collapse whose member revived is refused, like any completed undo`() {
+        // A revived member and a completed undo are the same observation: status back at
+        // priorStatus, records still naming the merge. Refusing loses an undo; accepting would
+        // delete evidence the survivor may have re-earned. The refusal is the deliberate choice.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(
+            proposition("survivor-revived", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-revived", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+        sweep(store, trace, records, survivor.id)
+        val foldedEvidence = store.findById(survivor.id)!!.provenanceEntries
+
+        store.save(store.findById(loser.id)!!.withStatus(PropositionStatus.ACTIVE))
+
+        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+
+        assertNull(result)
+        assertEquals(foldedEvidence, store.findById(survivor.id)?.provenanceEntries)
+    }
+
+    @Test
+    fun `a status-transition sweep records no merge, so its trace cannot authorize an undo`() {
+        // StatusTransitionSweepPolicy retires the loser and folds nothing. The trace looks the same
+        // as an applied merge; the absence of a merge target on the record is what differs.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(
+            proposition("survivor-transition", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-transition", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+
+        val runId = sweep(store, trace, records, survivor.id, policy = StatusTransitionSweepPolicy())
+
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+        assertEquals(
+            listOf<String?>(null),
+            records.findByProposition(loser.id).filter { it.runId == runId }.map { it.mergedIntoId },
+        )
+        // The survivor picks that revision up on its own afterwards.
+        store.save(store.findById(survivor.id)!!.withProvenanceEntries(listOf(revisionTwo)))
+
+        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+
+        assertNull(result)
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+    }
+
+    @Test
+    fun `a fallback retirement records no merge, so its trace cannot authorize an undo`() {
+        // The named survivor is not ACTIVE when the sweep runs, so the runner retires the loser
+        // without merging anything onto it. The trace still describes a duplicate-merge collapse,
+        // and that is exactly the shape that used to authorize an undo.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(
+            proposition(
+                "survivor-fallback",
+                listOf(revisionOne),
+                text = "Acme signed the agreement",
+                status = PropositionStatus.STALE,
+            ),
+        )
+        val loser = store.save(
+            proposition("loser-fallback", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+        val runner = DefaultCollectorRunner(
+            repository = store,
+            strategies = listOf(
+                // A strategy that marks the loser as a duplicate of the retired survivor and
+                // records the collapse, the way MultiSignalCollectorStrategy would. It is written
+                // out here because that strategy only ever sees ACTIVE candidates, and this
+                // scenario needs a survivor that is not one.
+                object : RunAwareCollectorStrategy {
+                    override fun mark(
+                        candidates: List<Proposition>,
+                        repository: PropositionRepository,
+                        ctx: CollectorRunContext,
+                    ): List<PropositionMark> {
+                        trace.recordRunContext(ctx.runId, ctx.contextId)
+                        trace.recordDecision(
+                            ctx.runId,
+                            decisionWith(
+                                componentId = "component-fallback",
+                                survivorId = survivor.id,
+                                retired = RetiredProposition(
+                                    propositionId = loser.id,
+                                    priorStatus = PropositionStatus.ACTIVE,
+                                    foldedProvenanceEvidenceKeys = listOf(
+                                        ProvenanceEvidenceKey.encode(revisionTwo),
+                                    ),
+                                ),
+                            ),
+                        )
+                        return listOf(
+                            PropositionMark(
+                                propositionId = loser.id,
+                                reason = MarkReason.Duplicate(survivorId = survivor.id),
+                                strategyName = "test-duplicate",
+                            ),
+                        )
+                    }
+
+                    override fun mark(
+                        candidates: List<Proposition>,
+                        repository: PropositionRepository,
+                        contextId: ContextId,
+                    ): List<PropositionMark> = emptyList()
+                },
+            ),
+            policy = MergingSweepPolicy(),
+            recordStore = records,
+            listener = DiceEventListener.DEV_NULL,
+        )
+
+        val runId = runner.run(contextId, dryRun = false).runId
+
+        // The loser was retired, and nothing was folded onto the survivor.
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+        assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(
+            listOf<String?>(null),
+            records.findByProposition(loser.id).filter { it.runId == runId }.map { it.mergedIntoId },
+        )
+
+        val result = undoSingleCollapse(trace, store, survivor.id, loser.id, records)
+
+        assertNull(result)
+        assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
+    }
+
+    /**
+     * Runs the whole collector — mark, decide, sweep, record — over one duplicate pair, the way
+     * production does. What lands in [records] is what `DefaultCollectorRunner` really writes.
+     */
+    private fun sweep(
+        store: InMemoryPropositionRepository,
+        trace: InMemoryCollectorTraceStore,
+        records: InMemoryCollectorRecordStore,
+        survivorId: String,
+        policy: SweepPolicy = MergingSweepPolicy(),
+        dryRun: Boolean = false,
+    ): String = DefaultCollectorRunner(
+        repository = store,
+        strategies = listOf(strategyFor(survivorId, trace)),
+        policy = policy,
+        recordStore = records,
+        listener = DiceEventListener.DEV_NULL,
+    ).run(contextId, dryRun = dryRun).runId
+
+    /** Runs the real strategy over one pair, then applies the fold the way a sweep does. */
+    private fun collapse(
+        store: InMemoryPropositionRepository,
+        trace: InMemoryCollectorTraceStore,
+        runId: String,
+        survivor: Proposition,
+        loser: Proposition,
+    ) {
+        strategyFor(survivor.id, trace).mark(listOf(survivor, loser), store, CollectorRunContext(runId, contextId))
+
+        store.save(store.findById(survivor.id)!!.absorbEvidence(loser))
+        store.save(store.findById(loser.id)!!.withStatus(PropositionStatus.STALE))
+    }
+
+    /** A deterministic one-pair strategy, so a trace under test comes from the real mark path. */
+    private fun strategyFor(survivorId: String, trace: InMemoryCollectorTraceStore) =
+        MultiSignalCollectorStrategy(
+            pairSources = listOf(
+                CandidatePairSource { candidates, _ ->
+                    listOf(CandidatePair(anchor = candidates[0], member = candidates[1]))
+                },
+            ),
+            scorers = listOf(CollectorSignalScorer { _, _ -> CollectorSignalScore(signal = "fixed", score = 1.0) }),
+            componentsFinder = InMemoryConnectedComponentsFinder(),
+            traceStore = trace,
+            survivorPolicy = CollectorSurvivorPolicy { members -> members.single { it.id == survivorId } },
+            matchThreshold = 0.5,
+        )
+
+    private fun foldedRevisionTwo(propositionId: String) = RetiredProposition(
+        propositionId = propositionId,
+        priorStatus = PropositionStatus.ACTIVE,
+        foldedProvenanceEvidenceKeys = listOf(ProvenanceEvidenceKey.encode(revisionTwo)),
+    )
+
+    private fun decisionWith(
+        componentId: String,
+        survivorId: String,
+        retired: RetiredProposition,
+    ) = CollectorDecision(
+        runId = "",
+        componentId = componentId,
+        survivorId = survivorId,
+        action = "duplicate-merge",
+        retired = listOf(retired),
+    )
+
+    private fun proposition(
+        id: String,
+        provenance: List<ProvenanceEntry>,
+        text: String = "$id proposition",
+        status: PropositionStatus = PropositionStatus.ACTIVE,
+    ) = Proposition(
+        id = id,
+        contextId = contextId,
+        text = text,
+        mentions = emptyList(),
+        confidence = 0.9,
+        provenanceEntries = provenance,
+        status = status,
+    )
+
+    /** Models a persistent backend whose ordinary save path never removes unloaded evidence. */
+    private class AppendPreservingStore(
+        private val delegate: InMemoryPropositionRepository = InMemoryPropositionRepository(),
+    ) : PropositionRepository by delegate {
+
+        override fun save(proposition: Proposition): Proposition {
+            val existing = delegate.findById(proposition.id) ?: return delegate.save(proposition)
+            return delegate.save(
+                proposition.copy(
+                    provenanceEntries = (existing.provenanceEntries + proposition.provenanceEntries).distinct(),
+                ),
+            )
+        }
+
+        override fun setProvenance(
+            propositionId: String,
+            entries: List<ProvenanceEntry>,
+        ): Proposition? = delegate.findById(propositionId)?.let { existing ->
+            delegate.save(existing.withProvenance(entries))
+        }
+    }
+
+    /** Stops the undo where a crash would, at the `undoneAt` stamp. */
+    private class FailingRecordStore(
+        private val delegate: InMemoryCollectorRecordStore,
+    ) : CollectorRecordStore by delegate {
+
+        override fun record(record: CollectorRecord) {
+            if (record.undoneAt != null) error("simulated crash before the undo stamp was persisted")
+            delegate.record(record)
+        }
+    }
+
+    /** Stops the undo at one proposition's save, standing in for a crash before the restore. */
+    private class FailingPropositionStore(
+        private val delegate: InMemoryPropositionRepository,
+        private val failOnSaveOf: String,
+    ) : PropositionRepository by delegate {
+
+        override fun save(proposition: Proposition): Proposition {
+            if (proposition.id == failOnSaveOf) error("simulated crash before the member was restored")
+            return delegate.save(proposition)
+        }
+    }
+
+    /** Counts every write an undo attempts, so "nothing was written" is an assertion. */
+    private class CountingStore(
+        private val delegate: InMemoryPropositionRepository = InMemoryPropositionRepository(),
+    ) : PropositionStore by delegate {
+
+        var writes = 0
+            private set
+
+        /** Puts a proposition in place without counting it as a write. */
+        fun seed(proposition: Proposition): Proposition = delegate.save(proposition)
+
+        override fun save(proposition: Proposition): Proposition {
+            writes++
+            return delegate.save(proposition)
+        }
+
+        override fun setProvenance(propositionId: String, entries: List<ProvenanceEntry>): Proposition? {
+            writes++
+            return delegate.setProvenance(propositionId, entries)
+        }
+    }
+}

--- a/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
@@ -442,6 +442,37 @@ class CollectorUndoCapabilityTest {
     }
 
     @Test
+    fun `a member that survived an earlier fold is undone from the fold that retired it`() {
+        // Run 1 folds A into B, so run 1's decision names B as the survivor. Run 2 later folds B
+        // into C. A lookup that can answer either side of a merge would find run 1 first for "B",
+        // the decision where it survived, and never reach run 2, the one that actually authorizes
+        // undoing B out of C.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val uniqueA = ProvenanceEntry(UriLocator("https://example.com/shadow/a"))
+        val uniqueB = ProvenanceEntry(UriLocator("https://example.com/shadow/b"))
+        val uniqueC = ProvenanceEntry(UriLocator("https://example.com/shadow/c"))
+        val a = store.save(proposition("a-shadowed", listOf(uniqueA), text = "Acme signed the first agreement"))
+        val b = store.save(proposition("b-shadowed", listOf(uniqueB), text = "Acme signed a related agreement"))
+
+        sweep(store, trace, records, survivorId = b.id)
+        assertEquals(PropositionStatus.STALE, store.findById(a.id)?.status)
+        assertEquals(setOf(uniqueA, uniqueB), store.findById(b.id)?.provenanceEntries?.toSet())
+
+        val c = store.save(proposition("c-shadowed", listOf(uniqueC), text = "Acme closed the funding round"))
+        sweep(store, trace, records, survivorId = c.id)
+        assertEquals(PropositionStatus.STALE, store.findById(b.id)?.status)
+        assertEquals(setOf(uniqueA, uniqueB, uniqueC), store.findById(c.id)?.provenanceEntries?.toSet())
+
+        val result = undo(trace, store, c.id, b.id, records)
+
+        assertTrue(result != null, "undo must find run 2's retirement of B, not run 1's decision where B survived")
+        assertEquals(PropositionStatus.ACTIVE, store.findById(b.id)?.status)
+        assertEquals(setOf(uniqueC), store.findById(c.id)?.provenanceEntries?.toSet())
+    }
+
+    @Test
     fun `retrying an undo that already succeeded takes nothing further from the survivor`() {
         // The records are append-only: the run's record still names the merge target after the undo
         // has run. Only the member's own status says the work is done.

--- a/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
@@ -136,6 +136,108 @@ class CollectorUndoCapabilityTest {
     }
 
     @Test
+    fun `an undo never saves over the survivor`() {
+        // The survivor's write goes through the capability and nothing else. A save after the
+        // subtraction would carry this function's copy of the survivor back over the store, and on a
+        // backend whose save replaces the row that copy would put back evidence another writer added
+        // in the meantime. Grounding and source ids come off in the same step as the evidence.
+        val store = SaveRecordingStore()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val keep = ProvenanceEntry(UriLocator("https://example.com/keep"))
+        val folded = ProvenanceEntry(UriLocator("https://example.com/folded"))
+        val survivor = store.seed(
+            proposition("survivor-no-save", listOf(keep, folded)).copy(
+                grounding = listOf("chunk-keep", "chunk-folded"),
+                sourceIds = listOf("src-keep", "src-folded"),
+            ),
+        )
+        val retired = store.seed(proposition("retired-no-save", listOf(folded), status = PropositionStatus.STALE))
+        val runId = "run-no-save"
+        authorize(records, runId, retired.id, survivor.id)
+        trace.recordRunContext(runId, contextId)
+        trace.recordDecision(
+            runId,
+            decisionWith(
+                componentId = "component-no-save",
+                survivorId = survivor.id,
+                retired = RetiredProposition(
+                    propositionId = retired.id,
+                    priorStatus = PropositionStatus.ACTIVE,
+                    foldedGrounding = listOf("chunk-folded"),
+                    foldedProvenanceRefs = listOf(folded.locator.key()),
+                    foldedSourceIds = listOf("src-folded"),
+                ),
+            ),
+        )
+
+        val result = undo(trace, store, survivor.id, retired.id, records)
+
+        assertEquals(listOf(retired.id), store.savedIds, "the member's restore is the only save an undo issues")
+        val after = store.findById(survivor.id)
+        assertEquals(listOf(keep), after?.provenanceEntries)
+        assertEquals(listOf("chunk-keep"), after?.grounding)
+        assertEquals(listOf("src-keep"), after?.sourceIds)
+        assertEquals(listOf(keep), result?.survivor?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, result?.restored?.status)
+    }
+
+    @Test
+    fun `evidence another writer adds after the subtraction survives the undo`() {
+        // The other writer lands right after the subtraction returns, inside the window a trailing
+        // save used to cover. In memory, save replaces the row, so saving the undo's copy would have
+        // put the survivor back to what the subtraction answered and dropped the newcomer.
+        val delegate = InMemoryPropositionRepository()
+        val newcomer = ProvenanceEntry(UriLocator("https://example.com/newcomer"))
+        val store = AddingAfterSubtract(delegate, adds = newcomer)
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val keep = ProvenanceEntry(UriLocator("https://example.com/keep"))
+        val folded = ProvenanceEntry(UriLocator("https://example.com/folded"))
+        val survivor = delegate.save(proposition("survivor-newcomer", listOf(keep, folded)))
+        val retired = delegate.save(proposition("retired-newcomer", listOf(folded), status = PropositionStatus.STALE))
+        val runId = "run-newcomer"
+        authorize(records, runId, retired.id, survivor.id)
+        trace.recordRunContext(runId, contextId)
+        trace.recordDecision(
+            runId,
+            decisionWith(
+                componentId = "component-newcomer",
+                survivorId = survivor.id,
+                retired = RetiredProposition(
+                    propositionId = retired.id,
+                    priorStatus = PropositionStatus.ACTIVE,
+                    foldedProvenanceRefs = listOf(folded.locator.key()),
+                ),
+            ),
+        )
+
+        val result = undo(trace, store, survivor.id, retired.id, records)
+
+        assertTrue(result != null, "the undo completes")
+        assertEquals(setOf(keep, newcomer), delegate.findById(survivor.id)?.provenanceEntries?.toSet())
+        assertEquals(PropositionStatus.ACTIVE, delegate.findById(retired.id)?.status)
+    }
+
+    @Test
+    fun `an undo announces the member's restore and nothing for the survivor`() {
+        // save is the write the decorator publishes from, and the survivor is never written through
+        // it, so a listener hears one event: the member coming back to its prior status. Coming back
+        // to ACTIVE is announced as a plain persist, the way the decorator treats every ACTIVE save.
+        val fold = appliedFold("announced")
+        val records = InMemoryCollectorRecordStore()
+        authorize(records, fold.runId, fold.retiredId, fold.survivorId)
+        val events = mutableListOf<DiceEvent>()
+        val decorated = EventEmittingPropositionRepository(fold.store) { events += it }
+
+        val result = undo(fold.trace, decorated, fold.survivorId, fold.retiredId, records)
+
+        assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
+        assertEquals(1, events.size, "one save, one event: $events")
+        assertEquals(fold.retiredId, (events.single() as PropositionPersisted).proposition.id)
+    }
+
+    @Test
     fun `folding a revisioned loser and undoing leaves the survivor's evidence as it was`() {
         val store = InMemoryPropositionRepository()
         val trace = InMemoryCollectorTraceStore()
@@ -1327,13 +1429,59 @@ class CollectorUndoCapabilityTest {
         status = status,
     )
 
+    /** Records the id of every proposition an undo saves, so "never over the survivor" is an assertion. */
+    private class SaveRecordingStore(
+        private val delegate: InMemoryPropositionRepository = InMemoryPropositionRepository(),
+    ) : PropositionRepository by delegate, ProvenanceSubtractionCapable {
+
+        val savedIds = mutableListOf<String>()
+
+        /** Puts a proposition in place without recording it as a save. */
+        fun seed(proposition: Proposition): Proposition = delegate.save(proposition)
+
+        override fun save(proposition: Proposition): Proposition {
+            savedIds += proposition.id
+            return delegate.save(proposition)
+        }
+
+        override fun subtractFoldedEvidence(
+            propositionId: String,
+            provenanceRefs: List<String>,
+            grounding: Collection<String>,
+            sourceIds: Collection<String>,
+        ): Proposition? = delegate.subtractFoldedEvidence(propositionId, provenanceRefs, grounding, sourceIds)
+    }
+
+    /** Another writer appending evidence to the proposition the moment the undo's subtraction returns. */
+    private class AddingAfterSubtract(
+        private val delegate: InMemoryPropositionRepository,
+        private val adds: ProvenanceEntry,
+    ) : PropositionRepository by delegate, ProvenanceSubtractionCapable {
+
+        override fun subtractFoldedEvidence(
+            propositionId: String,
+            provenanceRefs: List<String>,
+            grounding: Collection<String>,
+            sourceIds: Collection<String>,
+        ): Proposition? {
+            val subtracted = delegate.subtractFoldedEvidence(propositionId, provenanceRefs, grounding, sourceIds)
+            delegate.addProvenance(propositionId, listOf(adds))
+            return subtracted
+        }
+    }
+
     /** Models a persistent backend whose ordinary save path never removes unloaded evidence. */
     private class AppendPreservingStore(
         private val delegate: InMemoryPropositionRepository = InMemoryPropositionRepository(),
     ) : PropositionRepository by delegate, ProvenanceSubtractionCapable {
 
-        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? =
-            delegate.subtractProvenance(propositionId, provenanceRefs)
+        override fun subtractFoldedEvidence(
+            propositionId: String,
+            provenanceRefs: List<String>,
+            grounding: Collection<String>,
+            sourceIds: Collection<String>,
+        ): Proposition? =
+            delegate.subtractFoldedEvidence(propositionId, provenanceRefs, grounding, sourceIds)
 
         override fun save(proposition: Proposition): Proposition {
             val existing = delegate.findById(proposition.id) ?: return delegate.save(proposition)
@@ -1374,9 +1522,14 @@ class CollectorUndoCapabilityTest {
         private val deletes: String,
     ) : PropositionRepository by delegate, ProvenanceSubtractionCapable {
 
-        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {
+        override fun subtractFoldedEvidence(
+            propositionId: String,
+            provenanceRefs: List<String>,
+            grounding: Collection<String>,
+            sourceIds: Collection<String>,
+        ): Proposition? {
             delegate.delete(deletes)
-            return delegate.subtractProvenance(propositionId, provenanceRefs)
+            return delegate.subtractFoldedEvidence(propositionId, provenanceRefs, grounding, sourceIds)
         }
     }
 
@@ -1391,8 +1544,13 @@ class CollectorUndoCapabilityTest {
             return delegate.save(proposition)
         }
 
-        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? =
-            delegate.subtractProvenance(propositionId, provenanceRefs)
+        override fun subtractFoldedEvidence(
+            propositionId: String,
+            provenanceRefs: List<String>,
+            grounding: Collection<String>,
+            sourceIds: Collection<String>,
+        ): Proposition? =
+            delegate.subtractFoldedEvidence(propositionId, provenanceRefs, grounding, sourceIds)
     }
 
     /**
@@ -1425,9 +1583,14 @@ class CollectorUndoCapabilityTest {
             return delegate.setProvenance(propositionId, entries)
         }
 
-        override fun subtractProvenance(propositionId: String, provenanceRefs: List<String>): Proposition? {
+        override fun subtractFoldedEvidence(
+            propositionId: String,
+            provenanceRefs: List<String>,
+            grounding: Collection<String>,
+            sourceIds: Collection<String>,
+        ): Proposition? {
             writes++
-            return delegate.subtractProvenance(propositionId, provenanceRefs)
+            return delegate.subtractFoldedEvidence(propositionId, provenanceRefs, grounding, sourceIds)
         }
     }
 }

--- a/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
@@ -41,6 +41,7 @@ import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import com.embabel.dice.provenance.UriLocator
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -228,7 +229,7 @@ class CollectorUndoCapabilityTest {
         val records = InMemoryCollectorRecordStore()
         authorize(records, fold.runId, fold.retiredId, fold.survivorId)
         val events = mutableListOf<DiceEvent>()
-        val decorated = EventEmittingPropositionRepository(fold.store) { events += it }
+        val decorated = EventEmittingPropositionRepository.wrapping(fold.store) { events += it }
 
         val result = undo(fold.trace, decorated, fold.survivorId, fold.retiredId, records)
 
@@ -1140,32 +1141,36 @@ class CollectorUndoCapabilityTest {
     }
 
     @Test
-    fun `a decorator carries its delegate's subtraction, and reports honestly when it has none`() {
-        // Kotlin's interface delegation only covers PropositionRepository, so a decorator has to
-        // carry the capability itself. Wrapping a capable store and losing the capability would
-        // turn every undo behind that decorator into a refusal.
+    fun `the decorator's capabilities match its delegate's through the type system`() {
+        // Kotlin's interface delegation only covers PropositionRepository, so a decorator carries
+        // the capability type only when its delegate implements it. Wrapping a capable store and
+        // losing the capability type would make an `as? ProvenanceSubtractionCapable` probe return
+        // null, turning every undo behind that decorator into a refusal. The `wrapping` factory
+        // method picks the right shape so the type-level probe matches the delegate.
         val capable = appliedFold("decorated-capable")
+        val capableWrapper = EventEmittingPropositionRepository.wrapping(capable.store, DiceEventListener.DEV_NULL)
+        val capableSubtraction = capableWrapper as? ProvenanceSubtractionCapable
+        assertNotNull(capableSubtraction, "wrapping a subtraction-capable delegate produces a wrapper with the capability type")
+
         val capableRecords = InMemoryCollectorRecordStore()
         authorize(capableRecords, capable.runId, capable.retiredId, capable.survivorId)
-        val decorated = EventEmittingPropositionRepository(capable.store, DiceEventListener.DEV_NULL)
-        assertTrue(decorated.supportsProvenanceSubtraction)
-
-        val result = undo(capable.trace, decorated, capable.survivorId, capable.retiredId, capableRecords)
+        val result = undo(capable.trace, capableWrapper, capable.survivorId, capable.retiredId, capableRecords)
 
         assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
         assertEquals(listOf(revisionOne), capable.store.findById(capable.survivorId)?.provenanceEntries)
 
         val incapable = appliedFold("decorated-incapable")
-        val incapableRecords = InMemoryCollectorRecordStore()
-        authorize(incapableRecords, incapable.runId, incapable.retiredId, incapable.survivorId)
-        val overIncapable = EventEmittingPropositionRepository(
+        val incapableWrapper = EventEmittingPropositionRepository.wrapping(
             NoSubtractionStore(incapable.store),
             DiceEventListener.DEV_NULL,
         )
-        assertFalse(overIncapable.supportsProvenanceSubtraction)
+        val incapableSubtraction = incapableWrapper as? ProvenanceSubtractionCapable
+        assertNull(incapableSubtraction, "wrapping an incapable delegate produces a wrapper without the capability type")
 
+        val incapableRecords = InMemoryCollectorRecordStore()
+        authorize(incapableRecords, incapable.runId, incapable.retiredId, incapable.survivorId)
         assertThrows(CollapseUndoConfigurationException::class.java) {
-            undo(incapable.trace, overIncapable, incapable.survivorId, incapable.retiredId, incapableRecords)
+            undo(incapable.trace, incapableWrapper, incapable.survivorId, incapable.retiredId, incapableRecords)
         }
         assertEquals(
             listOf(revisionOne, revisionTwo),

--- a/dice/src/test/kotlin/com/embabel/dice/spi/InMemoryCollectorTraceStoreTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/spi/InMemoryCollectorTraceStoreTest.kt
@@ -39,14 +39,17 @@ class InMemoryCollectorTraceStoreTest {
         memberIds = members,
     )
 
-    private fun decision(runId: String, componentId: String, survivorId: String) = CollectorDecision(
+    private fun decision(runId: String, componentId: String, survivorId: String) =
+        decisionRetiring(runId, componentId, survivorId, retiredId = "P2")
+
+    private fun decisionRetiring(runId: String, componentId: String, survivorId: String, retiredId: String) = CollectorDecision(
         runId = runId,
         componentId = componentId,
         survivorId = survivorId,
         action = "merge",
         retired = listOf(
             RetiredProposition(
-                propositionId = "P2",
+                propositionId = retiredId,
                 priorStatus = PropositionStatus.ACTIVE,
             ),
         ),
@@ -104,5 +107,29 @@ class InMemoryCollectorTraceStoreTest {
         assertEquals(listOf(edge("C", "D")), store.edgesFor("run-b"))
         assertEquals(listOf(component("C", listOf("C", "D"))), store.componentsFor("run-b"))
         assertEquals(listOf(decision("run-b", "C", "C")), store.decisionsFor("run-b"))
+    }
+
+    @Test
+    fun `findDecisionRetiring does not return a decision where the proposition only survived`() {
+        val store = InMemoryCollectorTraceStore()
+        // "A" is the survivor here, "P2" is the retired member.
+        store.recordDecision("run-1", decision("run-1", "A", "A"))
+
+        assertTrue(store.findDecisionRetiring("A") == null, "a decision naming A as survivor must not count as retiring it")
+        assertEquals("A", store.findDecisionRetiring("P2")?.componentId)
+    }
+
+    @Test
+    fun `findDecisionRetiring answers the newest decision that retired the proposition`() {
+        val store = InMemoryCollectorTraceStore()
+        // Run 1 folds "A" into "B"; run 2 later folds "B" into "C". Both name "A" nowhere, but a
+        // proposition retired more than once (here it's "A" itself, retired again by a later run)
+        // must resolve to the newest of those decisions.
+        store.recordDecision("run-1", decisionRetiring(runId = "run-1", componentId = "comp-1", survivorId = "B", retiredId = "A"))
+        store.recordDecision("run-2", decisionRetiring(runId = "run-2", componentId = "comp-2", survivorId = "C", retiredId = "A"))
+
+        val newest = store.findDecisionRetiring("A")
+        assertEquals("comp-2", newest?.componentId)
+        assertEquals("C", newest?.survivorId)
     }
 }

--- a/docs/design/source-revisions.md
+++ b/docs/design/source-revisions.md
@@ -255,14 +255,17 @@ trace, not a transport for one you intend to undo from.
 
 ### Undo goes through the store, and writes nothing on a broken collapse
 
-`undoSingleCollapse` takes evidence off the survivor with
-`ProvenanceSubtractionCapable.subtractProvenance`, which names the refs to delete. Saving the
-reduced survivor is not enough on a persistent backend: `DrivinePropositionRepository.save` appends
-provenance and deletes no edge, so the folded rows would outlive the undo. The subtraction runs
-first and the save follows it, carrying grounding and source ids; **The order the writes go in**
-below says why that order is load-bearing in both directions. **Subtracting evidence by name**
-below says why the operation lives on its own capability and what implementing it promises;
-`CollectorUndoCapabilityTest` pins the undo against a store that models the append-only save.
+`undoSingleCollapse` takes the whole fold off the survivor with
+`ProvenanceSubtractionCapable.subtractFoldedEvidence`, which names the evidence refs, the grounding
+and the source ids to remove and takes all three off in one step. Saving the reduced survivor is not
+enough on a persistent backend: `DrivinePropositionRepository.save` appends provenance and deletes
+no edge, so the folded rows would outlive the undo. A save after the subtraction is not safe on a
+replacing backend either: it would carry the undo's copy of the survivor back over the store and put
+back evidence another writer added since. So nothing is saved over the survivor at all; **The order
+the writes go in** below says why. **Subtracting evidence by name** below says why the operation
+lives on its own capability and what implementing it promises; `CollectorUndoCapabilityTest` pins
+the undo against a store that models the append-only save, and `an undo never saves over the
+survivor` pins the absence of the save.
 
 Both participants are read before anything is written. A survivor whose retired member has since
 been deleted would otherwise end up with the member's evidence already subtracted and no member to
@@ -330,18 +333,17 @@ the collapse. `DrivineCollectorRecordStore` writes it through `coalesce($undoneA
 instead: an arriving stamp wins, a replay preserves. The append-only in-memory store has the
 property for free, and `CollectorRecordStore.record` now states it as a contract on implementors.
 
-**Where the stamp sits in the write order is what makes a crash recoverable.** Undo writes in four
-steps — subtract the evidence, save the survivor, stamp, restore the member — and the stamp is
-deliberately third rather than last. Put it after the restore and a process that dies in between
-leaves a finished undo still authorized, which no retry can repair: the member is already back at
-its prior status, so the retry declines and the stamp is never written; a later re-retirement then
-re-arms the whole thing destructively. Third, every interruption is recoverable:
+**Where the stamp sits in the write order is what makes a crash recoverable.** Undo writes in three
+steps, subtract the fold, stamp, restore the member, and the stamp is deliberately second, not
+last. Put it after the restore and a process that dies in between leaves a finished undo still
+authorized, which no retry can repair: the member is already back at its prior status, so the retry
+declines and the stamp is never written; a later re-retirement then re-arms the whole thing
+destructively. Second, every interruption is recoverable:
 
 | Interrupted after | State | What a retry does |
 | --- | --- | --- |
 | nothing | untouched | the whole undo |
-| subtract | evidence off, grounding on | re-derives against current evidence, so the subtraction is a no-op, then finishes |
-| save | survivor final, member retired, no stamp | same — re-subtracts nothing, stamps, restores |
+| subtract | survivor final, member retired, no stamp | re-derives against current evidence, so the subtraction is a no-op, then stamps and restores |
 | stamp | stamped, member still retired | restores only, touching no evidence |
 | restore | complete | nothing; the stamp refuses |
 
@@ -452,8 +454,10 @@ nothing" and never "wrote half of it".
 
 ### Subtracting evidence by name, not by remainder
 
-Undo removes evidence through `ProvenanceSubtractionCapable.subtractProvenance`, which names the
-refs to delete. The obvious alternative — `setProvenance` with the entries that should remain — has
+Undo removes a fold through `ProvenanceSubtractionCapable.subtractFoldedEvidence`, which names the
+evidence refs, the grounding and the source ids to take off and takes all three off in one step;
+`subtractProvenance` is the same call with empty grounding and source ids. The obvious
+alternative, `setProvenance` with the entries that should remain, has
 a window that loses data: naming what stays means reading the entries first, and any evidence
 another extraction adds between that read and the write is replaced away. Nothing recovers it,
 because the `save` that follows is append-only.
@@ -472,8 +476,8 @@ for the capability and refuses with `CollapseUndoConfigurationException` when th
 `InMemoryPropositionRepository` implements it over `ConcurrentHashMap.compute`, which holds the key
 for the whole remapping function, and takes an `addProvenance` override on the same primitive so the
 two operations serialize against each other. `DrivinePropositionRepository` deletes `DERIVED_FROM`
-edges by ref in one statement and prunes only the sources those edges pointed at, reading nothing
-first. Refs come in the same two forms the codec defines: a minted key is matched against the edge's
+edges by ref in one statement, prunes only the sources those edges pointed at, and rewrites the
+`grounding` and `sourceIds` lists in that same statement, reading nothing first. Refs come in the same two forms the codec defines: a minted key is matched against the edge's
 `entryKey`, and a bare locator key matches revisionless edges for that source only — which also
 reaches edges written before `entryKey` existed. `EventEmittingPropositionRepository` carries the
 capability type and forwards to its delegate, because Kotlin's interface delegation covers
@@ -489,38 +493,40 @@ subtraction starts.
 
 A subtraction can also answer null, which is the store saying it holds no such proposition. Undo
 reads that as the survivor having been deleted between its own read and this call, and stops there
-having written nothing. Continuing from the copy it read would save that copy back and recreate the
-proposition another writer deleted, folded evidence and all — the `save` that follows the
-subtraction is an upsert on every backend here. The member stays retired, no stamp is written, and
+having written nothing. Continuing from the copy it read would mean writing that copy back and
+recreating the proposition another writer deleted, folded evidence and all. The member stays retired, no stamp is written, and
 the null the undo returns says truthfully that no restore happened. What becomes of a member left
 retired into a survivor that no longer exists is the caller's decision; undo does not guess at it.
 `a survivor deleted before the subtraction is not recreated by the undo` pins that in memory, and
 `subtractProvenance answers null for a proposition that is not there` pins the graph backend's half.
 
-**A deletion can still arrive too late to be seen**, and this is a residual the capability leaves
-open. Every deletion up to the subtraction's own last look is caught, because no implementation may
-recreate what it is subtracting from: the in-memory `compute` finds no entry and writes none, and
-the Drivine override reads once after its delete statement. The window that stays open is between
-that answer and the survivor's `save`.
+**A deletion can still arrive too late to be seen**, on the member, and this is a residual the
+capability leaves open. Every deletion of the survivor is caught, because the survivor is only ever
+written through the subtraction and no implementation may recreate what it is subtracting from: the
+in-memory `compute` finds no entry and writes none, and the Drivine statement matches nothing. The
+window that stays open is on the member: its restore is a `PropositionStore.save`, an upsert on
+every backend here, so a member deleted between the undo's read and its restore comes back at its
+prior status.
 
 The upsert is what does it. `PropositionStore.save` writes the proposition whether or not a row for
 it still exists, and nothing on the contract says "save only if it is still there". Closing the
-window needs a conditional write — a compare-and-set, or an existence-guarded save on the store
-contract that every backend then has to implement — and it would have to reach every save in the
+window needs a conditional write, a compare-and-set or an existence-guarded save on the store
+contract that every backend then has to implement, and it would have to reach every save in the
 chain. That is more than an amendment to this slice should take on. It belongs with the other
-untransactional residuals here: no transaction spans the undo's four writes, and a caller needing
+untransactional residuals here: no transaction spans the undo's three writes, and a caller needing
 strict exclusion against concurrent deletion needs a boundary the SPI does not offer yet.
 
 ### The order the writes go in
 
-Evidence comes off first, and the survivor's `save` runs last. Both halves of that order are
-load-bearing. A persistent backend's `save` appends provenance and deletes nothing, so the
-subtraction is the only write that removes the folded evidence. And `save` is the write a decorator
-instruments — `EventEmittingPropositionRepository` publishes `PropositionPersisted` from it, while
-the provenance operations forward to the delegate unannounced. Saving first would fire the event
-while the folded evidence was still in the graph, handing a synchronous listener a survivor that no
-longer exists a moment later. `the survivor's persistence event carries its post-undo evidence` pins
-the ordering against the real decorator.
+The fold comes off the survivor first and in one step, the stamp goes second, and the member's
+restore goes last. The survivor is never written through `save`. On a persistent backend `save`
+appends provenance and deletes nothing, so it could not remove the fold; on a replacing backend it
+would carry the undo's copy back over evidence another writer added since the subtraction. `save` is
+also the write a decorator instruments: `EventEmittingPropositionRepository` publishes from it,
+while the provenance operations forward to the delegate unannounced, so a listener hears the
+member's restore and nothing for the survivor. `an undo announces the member's restore and nothing
+for the survivor` pins that against the real decorator, and `evidence another writer adds after the
+subtraction survives the undo` pins the window the trailing save used to open.
 
 ### Legacy evidence is unchanged, by construction
 

--- a/docs/design/source-revisions.md
+++ b/docs/design/source-revisions.md
@@ -215,7 +215,7 @@ flowchart TD
     E -->|"structural equality, all six fields"| DD["list dedup:<br/>withProvenanceEntries, withProvenance,<br/>absorbEvidence"]
     E -->|"ProvenanceEvidenceKey.encode"| K["opaque ref string<br/>dice-provenance:v1:..."]
     K --> T["recorded with the fold<br/>(collector trace)"]
-    T -->|"undo passes refs to<br/>Proposition.withoutFoldedEvidence"| M["ProvenanceEvidenceKey.matches"]
+    T -->|"undo passes refs to<br/>PropositionStore.subtractProvenance"| M["ProvenanceEvidenceKey.matches"]
     M --> Q{"carries the<br/>dice-provenance: prefix?"}
     Q -->|"yes, and it parses"| R1["remove the single entry<br/>whose six fields match"]
     Q -->|"yes, and it does not parse"| R2["match nothing;<br/>evidence is left alone"]
@@ -227,8 +227,10 @@ flowchart TD
 A collapse records what each loser actually added to the survivor, and names that evidence by its
 evidence key. `MultiSignalCollectorStrategy` encodes every entry on both sides and subtracts; what
 is left is the evidence the fold introduced. `RetiredProposition.foldedProvenanceEvidenceKeys`
-carries it, and `undoSingleCollapse` hands those refs to `Proposition.withoutFoldedEvidence`, where
-each one matches a single full entry.
+carries it, and `undoSingleCollapse` hands those refs to `PropositionStore.subtractProvenance`,
+where each one matches a single full entry. (`Proposition.withoutFoldedEvidence` still runs on the
+survivor for grounding and source ids, and is given no provenance refs — the store removes evidence
+now. **Subtracting evidence by name** below says why the move was needed.)
 
 Locator keys alone could not do this, and failed in two ways. A loser citing `r2` of a document the
 survivor already cites at `r1` shares its locator key with the survivor, so the recorded fold
@@ -253,15 +255,15 @@ trace, not a transport for one you intend to undo from.
 
 ### Undo goes through the store, and writes nothing on a broken collapse
 
-`undoSingleCollapse` takes evidence off the survivor with `PropositionStore.setProvenance`, the
-authoritative replace. Saving the reduced survivor is not enough on a persistent backend:
+`undoSingleCollapse` takes evidence off the survivor with `PropositionStore.subtractProvenance`,
+which names the refs to delete. Saving the reduced survivor is not enough on a persistent backend:
 `DrivinePropositionRepository.save` appends provenance and deletes no edge, so the folded rows would
-outlive the undo. The save still runs, carrying grounding and source ids, and `setProvenance`
-follows it with the evidence. Because `setProvenance` sits on the base store contract, a caller
-holding nothing richer than a `PropositionStore` reaches it without probing for a repository type at
-runtime — `undo removes folded evidence for a caller holding only the base store` pins that on the
-Drivine backend, and `CollectorUndoCapabilityTest` pins it against a store that models the
-append-only save.
+outlive the undo. The subtraction runs first and the save follows it, carrying grounding and source
+ids; **The order the writes go in** below says why that order is load-bearing in both directions.
+Because the operation sits on the base store contract, a caller holding nothing richer than a
+`PropositionStore` reaches it without probing for a repository type at runtime — `undo removes
+folded evidence for a caller holding only the base store` pins that on the Drivine backend, and
+`CollectorUndoCapabilityTest` pins it against a store that models the append-only save.
 
 Both participants are read before anything is written. A survivor whose retired member has since
 been deleted would otherwise end up with the member's evidence already subtracted and no member to
@@ -430,9 +432,57 @@ the same two forms the codec defines: a minted key is matched against the edge's
 bare locator key matches revisionless edges for that source only — which also reaches edges written
 before `entryKey` existed.
 
-`evidence added while a subtraction is in flight survives it on the graph backend` runs one scenario
-through both paths, injecting the concurrent write where each is vulnerable: the default loses the
-newcomer, the override keeps it.
+`evidence the subtraction does not name survives it on the graph backend` asserts the half that
+matters for production: the override keeps a newcomer added before the call, because its delete
+statement names what goes and touches nothing else. The add completes before the subtraction
+starts, so the test pins preservation rather than concurrent interleaving. Its other half does not currently demonstrate the default's data loss — Kotlin
+interface delegation forwards `subtractProvenance` to the delegate, so a decorator that overrides
+only `findById` never sees the subtraction and never injects anything. The default's window is
+stated in `PropositionStore.subtractProvenance`'s KDoc and is not pinned by a test today.
+
+A subtraction can also answer null, which is the store saying it holds no such proposition. Both
+implementations mean the same thing by it: one of the default's reads misses — the opening
+`findById`, or the delegated `setProvenance`'s own read when the refs matched — and the Drivine
+override's fresh `findById` misses, whether or not a delete statement ran before it. Undo reads that as the survivor
+having been deleted between its own read and this call, and stops there having written nothing.
+Continuing from the copy it read would save that copy back and recreate the proposition another
+writer deleted, folded evidence and all — the `save` that follows the subtraction is an upsert on
+every backend here. The member stays retired, no stamp is written, and the null the undo returns
+says truthfully that no restore happened. What becomes of a member left retired into a survivor that
+no longer exists is the caller's decision; undo does not guess at it. `a survivor deleted before the
+subtraction is not recreated by the undo` pins that, exercising the default's opening read — the
+in-memory store overrides neither `subtractProvenance` nor `setProvenance`, so the deletion lands
+before that read and the default answers null immediately. `subtractProvenance answers null for a proposition that is not there` pins
+the graph backend's half of the signal.
+
+**A deletion can still arrive too late to be seen**, and this is a residual rather than a fix. Where
+the window opens depends on the backend, because it depends on when the subtraction last looked.
+
+- **The Drivine override**: after its answer. It deletes the edges in one statement and reads once
+  afterwards, writing nothing to the proposition itself, so its null is exact and everything up to
+  that read is caught. The gap left is between that read and the survivor's `save`.
+- **The base contract's default**: earlier, and inside the subtraction. On a store inheriting both
+  defaults it reads, delegates to `setProvenance`, which reads again and saves — so a deletion
+  landing after that second read is undone by that save, and the survivor is recreated before undo
+  is handed anything to inspect; a store overriding `setProvenance` alone moves that last look to
+  wherever its own write reads. Its
+  other two exits return the proposition as the *first* read saw it: nothing to subtract, and
+  nothing matching. Both are reachable from undo — a fold that added no new evidence subtracts
+  nothing, and a retried undo matches nothing — so on those exits a deletion any time after that
+  first read goes unseen.
+
+What the resurrection leaves behind is the same in both cases: the survivor back without the folded
+evidence, the member restored, and — when the caller supplied a record store — the undo stamped
+done. The four-argument path writes no stamp, so there it is the survivor and the member only.
+
+The upsert is what does it. `PropositionStore.save` writes the proposition whether or not a row for
+it still exists, and nothing on the contract says "save only if it is still there". Closing the
+window needs a conditional write — a compare-and-set, or an existence-guarded save on the store
+contract that every backend then has to implement — and it would have to reach every save in the
+chain, including the one inside the default subtraction, rather than only undo's own. That is more
+than an amendment to this slice should take on. It belongs with the other untransactional residuals
+here: no transaction spans the undo's four writes, and a caller needing strict exclusion against
+concurrent deletion needs a boundary the SPI does not offer yet.
 
 ### The order the writes go in
 
@@ -729,7 +779,7 @@ Four slices, each green on its own, together equal to the reviewed
    revision, the delete cascade over parallel revisions, and the connector-collision and
    legacy-adoption cases around `:Source` identity.
 3. **Collector hardening** — the trace and undo half: a collapse records the evidence keys of what
-   it folded, undo subtracts them through `PropositionStore.setProvenance` and refuses to write
+   it folded, undo subtracts them through `PropositionStore.subtractProvenance` and refuses to write
    when a participant has gone, and `DrivineCollectorTraceStore` persists and reads the new field
    with rows written before it still readable.
 4. **Entry points** — `IncrementalPropositionExtraction`, pipeline wiring, the REST surface, and

--- a/docs/design/source-revisions.md
+++ b/docs/design/source-revisions.md
@@ -255,15 +255,14 @@ trace, not a transport for one you intend to undo from.
 
 ### Undo goes through the store, and writes nothing on a broken collapse
 
-`undoSingleCollapse` takes evidence off the survivor with `PropositionStore.subtractProvenance`,
-which names the refs to delete. Saving the reduced survivor is not enough on a persistent backend:
-`DrivinePropositionRepository.save` appends provenance and deletes no edge, so the folded rows would
-outlive the undo. The subtraction runs first and the save follows it, carrying grounding and source
-ids; **The order the writes go in** below says why that order is load-bearing in both directions.
-Because the operation sits on the base store contract, a caller holding nothing richer than a
-`PropositionStore` reaches it without probing for a repository type at runtime — `undo removes
-folded evidence for a caller holding only the base store` pins that on the Drivine backend, and
-`CollectorUndoCapabilityTest` pins it against a store that models the append-only save.
+`undoSingleCollapse` takes evidence off the survivor with
+`ProvenanceSubtractionCapable.subtractProvenance`, which names the refs to delete. Saving the
+reduced survivor is not enough on a persistent backend: `DrivinePropositionRepository.save` appends
+provenance and deletes no edge, so the folded rows would outlive the undo. The subtraction runs
+first and the save follows it, carrying grounding and source ids; **The order the writes go in**
+below says why that order is load-bearing in both directions. **Subtracting evidence by name**
+below says why the operation lives on its own capability and what implementing it promises;
+`CollectorUndoCapabilityTest` pins the undo against a store that models the append-only save.
 
 Both participants are read before anything is written. A survivor whose retired member has since
 been deleted would otherwise end up with the member's evidence already subtracted and no member to
@@ -302,11 +301,12 @@ row or five, the answer is the same. A plain status transition, a skip, and a fa
 all leave it null, so none of them can authorize an undo. A dry run's preview records the target it
 would have used, and the run header's `dryRun` flag is what says nothing happened.
 
-`undoSingleCollapse` takes an optional `CollectorRecordStore` and, given one, requires a non-dry
-run and a `TRANSITIONED` record whose `mergedIntoId` names this survivor. No inference from marks
-remains, and the multi-survivor ambiguity that forced a conservative refusal is gone by
-construction. A defensive check for records that disagree about the applied target stays in place
-and logs, because the alternative on a broken invariant is silently picking one.
+`undoSingleCollapse` requires a `CollectorRecordStore`, a non-dry run and a `TRANSITIONED` record
+whose `mergedIntoId` names this survivor. No inference from marks remains, and the multi-survivor
+ambiguity that forced a conservative refusal is gone by construction. A defensive check for records
+that disagree about the applied target stays in place and logs, because the alternative on a broken
+invariant is silently picking one. **What undo refuses before it starts** below covers the case
+where the caller supplies no records at all.
 
 **Has the undo already run?** Audit records never expire, so nothing in them says a collapse has been
 reversed — and that is a false *accept* waiting to happen, not just a missing convenience. Judge
@@ -416,73 +416,100 @@ re-gains after a fold is indistinguishable from the folded one under structural 
 removes it. Grounding refs and source ids have always behaved that way and evidence now matches
 them. A different revision of the same source is a different key and is untouched.
 
+### What undo refuses before it starts
+
+Undo is destructive and takes ids from whatever handed them to it — a URL path, a card in a drawer,
+a script. Three preconditions are checked ahead of any write, and each missing one refuses.
+
+**The context that owns the collapse.** The parameters are a
+`CollapseUndoCommand(contextId, survivorId, retiredId)`, and both the survivor and the retired
+member have to live in that context. One that does not throws
+`CollapseUndoContextMismatchException`, carrying the commanded context, the offending proposition
+and the context that really owns it. Without this the ownership check was every caller's own
+problem: the assistant's `MemoryUnmergeService` resolves the user's context and compares both
+propositions against it before calling in, and a caller that forgot had a destructive operation
+reachable across contexts with two string ids. `an undo issued for one context refuses ids belonging
+to another, and leaves it untouched` sets a whole collapse up in a second context — trace, live
+records, retired member and all — issues the undo in the first, and asserts the refusal plus the
+second context's evidence, member status and absent stamp; it then undoes the same collapse cleanly
+under the right context, so the refusal is about ownership alone. `a member from another context
+cannot be restored into this context's survivor` covers the mixed case.
+
+**The run's audit records.** A null `CollectorRecordStore` throws
+`CollapseUndoConfigurationException` naming the missing store, before any read. This used to be
+optional, and omitting it dropped the "did the collector really apply this merge" question and fell
+back on the member's status — which a later unrelated retirement satisfies just as well. A dry-run
+preview followed by a decay sweep moving the member ACTIVE to STALE was enough to arm an undo that
+then stripped a revision the survivor held for its own reasons.
+
+**A live record, with previews excluded.** `CollectorRun.dryRun` on the run header is how a preview is
+marked, and a dry-run header refuses whatever its records say — a dry run writes records carrying
+`mergedIntoId` and a `newStatus` exactly like a merge that happened, so the header is the only
+signal that separates them. Three tests share one world state and vary only the audit trail: no
+store refuses, a dry-run record refuses, a live record proceeds. Each refusal asserts the survivor's
+evidence, the member's status and the absence of an `undoneAt` stamp, so "refused" means "wrote
+nothing" and never "wrote half of it".
+
 ### Subtracting evidence by name, not by remainder
 
-Undo removes evidence through `PropositionStore.subtractProvenance`, which names the refs to delete.
-The obvious alternative — `setProvenance` with the entries that should remain — has a window that
-loses data: naming what stays means reading the entries first, and any evidence another extraction
-adds between that read and the write is replaced away. Nothing recovers it, because the `save` that
-follows is append-only.
+Undo removes evidence through `ProvenanceSubtractionCapable.subtractProvenance`, which names the
+refs to delete. The obvious alternative — `setProvenance` with the entries that should remain — has
+a window that loses data: naming what stays means reading the entries first, and any evidence
+another extraction adds between that read and the write is replaced away. Nothing recovers it,
+because the `save` that follows is append-only.
 
-`subtractProvenance` ships with a default implementation that is exactly that read-modify-write, so
-an existing store keeps working and a single-JVM in-memory store has nothing to race with; its KDoc
-says so. `DrivinePropositionRepository` overrides it with one statement that deletes `DERIVED_FROM`
-edges by ref and prunes only the sources those edges pointed at, reading nothing first. Refs come in
-the same two forms the codec defines: a minted key is matched against the edge's `entryKey`, and a
-bare locator key matches revisionless edges for that source only — which also reaches edges written
-before `entryKey` existed.
+The operation lives on its own opt-in capability, beside `SourceRevisionQueryCapable`, for the very
+reason that window exists. A default body on `PropositionStore` would have to *be* that
+read-modify-write, and it would compile on every backend while quietly carrying the data loss the
+operation is there to prevent; a store with no way to delete by name would then look identical to
+one that can. The capability states the promise directly: the read of the current entries and the
+write of what survives land as one step, an entry another writer adds while a subtraction is in
+flight is still there when it finishes, and subtracting the last entry from a proposition somebody
+already deleted answers null and writes nothing. `supportsProvenanceSubtraction` carries the runtime
+half of that for a decorator that forwards to a delegate it discovers at construction. Undo probes
+for the capability and refuses with `CollapseUndoConfigurationException` when the store has none.
 
-`evidence the subtraction does not name survives it on the graph backend` asserts the half that
-matters for production: the override keeps a newcomer added before the call, because its delete
-statement names what goes and touches nothing else. The add completes before the subtraction
-starts, so the test pins preservation rather than concurrent interleaving. Its other half does not currently demonstrate the default's data loss — Kotlin
-interface delegation forwards `subtractProvenance` to the delegate, so a decorator that overrides
-only `findById` never sees the subtraction and never injects anything. The default's window is
-stated in `PropositionStore.subtractProvenance`'s KDoc and is not pinned by a test today.
+`InMemoryPropositionRepository` implements it over `ConcurrentHashMap.compute`, which holds the key
+for the whole remapping function, and takes an `addProvenance` override on the same primitive so the
+two operations serialize against each other. `DrivinePropositionRepository` deletes `DERIVED_FROM`
+edges by ref in one statement and prunes only the sources those edges pointed at, reading nothing
+first. Refs come in the same two forms the codec defines: a minted key is matched against the edge's
+`entryKey`, and a bare locator key matches revisionless edges for that source only — which also
+reaches edges written before `entryKey` existed. `EventEmittingPropositionRepository` carries the
+capability type and forwards to its delegate, because Kotlin's interface delegation covers
+`PropositionRepository` alone: a decorator that stayed silent would hide a capable delegate and turn
+every undo behind it into a refusal.
 
-A subtraction can also answer null, which is the store saying it holds no such proposition. Both
-implementations mean the same thing by it: one of the default's reads misses — the opening
-`findById`, or the delegated `setProvenance`'s own read when the refs matched — and the Drivine
-override's fresh `findById` misses, whether or not a delete statement ran before it. Undo reads that as the survivor
-having been deleted between its own read and this call, and stops there having written nothing.
-Continuing from the copy it read would save that copy back and recreate the proposition another
-writer deleted, folded evidence and all — the `save` that follows the subtraction is an upsert on
-every backend here. The member stays retired, no stamp is written, and the null the undo returns
-says truthfully that no restore happened. What becomes of a member left retired into a survivor that
-no longer exists is the caller's decision; undo does not guess at it. `a survivor deleted before the
-subtraction is not recreated by the undo` pins that, exercising the default's opening read — the
-in-memory store overrides neither `subtractProvenance` nor `setProvenance`, so the deletion lands
-before that read and the default answers null immediately. `subtractProvenance answers null for a proposition that is not there` pins
-the graph backend's half of the signal.
+`evidence added while a subtraction is running survives it` races an addition against a subtraction
+on one proposition over 200 rounds, with two real threads released together on a latch, and asserts
+both effects are on the proposition at the end. The read-modify-write shape this replaced loses the
+addition on the first round. `evidence the subtraction does not name survives it on the graph
+backend` asserts the same property for the Drivine statement, with the add completing before the
+subtraction starts.
 
-**A deletion can still arrive too late to be seen**, and this is a residual rather than a fix. Where
-the window opens depends on the backend, because it depends on when the subtraction last looked.
+A subtraction can also answer null, which is the store saying it holds no such proposition. Undo
+reads that as the survivor having been deleted between its own read and this call, and stops there
+having written nothing. Continuing from the copy it read would save that copy back and recreate the
+proposition another writer deleted, folded evidence and all — the `save` that follows the
+subtraction is an upsert on every backend here. The member stays retired, no stamp is written, and
+the null the undo returns says truthfully that no restore happened. What becomes of a member left
+retired into a survivor that no longer exists is the caller's decision; undo does not guess at it.
+`a survivor deleted before the subtraction is not recreated by the undo` pins that in memory, and
+`subtractProvenance answers null for a proposition that is not there` pins the graph backend's half.
 
-- **The Drivine override**: after its answer. It deletes the edges in one statement and reads once
-  afterwards, writing nothing to the proposition itself, so its null is exact and everything up to
-  that read is caught. The gap left is between that read and the survivor's `save`.
-- **The base contract's default**: earlier, and inside the subtraction. On a store inheriting both
-  defaults it reads, delegates to `setProvenance`, which reads again and saves — so a deletion
-  landing after that second read is undone by that save, and the survivor is recreated before undo
-  is handed anything to inspect; a store overriding `setProvenance` alone moves that last look to
-  wherever its own write reads. Its
-  other two exits return the proposition as the *first* read saw it: nothing to subtract, and
-  nothing matching. Both are reachable from undo — a fold that added no new evidence subtracts
-  nothing, and a retried undo matches nothing — so on those exits a deletion any time after that
-  first read goes unseen.
-
-What the resurrection leaves behind is the same in both cases: the survivor back without the folded
-evidence, the member restored, and — when the caller supplied a record store — the undo stamped
-done. The four-argument path writes no stamp, so there it is the survivor and the member only.
+**A deletion can still arrive too late to be seen**, and this is a residual the capability leaves
+open. Every deletion up to the subtraction's own last look is caught, because no implementation may
+recreate what it is subtracting from: the in-memory `compute` finds no entry and writes none, and
+the Drivine override reads once after its delete statement. The window that stays open is between
+that answer and the survivor's `save`.
 
 The upsert is what does it. `PropositionStore.save` writes the proposition whether or not a row for
 it still exists, and nothing on the contract says "save only if it is still there". Closing the
 window needs a conditional write — a compare-and-set, or an existence-guarded save on the store
 contract that every backend then has to implement — and it would have to reach every save in the
-chain, including the one inside the default subtraction, rather than only undo's own. That is more
-than an amendment to this slice should take on. It belongs with the other untransactional residuals
-here: no transaction spans the undo's four writes, and a caller needing strict exclusion against
-concurrent deletion needs a boundary the SPI does not offer yet.
+chain. That is more than an amendment to this slice should take on. It belongs with the other
+untransactional residuals here: no transaction spans the undo's four writes, and a caller needing
+strict exclusion against concurrent deletion needs a boundary the SPI does not offer yet.
 
 ### The order the writes go in
 
@@ -750,7 +777,14 @@ a runaway or hostile value.
 
 Stated with the same scope on every Wave A slice:
 
-- **Source compatibility: claimed.** Existing Kotlin and Java call sites compile unchanged.
+- **Source compatibility: claimed, with two carve-outs on the undo slice.** Existing Kotlin and
+  Java call sites compile unchanged, apart from these: `undoSingleCollapse`'s parameter list becomes
+  `(CollapseUndoCommand, CollectorTraceQuery, PropositionStore, CollectorRecordStore?)`, so each
+  call site needs a one-line edit, and `PropositionStore.subtractProvenance` is gone, so a store
+  that declared `override fun subtractProvenance` has to declare `ProvenanceSubtractionCapable` and
+  drop the `override`. Both are deliberate: the first is what makes the context and the audit records required,
+  and the second is what makes atomicity a promise a backend has to make. A store that never
+  mentioned the operation compiles unchanged, and calls nothing new.
 - **JSON compatibility: claimed.** Stored propositions written before this change load, and
   round-trip, with a null revision.
 - **Java constructor-descriptor compatibility: claimed.** `@JvmOverloads` preserves every concrete

--- a/docs/design/source-revisions.md
+++ b/docs/design/source-revisions.md
@@ -214,7 +214,7 @@ flowchart TD
     E["ProvenanceEntry"]
     E -->|"structural equality, all six fields"| DD["list dedup:<br/>withProvenanceEntries, withProvenance,<br/>absorbEvidence"]
     E -->|"ProvenanceEvidenceKey.encode"| K["opaque ref string<br/>dice-provenance:v1:..."]
-    K --> T["recorded with the fold<br/>(collector trace, slice 3)"]
+    K --> T["recorded with the fold<br/>(collector trace)"]
     T -->|"undo passes refs to<br/>Proposition.withoutFoldedEvidence"| M["ProvenanceEvidenceKey.matches"]
     M --> Q{"carries the<br/>dice-provenance: prefix?"}
     Q -->|"yes, and it parses"| R1["remove the single entry<br/>whose six fields match"]
@@ -222,13 +222,228 @@ flowchart TD
     Q -->|"no: a legacy locator key"| R3["remove only revisionless entries<br/>with that locator key"]
 ```
 
-### The interim gap, until the collector slice lands
+### Recording a fold, and undoing it
 
-Storage keys its edges by `encode`, but no *collapse* records an encoded ref yet. Until slice 3
-rewires `MultiSignalCollectorStrategy`, a collapse still writes down plain locator keys, so undoing
-one that folded revisioned evidence takes the legacy path and leaves those entries on the survivor.
-The direction of the gap is safe — evidence is retained, never wrongly deleted — and it closes when
-slice 3 starts recording encoded refs.
+A collapse records what each loser actually added to the survivor, and names that evidence by its
+evidence key. `MultiSignalCollectorStrategy` encodes every entry on both sides and subtracts; what
+is left is the evidence the fold introduced. `RetiredProposition.foldedProvenanceEvidenceKeys`
+carries it, and `undoSingleCollapse` hands those refs to `Proposition.withoutFoldedEvidence`, where
+each one matches a single full entry.
+
+Locator keys alone could not do this, and failed in two ways. A loser citing `r2` of a document the
+survivor already cites at `r1` shares its locator key with the survivor, so the recorded fold
+subtracted to nothing and undo left `r2` behind. And a bare locator key matches revisionless
+evidence only, so even a ref that did get recorded could not reach a revisioned entry. Both are now
+pinned: `MultiSignalCollectorStrategyTest.records only the distinct evidence a fold actually adds`
+covers what gets written down, and `folding a revisioned loser and undoing leaves the survivor's
+evidence as it was` runs the whole round trip — in memory in `CollectorUndoCapabilityTest`, and
+against Neo4j in `DrivineCollectorTraceStoreIntegrationTest`, where the survivor's `DERIVED_FROM`
+edge count goes from one to two across the fold and back to one after the undo.
+
+`foldedProvenanceRefs` stays beside the evidence keys with its meaning unchanged: the locator keys
+of sources the survivor was not already citing. Trace readers display those, and an undo of a trace
+recorded before evidence keys existed falls back to them, matching revisionless evidence only — so
+an old trace removes exactly what it always removed. The two fields are the same fold stated at two
+granularities, and the finer one wins wherever it exists.
+
+Evidence keys are left out of the JSON view of a trace. A `RetiredProposition` written to JSON and
+read back carries its locator refs and no evidence keys, so it undoes at locator granularity;
+`SourceRevisionCompatibilityTest` asserts both halves of that. JSON is a readable projection of a
+trace, not a transport for one you intend to undo from.
+
+### Undo goes through the store, and writes nothing on a broken collapse
+
+`undoSingleCollapse` takes evidence off the survivor with `PropositionStore.setProvenance`, the
+authoritative replace. Saving the reduced survivor is not enough on a persistent backend:
+`DrivinePropositionRepository.save` appends provenance and deletes no edge, so the folded rows would
+outlive the undo. The save still runs, carrying grounding and source ids, and `setProvenance`
+follows it with the evidence. Because `setProvenance` sits on the base store contract, a caller
+holding nothing richer than a `PropositionStore` reaches it without probing for a repository type at
+runtime — `undo removes folded evidence for a caller holding only the base store` pins that on the
+Drivine backend, and `CollectorUndoCapabilityTest` pins it against a store that models the
+append-only save.
+
+Both participants are read before anything is written. A survivor whose retired member has since
+been deleted would otherwise end up with the member's evidence already subtracted and no member to
+restore it to. Four tests count the writes an undo attempts against a missing survivor and a missing
+retired member, in memory and on Neo4j, and assert the count is zero.
+
+### Proving a collapse was applied before reversing it
+
+A retirement record says a collapse was *proposed*. `MultiSignalCollectorStrategy` writes it during
+the mark phase, and `DefaultCollectorRunner` only decides what to do afterwards, so a dry run, a
+skipped merge, or a merge the runner declines all leave a trace that reads exactly like an applied
+fold. Reversing one of those subtracts evidence the survivor holds for its own reasons. The record
+also survives its own undo — nothing consumes it — so a second undo has to be recognised too.
+
+So authorization is two conditions, and both have to hold.
+
+**Was the merge applied, into this survivor?** The trace cannot say, and neither could the audit
+records until this slice: they described *marks* and status changes, not the action the sweep took.
+Three different things produced the same record. `MergingSweepPolicy` merges into the first mark
+naming a survivor that is neither blank nor the member itself, while `DefaultCollectorRunner` writes
+a record for *every* mark, so a member marked duplicate by two strategies left two records naming
+two survivors with nothing to say which merge ran. `StatusTransitionSweepPolicy` retires a
+duplicate-marked member and folds nothing. And the runner itself retires a loser without merging
+when the target has vanished or is no longer ACTIVE. All three looked like an applied merge.
+
+Worse, the two record stores disagree about how many records survive. `DrivineCollectorRecordStore`
+MERGEs on the natural key (`propositionId`, `runId`), so a member marked by several strategies keeps
+**one** row and the last write wins; `InMemoryCollectorRecordStore` keeps one per mark. Any rule
+that reads the merge target off a mark therefore gives a different answer on the two stores, and on
+the production one it reports whichever mark was written last.
+
+So `CollectorRecord` gains `mergedIntoId`: the survivor the sweep actually folded this proposition
+into. `DefaultCollectorRunner` sets it only after the merge is saved, and sets the same value on
+every record it writes for that member — which is what makes the field survive the overwrite. One
+row or five, the answer is the same. A plain status transition, a skip, and a fallback retirement
+all leave it null, so none of them can authorize an undo. A dry run's preview records the target it
+would have used, and the run header's `dryRun` flag is what says nothing happened.
+
+`undoSingleCollapse` takes an optional `CollectorRecordStore` and, given one, requires a non-dry
+run and a `TRANSITIONED` record whose `mergedIntoId` names this survivor. No inference from marks
+remains, and the multi-survivor ambiguity that forced a conservative refusal is gone by
+construction. A defensive check for records that disagree about the applied target stays in place
+and logs, because the alternative on a broken invariant is silently picking one.
+
+**Has the undo already run?** Audit records never expire, so nothing in them says a collapse has been
+reversed — and that is a false *accept* waiting to happen, not just a missing convenience. Judge
+completion by status alone and this sequence bites: run 1 merges the member into S1, the undo
+succeeds, and later anything at all retires the member again — a decay sweep, a second collector run
+folding it into S2. Run 1's records still say "applied" and the member is off its prior status
+again, so a retry of run 1's undo proceeds: it subtracts run 1's evidence from S1 a second time,
+deleting whatever S1 has legitimately re-gained since, and restores the member, clobbering the newer
+retirement.
+
+So `CollectorRecord` gains `undoneAt`, stamped by `undoSingleCollapse`. A store keyed by
+(proposition, run) updates that row in place; one that appends leaves the original beside the
+stamped copy, so a reader treats *any* stamped record for the pair as the whole collapse being
+undone. A stamped record never authorizes again, however the member's status has moved since.
+
+Two details make the stamp trustworthy rather than decorative.
+
+**Replay must not erase it.** Re-recording a collector outcome is supported, and a replayed record
+carries no stamp, so a plain `SET n.undoneAt = $undoneAt` would clear a stored one and re-authorize
+the collapse. `DrivineCollectorRecordStore` writes it through `coalesce($undoneAt, n.undoneAt)`
+instead: an arriving stamp wins, a replay preserves. The append-only in-memory store has the
+property for free, and `CollectorRecordStore.record` now states it as a contract on implementors.
+
+**Where the stamp sits in the write order is what makes a crash recoverable.** Undo writes in four
+steps — subtract the evidence, save the survivor, stamp, restore the member — and the stamp is
+deliberately third rather than last. Put it after the restore and a process that dies in between
+leaves a finished undo still authorized, which no retry can repair: the member is already back at
+its prior status, so the retry declines and the stamp is never written; a later re-retirement then
+re-arms the whole thing destructively. Third, every interruption is recoverable:
+
+| Interrupted after | State | What a retry does |
+| --- | --- | --- |
+| nothing | untouched | the whole undo |
+| subtract | evidence off, grounding on | re-derives against current evidence, so the subtraction is a no-op, then finishes |
+| save | survivor final, member retired, no stamp | same — re-subtracts nothing, stamps, restores |
+| stamp | stamped, member still retired | restores only, touching no evidence |
+| restore | complete | nothing; the stamp refuses |
+
+The subtraction is safe to repeat because it is recomputed from the survivor's *current* evidence by
+key, so a ref that is already gone removes nothing.
+
+That fourth row needs one more thing to be sound, because "stamped and still retired" also describes
+a collapse undone long ago whose member something has retired again since. Two signals separate
+them.
+
+The member must sit exactly where this collapse left it, per the record's `newStatus`. A record
+without one predates the mechanism and cannot say where that was, so it fails the signal instead of
+passing it vacuously — otherwise a stamped legacy record would resume against a re-retirement to any
+status at all.
+
+And no other run may have **written** the member at or after the stamp. That counts `TRANSITIONED`
+and `HARD_DELETED` records from non-dry runs only. The filter is load-bearing in the other
+direction: a `SKIPPED` record is the literal statement that a run left the member alone, and a dry
+run changes nothing, so counting either as action would refuse the resumption forever and strand a
+member whose undo is genuinely half-finished — evidence off the survivor, member retired, every
+retry declining. `a later run that skipped the member does not strand an interrupted undo` pins it.
+
+Both timestamps are written by whichever host produced them, so the comparison assumes roughly
+synchronized clocks. Several hosts sharing one store can order them wrongly: a re-retirement whose
+clock runs behind stamps `at` before `undoneAt` and slips past the check.
+
+What defeats both signals is a re-retirement that leaves no record and lands on the same status.
+Two deployments produce that: host code changing a proposition's status directly, and a collector
+runner wired without a record store at all, where `persistRun` no-ops and a whole re-retirement —
+or a re-*merge* into a different survivor — passes unrecorded. The consequence is bounded but wider
+than a status flip: the stamp gate still makes the full re-subtraction unreachable, so no evidence
+is lost, but a false resume can leave the member live while the newer survivor keeps the copy it
+folded, which is a merge-state desync someone has to reconcile.
+
+**Is the merge still in force?** The member's own status — and it is all a caller without records
+has for any of the three questions. Note what it does not say: "still retired *by this collapse*". A
+later unrelated retirement satisfies it just as well, which is exactly why the `undoneAt` stamp
+rather than status is what closes the retry.
+
+Leaning on status costs one false refusal, deliberately. A member that was genuinely retired, whose
+undo has not run, and which has since revived to its prior status reads as never retired. Refusing
+loses a legitimate undo and touches nothing; accepting would subtract evidence for a collapse that
+may never have been applied. Silent data loss is the worse outcome, so refusal wins the tie, and a
+caller that needs the undo can reinstate the fold or remove the evidence directly.
+
+Without the records only the status condition is checked, which is the older, weaker behaviour kept
+for existing callers: it accepts a dry run's trace followed by an unrelated decay transition, and it
+has nothing stopping the re-arm sequence above. The four-argument overload keeps that behaviour with
+the limitation stated in its KDoc; anything holding the records should pass them.
+
+Two further refusals are correct rather than conservative, and worth naming so they are not mistaken
+for defects. A **chain-resolved merge** — stacked strategies mark A into B while B is itself merged
+into C, so the runner folds A onto the terminal survivor C and records C while the trace decision
+still names B — can never be undone through the records: undoing against B fails the record check,
+and against C fails the caller-error `require`. That is right, because the folded evidence keys were
+computed against B's evidence, and subtracting them from C would remove the wrong set. And
+`findDecisionForProposition` returns an arbitrary first match on both shipped stores, so a dry-run
+preview of a collapse recorded before the real one can **shadow** the applied decision; the undo
+then evaluates the preview's run, meets a dry-run header, and declines.
+
+A sibling's folded refs are held on the survivor only until that sibling's own undo has run; after
+that it holds its own copy again, so the last member of a shared fold to be undone takes the shared
+evidence with it and the survivor lands back on its pre-collapse evidence. With records that is read
+off the sibling's `undoneAt` for this run, and it has to be: judged by status, a sibling that was
+undone and then retired again by a later run reads as still participating, so the shared evidence
+would be retained forever even though both original folds are reversed. Without records the fallback
+is status, which is what a legacy caller gets. A sibling that has been deleted counts as still
+holding its claim either way, since the survivor's copy is then the only one left.
+
+One limit remains, and it is inherent rather than missing data: an entry the survivor independently
+re-gains after a fold is indistinguishable from the folded one under structural dedup, so undo
+removes it. Grounding refs and source ids have always behaved that way and evidence now matches
+them. A different revision of the same source is a different key and is untouched.
+
+### Subtracting evidence by name, not by remainder
+
+Undo removes evidence through `PropositionStore.subtractProvenance`, which names the refs to delete.
+The obvious alternative — `setProvenance` with the entries that should remain — has a window that
+loses data: naming what stays means reading the entries first, and any evidence another extraction
+adds between that read and the write is replaced away. Nothing recovers it, because the `save` that
+follows is append-only.
+
+`subtractProvenance` ships with a default implementation that is exactly that read-modify-write, so
+an existing store keeps working and a single-JVM in-memory store has nothing to race with; its KDoc
+says so. `DrivinePropositionRepository` overrides it with one statement that deletes `DERIVED_FROM`
+edges by ref and prunes only the sources those edges pointed at, reading nothing first. Refs come in
+the same two forms the codec defines: a minted key is matched against the edge's `entryKey`, and a
+bare locator key matches revisionless edges for that source only — which also reaches edges written
+before `entryKey` existed.
+
+`evidence added while a subtraction is in flight survives it on the graph backend` runs one scenario
+through both paths, injecting the concurrent write where each is vulnerable: the default loses the
+newcomer, the override keeps it.
+
+### The order the writes go in
+
+Evidence comes off first, and the survivor's `save` runs last. Both halves of that order are
+load-bearing. A persistent backend's `save` appends provenance and deletes nothing, so the
+subtraction is the only write that removes the folded evidence. And `save` is the write a decorator
+instruments — `EventEmittingPropositionRepository` publishes `PropositionPersisted` from it, while
+the provenance operations forward to the delegate unannounced. Saving first would fire the event
+while the folded evidence was still in the graph, handing a synchronous listener a survivor that no
+longer exists a moment later. `the survivor's persistence event carries its post-undo evidence` pins
+the ordering against the real decorator.
 
 ### Legacy evidence is unchanged, by construction
 
@@ -513,9 +728,10 @@ Four slices, each green on its own, together equal to the reviewed
    Neo4j actually runs, the DERIVED_FROM edge-count proofs for repeated and concurrent writes of one
    revision, the delete cascade over parallel revisions, and the connector-collision and
    legacy-adoption cases around `:Source` identity.
-3. **Collector hardening** — the trace and undo half: `CollectorSignals` carrying evidence keys,
-   undo routed through the store SPI, `DrivineCollectorTraceStore`, and
-   `MultiSignalCollectorStrategy`.
+3. **Collector hardening** — the trace and undo half: a collapse records the evidence keys of what
+   it folded, undo subtracts them through `PropositionStore.setProvenance` and refuses to write
+   when a participant has gone, and `DrivineCollectorTraceStore` persists and reads the new field
+   with rows written before it still readable.
 4. **Entry points** — `IncrementalPropositionExtraction`, pipeline wiring, the REST surface, and
    the executed binary-compatibility fixture. The async `SourceAnalysisRequestEvent` path carries a
    revision the same way `rememberText` does, since both build `SourceAnalysisContext` through


### PR DESCRIPTION
PR 3 of the source-revision series (refs #64), stacked on #91. Collector fold and undo become authoritative under revisions. Fold refs record through the evidence codec, so a revisioned loser's evidence subtracts exactly on undo. Undo authorization is proven from durable facts the acting paths write themselves: the sweep records the survivor it actually merged into (`CollectorRecord.mergedIntoId`, written after the applied save), and a completed undo stamps `undoneAt` before the member's restore, so every crash window is retry-recoverable and a stranded restore resumes without touching evidence. The dry-run trace contract holds: previews record everything, gated by the run header, and can never authorize.

**Changed in this review round:**

- **Undo fails closed in every direction the review named.** `undoSingleCollapse` takes a `CollapseUndoCommand(contextId, survivorId, retiredId)`, and both propositions must live in that context — a mismatch throws before any write, so ids found anywhere can no longer reverse a collapse in a context the caller has no standing in. A `CollectorRecordStore` is required; the status-only fallback is gone, so nothing skips the "did the collector apply this merge" question. Authorization needs a live run header and a `TRANSITIONED` record naming this survivor.
- **Evidence subtraction is an atomic capability.** `PropositionStore.subtractProvenance` and its read-modify-write default are removed; `ProvenanceSubtractionCapable` states the contract — read and write land as one step, evidence added concurrently survives, subtracting from a deleted proposition answers null and writes nothing. Undo requires the capability and refuses when the store cannot answer. A 200-round race test proves the atomicity; the replaced shape loses the concurrent addition on round one.
- **A deleted survivor ends the undo.** When subtraction answers null, the undo is abandoned with a warn log, nothing is written, and the member stays retired — saving the stale in-memory copy would have recreated another writer's deleted proposition, folded evidence and all. The deletion wins; the KDoc says how late a deletion can land per store.
- `subtractProvenance` semantics pinned on both store paths; connector keys pinned injective where collisions once lived.

**Breaking changes: none for callers of `undoSingleCollapse`; one source-level break for a store that overrode `subtractProvenance`.** Both have a mechanical migration.

*`undoSingleCollapse`'s parameter list.* The four-argument form stays as a `@Deprecated` overload with the body it shipped with — it checks neither context ownership nor the audit records — so an unmigrated caller keeps the behavior it had and gets a compiler warning pointing at the command form. Removed in the next minor release. The guarded form:

```kotlin
// before
undoSingleCollapse(traceQuery, propositionStore, survivorId, retiredId)
// after
undoSingleCollapse(
    command = CollapseUndoCommand(contextId, survivorId, retiredId),
    traceQuery = traceQuery,
    propositions = propositionStore,   // must be ProvenanceSubtractionCapable
    collectorRecords = collectorRecordStore,
)
```

A caller with no `ContextId` has to obtain one, which is the point. Downstream callers migrate with this snippet when convenient; their own hand-rolled ownership checks become redundant once they do.

*`PropositionStore.subtractProvenance`.* A store that overrode it declares `ProvenanceSubtractionCapable` and drops the `override`; `DrivinePropositionRepository` is adapted in this change — its one-statement edge delete already satisfied the contract, so only the supertype list moved. A store that never mentioned the operation compiles unchanged.

No stored data changes. `CollectorRecord`'s two new fields ride `@JvmOverloads` and decode absent-as-null for every stored row.

```mermaid
sequenceDiagram
    participant U as undoCollapse
    participant P as ProvenanceSubtractionCapable
    U->>P: subtractProvenance(survivor, refs)
    alt survivor already deleted
        P-->>U: null
        Note over U: abandon, warn, write nothing
        Note over U: member stays retired
    else subtraction applied
        P-->>U: survivor minus this member's evidence
        U->>P: save survivor, final state, event-carrying
        U->>P: stamp undoneAt on the collector record
        U->>P: restore member to its prior status
    end
```

The stamp sits between the evidence writes and the restore, which is what makes every crash window recoverable; the crash matrix is in the KDoc.

