### PR TITLE
fix(provenance): escape connector ids so ConnectorRef keys are injective

### DIFF
--- a/dice/src/main/kotlin/com/embabel/dice/provenance/SourceLocator.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/provenance/SourceLocator.kt
@@ -51,9 +51,11 @@ sealed interface SourceLocator {
      * A stable, comparable key identifying this locator.
      *
      * Keys are prefixed by locator kind so that distinct kinds never collide
-     * (`uri:...`, `file:...`, `content:...`, `connector:...`). Use this for
-     * deduplication, indexing, and reference equality rather than the [display]
-     * label.
+     * (`uri:...`, `file:...`, `content:...`, `connector:...`), and distinct
+     * locators always render distinct keys — [ConnectorRef] escapes its
+     * connector id so free-text ids containing colons cannot blur the boundary
+     * between its two segments. Use this for deduplication, indexing, and
+     * reference equality rather than the [display] label.
      *
      * @return a stable key string for this locator
      */
@@ -142,6 +144,16 @@ data class ContentAddressedLocator @JvmOverloads constructor(
  * [externalId] within the system identified by [connectorId]. DICE only holds
  * the identifiers needed to ask the connector for the material later.
  *
+ * Both ids are free text, so the key escapes the connector id (`\` becomes `\\`,
+ * `:` becomes `\:`) to keep the boundary between the two segments unambiguous —
+ * otherwise `ConnectorRef("a:b", "c")` and `ConnectorRef("a", "b:c")` would both
+ * render `connector:a:b:c` and wrongly compare equal. The external id needs no
+ * escaping because it is the last segment. For any connector id without `:` or
+ * `\` — every realistic one — the key is byte-identical to the pre-escaping
+ * rendering, so existing stored `:Source` nodes keep their keys. A stored key
+ * whose connector id did contain those characters was ambiguous when written
+ * and cannot be re-keyed from the key alone; re-ingesting the source is the fix.
+ *
  * @property connectorId Identifier of the connector that owns the material
  *   (e.g. "slack", "notion", "gmail")
  * @property externalId Identifier of the material within that connector
@@ -158,10 +170,28 @@ data class ConnectorRef @JvmOverloads constructor(
         require(externalId.isNotBlank()) { "externalId must not be blank" }
     }
 
-    override fun key(): String = "connector:$connectorId:$externalId"
+    override fun key(): String = "connector:${escapeSegment(connectorId)}:$externalId"
 
     // Identity is [key]; [display] is presentation-only and excluded (see SourceLocator contract).
     override fun equals(other: Any?): Boolean = other is SourceLocator && other.key() == key()
 
     override fun hashCode(): Int = key().hashCode()
+
+    private companion object {
+
+        private fun escapeSegment(value: String): String {
+            if (value.none { it == ':' || it == '\\' }) {
+                return value
+            }
+            return buildString(value.length + 2) {
+                for (character in value) {
+                    when (character) {
+                        '\\' -> append("\\\\")
+                        ':' -> append("\\:")
+                        else -> append(character)
+                    }
+                }
+            }
+        }
+    }
 }

--- a/dice/src/test/kotlin/com/embabel/dice/provenance/SourceLocatorTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/provenance/SourceLocatorTest.kt
@@ -45,6 +45,31 @@ class SourceLocatorTest {
     }
 
     @Test
+    fun `connector keys stay legacy-shaped when only the external id contains colons`() {
+        // Stored :Source nodes are keyed by this rendering, so it must not shift
+        // for any connector id without ':' or '\' — i.e. all realistic ones.
+        assertEquals(
+            "connector:slack:C123:1699999999.123456",
+            ConnectorRef("slack", "C123:1699999999.123456").key(),
+        )
+    }
+
+    @Test
+    fun `connector key escaping keeps structurally different refs distinct`() {
+        // Without escaping, both of these rendered "connector:a:b:c".
+        val colonInConnector = ConnectorRef("a:b", "c")
+        val colonInExternal = ConnectorRef("a", "b:c")
+        assertEquals("""connector:a\:b:c""", colonInConnector.key())
+        assertEquals("connector:a:b:c", colonInExternal.key())
+        assertNotEquals(colonInConnector, colonInExternal)
+        assertNotEquals(colonInConnector.hashCode(), colonInExternal.hashCode())
+
+        // Backslashes are doubled so an id ending in '\' can't fake an escape.
+        assertEquals("""connector:a\\:b:c""", ConnectorRef("""a\""", "b:c").key())
+        assertNotEquals(ConnectorRef("""a\""", "b:c"), colonInConnector)
+    }
+
+    @Test
     fun `display does not participate in identity`() {
         val a = UriLocator("https://example.com/doc", display = "Doc A")
         val b = UriLocator("https://example.com/doc", display = "Doc B")


### PR DESCRIPTION
`ConnectorRef.key()` concatenated two free-text segments with `:`, so structurally different refs could render the same key and compare equal — `ConnectorRef("a:b", "c")` and `ConnectorRef("a", "b:c")` both produced `connector:a:b:c` (found in the source-revision Codex review; the storage layer has a structural guard, but the identity defect was upstream).

Fix: escape `\` and `:` in the connector id only. The first unescaped colon after `connector:` now unambiguously ends the connector-id segment, making the encoding injective. The external id stays raw, so for any connector id without `:` or `\` the key is byte-identical to the previous rendering — existing `:Source` nodes keyed by `SourceLocator.key()` are unaffected. Keys whose connector id did contain those characters were ambiguous when written and can't be re-keyed from the key alone; re-ingesting the source is the remedy (noted in the KDoc).

Nothing parses keys back (`PropositionGraphMapper` persists `connectorId`/`externalId` as separate node properties), so injectivity is all the contract needs — which is why this avoids length-framing and the stored-key churn it would bring.

Verified: `./mvnw -pl dice -am test` (1189 tests) and `./mvnw -pl dice-storage clean test` (89 tests) green.
