### PR TITLE
REST controller conditions answered after auto-configuration

### DIFF
--- a/dice-storage-autoconfigure/pom.xml
+++ b/dice-storage-autoconfigure/pom.xml
@@ -164,6 +164,30 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!--
+          Test: WebApplicationContextRunner needs a servlet API to build its mock context, and that
+          is how the REST controllers' web conditions are checked. Runtime needs nothing new: the
+          controllers live in dice, which already declares the servlet API itself.
+        -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!--
+          Test: the REST wiring tests read the URLs a context really exposes off a live
+          RequestMappingHandlerMapping, which lives in spring-webmvc. `dice` declares spring-webmvc
+          optional, so it stops there and never reaches this module's classpath. Asking whether a
+          controller bean exists is a weaker question than asking which routes resolve, and the
+          second one is what a host's endpoint snapshot is about.
+        -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dice-storage-autoconfigure/src/test/kotlin/com/embabel/dice/storage/autoconfigure/DiceRestImportWiringTest.kt
+++ b/dice-storage-autoconfigure/src/test/kotlin/com/embabel/dice/storage/autoconfigure/DiceRestImportWiringTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.storage.autoconfigure
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.rag.ingestion.HierarchicalContentReader
+import com.embabel.common.ai.model.EmbeddingService
+import com.embabel.dice.common.EntityResolver
+import com.embabel.dice.common.SchemaRegistry
+import com.embabel.dice.pipeline.PropositionPipeline
+import com.embabel.dice.projection.memory.CollectorRunner
+import com.embabel.dice.web.rest.DiceRestConfiguration
+import com.embabel.dice.web.rest.DiscoveryController
+import com.embabel.dice.web.rest.MemoryController
+import com.embabel.dice.web.rest.PropositionPipelineController
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping
+
+/**
+ * The controllers behind a host's `@Import(DiceRestConfiguration)` must see the store beans the
+ * auto-configurations contribute. `@ConditionalOnBean` on a plainly imported class is answered
+ * while the importing configuration is read, before Spring Boot registers any auto-configuration
+ * bean definition, so a condition naming an autoconfigured store answers "no" in exactly the
+ * wiring the docs recommend. These tests pin the fix: the conditional controllers arrive through
+ * a deferred import that is processed after the auto-configuration selector.
+ *
+ * The host shape throughout is the documented one — stores from `dice-storage-autoconfigure`,
+ * runner and pipeline hand-built.
+ */
+class DiceRestImportWiringTest {
+
+    private val autoConfigurations = AutoConfigurations.of(
+        DiceStorageAutoConfiguration::class.java,
+        CollectorAutoConfiguration::class.java,
+    )
+
+    private val importingHost = WebApplicationContextRunner()
+        .withConfiguration(autoConfigurations)
+        .withUserConfiguration(ImportingHostConfig::class.java, EndpointMappingConfig::class.java)
+
+    @Test
+    fun `discovery routes exist for a host on autoconfigured stores`() {
+        importingHost.run { ctx ->
+            assertThat(ctx).hasSingleBean(DiscoveryController::class.java)
+            assertThat(endpoints(ctx)).anyMatch { "/discovery" in it }
+        }
+    }
+
+    @Test
+    fun `pipeline routes exist for a host on autoconfigured stores`() {
+        importingHost.run { ctx ->
+            assertThat(ctx).hasSingleBean(PropositionPipelineController::class.java)
+        }
+    }
+
+    @Test
+    fun `memory routes ride the same import`() {
+        importingHost.run { ctx ->
+            assertThat(ctx).hasSingleBean(MemoryController::class.java)
+            assertThat(endpoints(ctx)).anyMatch { "/memory" in it }
+        }
+    }
+
+    @Test
+    fun `no import means no dice routes whatever the autoconfigurations wired`() {
+        WebApplicationContextRunner()
+            .withConfiguration(autoConfigurations)
+            .withUserConfiguration(NonImportingHostConfig::class.java, EndpointMappingConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).doesNotHaveBean(DiscoveryController::class.java)
+                assertThat(ctx).doesNotHaveBean(PropositionPipelineController::class.java)
+                assertThat(ctx).doesNotHaveBean(MemoryController::class.java)
+                assertThat(endpoints(ctx)).isEmpty()
+            }
+    }
+
+    @Test
+    fun `a missing collector runner leaves discovery off and the context clean`() {
+        WebApplicationContextRunner()
+            .withConfiguration(autoConfigurations)
+            .withUserConfiguration(NoRunnerHostConfig::class.java, EndpointMappingConfig::class.java)
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+                assertThat(ctx).doesNotHaveBean(DiscoveryController::class.java)
+                assertThat(ctx).hasSingleBean(MemoryController::class.java)
+            }
+    }
+
+    /** The URLs this context actually resolves, as `METHOD /path`, read off a live handler mapping. */
+    private fun endpoints(ctx: ApplicationContext): List<String> =
+        ctx.getBean(RequestMappingHandlerMapping::class.java).handlerMethods.keys
+            .flatMap { info ->
+                val verbs = info.methodsCondition.methods.map { it.name }.ifEmpty { listOf("ANY") }
+                info.pathPatternsCondition?.patternValues.orEmpty()
+                    .flatMap { path -> verbs.map { verb -> "$verb $path" } }
+            }
+            .sorted()
+
+    /**
+     * A live Spring MVC handler mapping. It builds its table from the controller bean definitions
+     * the context holds and reads their types without creating them.
+     */
+    @Configuration(proxyBeanMethods = false)
+    open class EndpointMappingConfig {
+        @Bean
+        open fun requestMappingHandlerMapping(): RequestMappingHandlerMapping = RequestMappingHandlerMapping()
+    }
+
+    /** Everything a host hand-builds today: the AI stub the in-memory store needs, runner, pipeline. */
+    @Configuration(proxyBeanMethods = false)
+    open class HandBuiltBeansConfig {
+        @Bean
+        open fun ai(): Ai {
+            val ai = mock<Ai>()
+            whenever(ai.withDefaultEmbeddingService()).thenReturn(mock<EmbeddingService>())
+            return ai
+        }
+
+        @Bean
+        open fun collectorRunner(): CollectorRunner = mock<CollectorRunner>()
+
+        @Bean
+        open fun propositionPipeline(): PropositionPipeline = mock<PropositionPipeline>()
+
+        @Bean
+        open fun entityResolver(): EntityResolver = mock<EntityResolver>()
+
+        @Bean
+        open fun schemaRegistry(): SchemaRegistry = mock<SchemaRegistry>()
+
+        /**
+         * The pipeline controller's default content reader is the Tika one, and Tika's rag-ingestion
+         * module is optional and absent here; a supplied bean keeps the default from evaluating.
+         */
+        @Bean
+        open fun contentReader(): HierarchicalContentReader = mock<HierarchicalContentReader>()
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @Import(DiceRestConfiguration::class, HandBuiltBeansConfig::class)
+    open class ImportingHostConfig
+
+    @Configuration(proxyBeanMethods = false)
+    @Import(HandBuiltBeansConfig::class)
+    open class NonImportingHostConfig
+
+    /** Imports DICE REST and wires the pipeline, with no collector runner anywhere. */
+    @Configuration(proxyBeanMethods = false)
+    @Import(DiceRestConfiguration::class)
+    open class NoRunnerHostConfig {
+        @Bean
+        open fun ai(): Ai {
+            val ai = mock<Ai>()
+            whenever(ai.withDefaultEmbeddingService()).thenReturn(mock<EmbeddingService>())
+            return ai
+        }
+
+        @Bean
+        open fun propositionPipeline(): PropositionPipeline = mock<PropositionPipeline>()
+
+        @Bean
+        open fun entityResolver(): EntityResolver = mock<EntityResolver>()
+
+        @Bean
+        open fun schemaRegistry(): SchemaRegistry = mock<SchemaRegistry>()
+
+        /**
+         * The pipeline controller's default content reader is the Tika one, and Tika's rag-ingestion
+         * module is optional and absent here; a supplied bean keeps the default from evaluating.
+         */
+        @Bean
+        open fun contentReader(): HierarchicalContentReader = mock<HierarchicalContentReader>()
+    }
+}

--- a/dice-storage-autoconfigure/src/test/kotlin/com/embabel/dice/storage/autoconfigure/GovernanceOperatorAutoConfigurationTest.kt
+++ b/dice-storage-autoconfigure/src/test/kotlin/com/embabel/dice/storage/autoconfigure/GovernanceOperatorAutoConfigurationTest.kt
@@ -85,7 +85,7 @@ class GovernanceOperatorAutoConfigurationTest {
      * is read, and Spring Boot registers auto-configuration bean definitions after that. So a plain
      * entry in `DiceRestConfiguration`'s `@Import` list would answer "no service" for every host
      * whose loop came from `MetamodelAutoConfiguration` — which is every host that follows the
-     * documented wiring. `GovernanceControllerImport` defers the import to the end of the round,
+     * documented wiring. `ConditionalControllerImport` defers the import to the end of the round,
      * and this test is what would catch that deferral being dropped: the service below exists only
      * because the auto-configuration built it.
      */

--- a/dice/src/main/kotlin/com/embabel/dice/web/rest/DiceRestConfiguration.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/web/rest/DiceRestConfiguration.kt
@@ -25,9 +25,9 @@ import org.springframework.core.type.AnnotationMetadata
  * Opt-in Spring configuration that activates all DICE REST controllers.
  *
  * Import this in your application config to expose the proposition extraction, memory, discovery,
- * and schema-governance endpoints. Nothing is component-scanned — the controllers only activate when
- * this class is imported AND the required beans (PropositionPipeline, PropositionStore,
- * GovernanceOperationsService, etc.) are present.
+ * and schema-governance endpoints. Nothing is component-scanned: the controllers only activate when
+ * this class is imported AND the beans they need (PropositionPipeline, PropositionStore,
+ * GovernanceOperationsService, etc.) are present, wherever those beans come from.
  *
  * ```java
  * @Configuration
@@ -37,40 +37,44 @@ import org.springframework.core.type.AnnotationMetadata
  */
 @Configuration
 @Import(
-    PropositionPipelineController::class,
     MemoryController::class,
-    DiscoveryController::class,
-    GovernanceControllerImport::class,
+    ConditionalControllerImport::class,
 )
 class DiceRestConfiguration
 
 /**
- * Brings [GovernanceController] in last, once every other bean definition is on the registry.
+ * Brings the conditional controllers in last, once every other bean definition is on the registry.
  *
- * The other three controllers are named directly in the `@Import` above and carry their own
- * `@ConditionalOnBean`. That condition is answered while the importing configuration class is being
- * read, so it can see the host's own beans and it cannot see anything an auto-configuration will
- * contribute later — Spring Boot registers auto-configuration bean definitions after every
- * configuration class the application imported.
+ * [MemoryController] is named directly in the `@Import` above because it carries no condition. The
+ * other three gate on `@ConditionalOnBean`: [DiscoveryController] on the proposition store, the
+ * projection record store and the collector runner; [PropositionPipelineController] on the
+ * pipeline; [GovernanceController] on a `GovernanceOperationsService`. A condition on a plainly
+ * imported class is answered while the importing configuration class is being read, so it can only
+ * see beans already on the registry at that moment: nothing an auto-configuration will contribute
+ * later, because Spring Boot registers auto-configuration bean definitions after every configuration
+ * class the application imported, and nothing from a host configuration Spring happens to process
+ * afterwards. A host on `dice-storage-autoconfigure` for its stores therefore got no discovery
+ * routes at all, silently, and a host whose governance loop came from `MetamodelAutoConfiguration`
+ * would have lost its governance routes the same way.
  *
- * `GovernanceController` needs a `GovernanceOperationsService`, and that service is exactly such a
- * bean: `MetamodelAutoConfiguration` in `dice-storage-autoconfigure` builds it for a host that
- * declared a schema. Naming the controller in the `@Import` list would therefore leave it switched
- * off in every application that got its governance loop from the auto-configuration.
- *
- * A [DeferredImportSelector] is the fix, because Spring processes deferred imports at the end of the
- * configuration-parsing round and this one declares the lowest precedence, so it runs behind Spring
- * Boot's own auto-configuration selector. By the time the controller's condition is asked, the
- * governance service is either on the registry or it never will be, and the answer is right in both
- * directions: the controller appears for a host whose governance loop is wired, and stays away —
- * with a clean context and no `/api/v1/metamodel` route — for a host that declared no schema, killed
- * the loop with `embabel.dice.metamodel.enabled=false`, runs `drift.mode=off`, or uses the in-memory
+ * A [DeferredImportSelector] is the fix, because Spring processes deferred imports at the end of
+ * the configuration-parsing round and this one declares the lowest precedence, so it runs behind
+ * Spring Boot's own auto-configuration selector. By the time each controller's condition is asked,
+ * its beans are either on the registry or they never will be, and the answer is right in both
+ * directions: the controller appears wherever its collaborators exist, whoever contributed them,
+ * and stays away, with a clean context and no routes, where they are absent. For the governance
+ * controller that means no `/api/v1/metamodel` route for a host that declared no schema, killed the
+ * loop with `embabel.dice.metamodel.enabled=false`, runs `drift.mode=off`, or uses the in-memory
  * backend that has no drift log to read.
  */
-internal class GovernanceControllerImport : DeferredImportSelector, Ordered {
+internal class ConditionalControllerImport : DeferredImportSelector, Ordered {
 
     override fun selectImports(importingClassMetadata: AnnotationMetadata): Array<String> =
-        arrayOf(GovernanceController::class.java.name)
+        arrayOf(
+            PropositionPipelineController::class.java.name,
+            DiscoveryController::class.java.name,
+            GovernanceController::class.java.name,
+        )
 
     /** Behind Spring Boot's auto-configuration selector, which sits one step above this. */
     override fun getOrder(): Int = Ordered.LOWEST_PRECEDENCE

--- a/dice/src/main/kotlin/com/embabel/dice/web/rest/GovernanceController.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/web/rest/GovernanceController.kt
@@ -58,7 +58,7 @@ import org.springframework.web.bind.annotation.RestController
  * So a host that imports [DiceRestConfiguration] and declared no schema resolves zero
  * `/api/v1/metamodel` URLs and starts cleanly, and a host that wants the governance loop through
  * agent tools or its own code with no endpoint open leaves the import out. See
- * [GovernanceControllerImport] for why the condition is asked late enough to see a service the
+ * [ConditionalControllerImport] for why the condition is asked late enough to see a service the
  * auto-configuration built.
  *
  * `@ConditionalOnMissingBean` lets a host put these operations somewhere else — a different path,

--- a/docs/design/metamodel-wiring.md
+++ b/docs/design/metamodel-wiring.md
@@ -273,7 +273,7 @@ There is one wrinkle worth knowing, because it decides where the controller can 
 that imported it, and Spring Boot registers auto-configuration bean definitions after that point. A
 plain entry in `DiceRestConfiguration`'s `@Import` list would therefore see no
 `GovernanceOperationsService` in any application whose loop came from the auto-configuration —
-which is every application following this note. `GovernanceControllerImport`, a
+which is every application following this note. `ConditionalControllerImport`, a
 `DeferredImportSelector` with the lowest precedence, is what puts the question after Spring Boot's
 own auto-configuration selector has answered. `GovernanceOperatorAutoConfigurationTest` pins all
 four combinations of import and loop, reading the live handler mapping so an empty answer means a


### PR DESCRIPTION
`@ConditionalOnBean` on a plainly imported class is answered while the importing configuration class is being read, before Spring Boot registers any auto-configuration bean definition. So `DiscoveryController` and `PropositionPipelineController`, both named in `DiceRestConfiguration`'s `@Import` list with conditions on store beans, silently dropped their routes in the documented wiring: stores from `dice-storage-autoconfigure`, runner and pipeline hand-built. The repro showed the pipeline controller affected too — its host-supplied gate bean sat in a sibling import Spring processed after the condition was asked, so the plain-import shape is order-fragile even against host beans.

The fix: `MemoryController` (unconditional) stays a direct import; the two conditional controllers arrive through `ConditionalControllerImport`, an internal `DeferredImportSelector` at lowest precedence, behind Boot's own auto-configuration selector. By the time each condition is asked, its beans are on the registry or never will be. No new public API, no properties; the host-facing idiom is still one `@Import(DiceRestConfiguration.class)`.

Evidence: the two discriminating tests fail against unmodified main (routes read off a live `RequestMappingHandlerMapping`, so failure means a real 404) and pass with the fix. Five wiring tests total: both route tests, memory riding the same import, the no-import negative, and a missing-runner negative proving a clean context with discovery absent.

Same measurement and idiom as the governance activation work on #88; when that lands, `GovernanceController` folds into this selector's array as one line.
