### PR TITLE
Record collector decisions from the duplicate strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -728,6 +728,23 @@ and the consumer PRs that deliver it).
   moved to `QUARANTINED`. **Compatibility: additive.** No shipped symbol changes; the module now
   builds from a clean tree.
 
+- `DuplicateCollectorStrategy` records a `CollectorDecision` for every component it collapses, given
+  a `CollectorTraceStore`. It takes the store as a third, optional constructor argument, the same
+  way `MultiSignalCollectorStrategy` does, and implements `RunAwareCollectorStrategy` so it sees the
+  run id. Before this, a sweep run with the duplicate strategy wrote `CollectorRecord` rows naming
+  the survivor and no decision at all, so `undoSingleCollapse` and anything reading
+  `CollectorTraceQuery.findDecisionForProposition` found nothing to reverse: the collapse was
+  applied and could not be undone. Each decision carries one `RetiredProposition` per loser with the
+  grounding, provenance refs, evidence keys, source ids and prior status the merging sweep folds
+  onto the survivor, computed by the same rule the multi-signal strategy uses (only what the
+  survivor did not already hold). The cluster similarities are recorded as candidate edges and the
+  union-find components as components, so a duplicate run reads back through the trace endpoint
+  like a multi-signal one. A blank run id (the read-only `collect()` path) still records nothing.
+  **Compatibility: additive.** The existing one- and two-argument constructors are unchanged via
+  `@JvmOverloads`, and a strategy built without a trace store behaves exactly as before. A host that
+  wants duplicate collapses to be undoable passes its `CollectorTraceStore` bean when it builds the
+  strategy.
+
 - `:Source.display` in the graph projection is write-once. A `:Source` node is global — one locator
   key is one node across every context that cites it — and `display` used to be refreshed on every
   write, so whichever writer ran last owned the label every other context read. It is now set on

--- a/dice/src/main/kotlin/com/embabel/dice/projection/memory/DuplicateCollectorStrategy.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/projection/memory/DuplicateCollectorStrategy.kt
@@ -15,11 +15,18 @@
  */
 package com.embabel.dice.projection.memory
 
-import com.embabel.agent.core.ContextId
+import com.embabel.agent.rag.service.Cluster
+import com.embabel.dice.projection.memory.collector.CollectorRunContext
+import com.embabel.dice.projection.memory.collector.retiredByFold
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionQuery
 import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
+import com.embabel.dice.spi.CollectorCandidateEdge
+import com.embabel.dice.spi.CollectorComponent
+import com.embabel.dice.spi.CollectorDecision
+import com.embabel.dice.spi.CollectorSignalScore
+import com.embabel.dice.spi.CollectorTraceStore
 import com.embabel.dice.spi.MarkReason
 import com.embabel.dice.spi.PropositionMark
 import org.slf4j.LoggerFactory
@@ -28,40 +35,58 @@ import org.slf4j.LoggerFactory
  * A [CollectorStrategy] that finds near-duplicate propositions and marks all but the strongest
  * member of each duplicate group.
  *
- * Because clusters from [PropositionRepository.findClusters] can overlap (a proposition may
- * appear in more than one cluster), survivors are picked globally per connected component rather
- * than per cluster. Within each component the survivor is the proposition with the highest
- * effective confidence, with reinforcement count and id as tie-breakers. Every non-survivor gets
- * a [MarkReason.Duplicate] mark pointing at its component's survivor; survivors are never marked.
+ * Clusters from [PropositionRepository.findClusters] can overlap (a proposition may appear in more
+ * than one cluster), so survivors are picked once per connected component across all clusters.
+ * Within each component the survivor is the proposition with the highest effective confidence,
+ * with reinforcement count and id as tie-breakers. Every non-survivor gets a
+ * [MarkReason.Duplicate] mark pointing at its component's survivor; survivors are never marked.
  *
- * Only propositions in the runner's candidate snapshot are considered — any cluster member
- * absent from `candidates` is silently ignored. This keeps every emitted mark tied to a swept
- * candidate and avoids a second read of the repository. The strategy never writes.
+ * Only propositions in the runner's candidate snapshot are considered: any cluster member absent
+ * from `candidates` is silently ignored. This keeps every emitted mark tied to a swept candidate
+ * and avoids a second read of the repository. The strategy never writes to the repository.
+ *
+ * Given a [traceStore] and a real run (a non-blank [CollectorRunContext.runId]), each component
+ * that collapses is also written down as a [CollectorDecision]: the survivor, and for every loser
+ * the grounding, provenance and source ids the merging sweep will fold onto the survivor from it.
+ * That record is what [com.embabel.dice.spi.undoSingleCollapse] reads to reverse a collapse, so a
+ * sweep run without a trace store cannot be undone afterwards. The similarity edges and the
+ * components are recorded beside it, for inspection. Trace writes are best effort: a failure is
+ * logged and the marks are still returned.
  *
  * Default [similarityThreshold] (0.7) and [topK] (10) match [PropositionRepository.findClusters]
  * so behavior is consistent with the repository's own clustering out of the box.
  *
  * @property similarityThreshold Minimum cosine similarity for two propositions to be clustered together.
  * @property topK Maximum number of similar members considered per cluster seed.
+ * @property traceStore Where collapse decisions are recorded. Null records nothing.
  */
 class DuplicateCollectorStrategy @JvmOverloads constructor(
     private val similarityThreshold: Double = 0.7,
     private val topK: Int = 10,
-) : CollectorStrategy {
+    private val traceStore: CollectorTraceStore? = null,
+) : RunAwareCollectorStrategy {
 
     private val logger = LoggerFactory.getLogger(DuplicateCollectorStrategy::class.java)
 
     override fun mark(
         candidates: List<Proposition>,
         repository: PropositionRepository,
-        contextId: ContextId,
+        ctx: CollectorRunContext,
     ): List<PropositionMark> {
         val byId = candidates.associateBy { it.id }
+        val contextId = ctx.contextId
+        // A blank runId is the mark-only collect() path or the legacy bridge: nothing written under
+        // it could be looked up again, so no trace is kept for it.
+        val trace = traceStore?.takeIf { ctx.runId.isNotBlank() }
+        val runId = ctx.runId
+        if (trace != null) record("recordRunContext") { trace.recordRunContext(runId, contextId) }
+
         val clusters = repository.findClusters(
             similarityThreshold = similarityThreshold,
             topK = topK,
             query = PropositionQuery.forContextId(contextId).withStatus(PropositionStatus.ACTIVE),
         )
+        if (trace != null) record("recordCandidateEdges") { trace.recordCandidateEdges(runId, edgesFrom(clusters, byId)) }
 
         // Build connected components over clustered members, restricted to the runner-supplied
         // candidate snapshot so every mark maps to a swept candidate.
@@ -76,28 +101,49 @@ class DuplicateCollectorStrategy @JvmOverloads constructor(
             }
         }
 
-        // Group candidate members by their component root.
+        // Group candidate members by their component root; the root id names the component.
         val componentMembers: Map<String, List<Proposition>> = unionFind.members()
             .mapNotNull { id -> byId[id] }
             .groupBy { unionFind.find(it.id) }
+        if (trace != null) {
+            record("recordComponents") {
+                trace.recordComponents(
+                    runId,
+                    componentMembers.map { (componentId, members) -> CollectorComponent(componentId, members.map { it.id }) },
+                )
+            }
+        }
 
-        val marks = componentMembers.values
-            .filter { it.size >= 2 }
-            .flatMap { members ->
+        val marks = componentMembers.entries
+            .filter { it.value.size >= 2 }
+            .flatMap { (componentId, members) ->
                 // Global survivor per component: max effectiveConfidence, then reinforceCount,
                 // then a stable id tie-break for full determinism on ties.
                 val survivor = members.maxWith(
                     compareBy<Proposition>({ it.effectiveConfidence() }, { it.reinforceCount }, { it.id }),
                 )
-                members
-                    .filter { it.id != survivor.id }
-                    .map {
-                        PropositionMark(
-                            propositionId = it.id,
-                            reason = MarkReason.Duplicate(survivorId = survivor.id),
-                            strategyName = STRATEGY_NAME,
+                val losers = members.filter { it.id != survivor.id }
+                if (trace != null) {
+                    record("recordDecision") {
+                        trace.recordDecision(
+                            runId,
+                            CollectorDecision(
+                                runId = runId,
+                                componentId = componentId,
+                                survivorId = survivor.id,
+                                action = MERGE_ACTION,
+                                retired = losers.map { retiredByFold(it, survivor) },
+                            ),
                         )
                     }
+                }
+                losers.map {
+                    PropositionMark(
+                        propositionId = it.id,
+                        reason = MarkReason.Duplicate(survivorId = survivor.id),
+                        strategyName = STRATEGY_NAME,
+                    )
+                }
             }
             // Each non-survivor belongs to exactly one component, but dedup defensively so a
             // proposition is never marked more than once across overlapping clusters.
@@ -109,6 +155,45 @@ class DuplicateCollectorStrategy @JvmOverloads constructor(
         )
         return marks
     }
+
+    /**
+     * Runs a trace-store write and keeps going if it fails. The trace is for inspecting and undoing
+     * a run later; the marks are the product, and a store hiccup must not abort the sweep.
+     */
+    private fun record(what: String, block: () -> Unit) {
+        runCatching(block).onFailure { e ->
+            logger.warn("DuplicateCollectorStrategy: trace store write '{}' failed, continuing run", what, e)
+        }
+    }
+
+    /**
+     * One edge per clustered pair that reached a candidate, carrying the repository's cosine score
+     * as its single signal. The anchor is kept even when it is outside the candidate snapshot: the
+     * union-find above still groups that cluster's candidate members through it, so the edge is
+     * what explains the component. Pairs are canonicalized (smaller id as anchor) and deduped, so a
+     * pair found from both ends is recorded once.
+     */
+    private fun edgesFrom(
+        clusters: List<Cluster<Proposition>>,
+        byId: Map<String, Proposition>,
+    ): List<CollectorCandidateEdge> = clusters
+        .flatMap { cluster ->
+            cluster.similar
+                .filter { byId.containsKey(it.match.id) && it.match.id != cluster.anchor.id }
+                .map { similar ->
+                    val (anchorId, memberId) =
+                        if (cluster.anchor.id <= similar.match.id) cluster.anchor.id to similar.match.id
+                        else similar.match.id to cluster.anchor.id
+                    CollectorCandidateEdge(
+                        anchorId = anchorId,
+                        memberId = memberId,
+                        aggregateScore = similar.score,
+                        vetoed = false,
+                        signals = listOf(CollectorSignalScore(signal = COSINE_SIGNAL, score = similar.score)),
+                    )
+                }
+        }
+        .distinctBy { it.anchorId to it.memberId }
 
     /**
      * Simple union-find over proposition ids, used to merge overlapping clusters into
@@ -147,5 +232,9 @@ class DuplicateCollectorStrategy @JvmOverloads constructor(
 
     companion object {
         private const val STRATEGY_NAME = "duplicate"
+
+        /** Same action name the multi-signal strategy records, so trace readers see one vocabulary. */
+        private const val MERGE_ACTION = "duplicate-merge"
+        private const val COSINE_SIGNAL = "cosine"
     }
 }

--- a/dice/src/main/kotlin/com/embabel/dice/projection/memory/collector/FoldedEvidence.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/projection/memory/collector/FoldedEvidence.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.dice.projection.memory.collector
+
+import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
+import com.embabel.dice.spi.RetiredProposition
+
+/**
+ * The undo record for one proposition about to be folded into a survivor: only the grounding,
+ * provenance and source ids the survivor does not already hold.
+ *
+ * `absorbEvidence` is a deduplicating union, so anything the survivor owned before the merge
+ * (common for near-duplicates from the same source) is left out. Recording it as folded would let
+ * a later undo strip evidence the survivor held on its own.
+ *
+ * Evidence is compared by its full evidence key, so one document read at two revisions counts as
+ * two pieces of evidence: a survivor citing r1 does not hide the loser's r2, and undo can name r2
+ * exactly. The locator keys stay beside them for trace readers and for consumers still reading the
+ * older field.
+ */
+internal fun retiredByFold(loser: Proposition, survivor: Proposition): RetiredProposition {
+    val survivorGrounding = survivor.grounding.toSet()
+    val survivorProvenanceRefs = survivor.provenanceEntries
+        .map { it.locator.key() }
+        .toSet()
+    val survivorEvidenceKeys = survivor.provenanceEntries
+        .map(ProvenanceEvidenceKey::encode)
+        .toSet()
+    val survivorSourceIds = survivor.sourceIds.toSet()
+    return RetiredProposition(
+        propositionId = loser.id,
+        priorStatus = loser.status,
+        foldedGrounding = loser.grounding - survivorGrounding,
+        foldedProvenanceRefs = loser.provenanceEntries
+            .map { it.locator.key() }
+            .distinct() - survivorProvenanceRefs,
+        foldedSourceIds = loser.sourceIds - survivorSourceIds,
+        foldedProvenanceEvidenceKeys = loser.provenanceEntries
+            .map(ProvenanceEvidenceKey::encode)
+            .distinct() - survivorEvidenceKeys,
+    )
+}

--- a/dice/src/main/kotlin/com/embabel/dice/projection/memory/collector/MultiSignalCollectorStrategy.kt
+++ b/dice/src/main/kotlin/com/embabel/dice/projection/memory/collector/MultiSignalCollectorStrategy.kt
@@ -19,7 +19,6 @@ import com.embabel.agent.core.ContextId
 import com.embabel.dice.projection.memory.RunAwareCollectorStrategy
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionRepository
-import com.embabel.dice.provenance.ProvenanceEvidenceKey
 import com.embabel.dice.spi.CandidatePair
 import com.embabel.dice.spi.CandidatePairSource
 import com.embabel.dice.spi.CollectorCandidateEdge
@@ -30,7 +29,6 @@ import com.embabel.dice.spi.CollectorTraceStore
 import com.embabel.dice.spi.ConnectedComponentsFinder
 import com.embabel.dice.spi.MarkReason
 import com.embabel.dice.spi.PropositionMark
-import com.embabel.dice.spi.RetiredProposition
 import org.slf4j.LoggerFactory
 
 /**
@@ -302,37 +300,8 @@ class MultiSignalCollectorStrategy(
         val losers = members.filter { it.id != survivor.id }
 
         if (tracing) {
-            // Record only what each loser actually ADDS to the survivor, not its whole evidence
-            // set: absorbEvidence is a deduplicating union, so any ref the survivor already owned
-            // pre-merge (common for near-duplicates from the same source) must not be recorded as
-            // "folded", or undo would later strip evidence the survivor held independently.
-            //
-            // Evidence is compared by its full evidence key, so one document read at two revisions
-            // counts as two pieces of evidence: a survivor citing r1 does not hide the loser's r2,
-            // and undo can name r2 exactly. The locator keys stay beside them for trace readers and
-            // for consumers still reading the older field.
-            val survivorGrounding = survivor.grounding.toSet()
-            val survivorProvenanceRefs = survivor.provenanceEntries
-                .map { it.locator.key() }
-                .toSet()
-            val survivorEvidenceKeys = survivor.provenanceEntries
-                .map(ProvenanceEvidenceKey::encode)
-                .toSet()
-            val survivorSourceIds = survivor.sourceIds.toSet()
-            val retired = losers.map { loser ->
-                RetiredProposition(
-                    propositionId = loser.id,
-                    priorStatus = loser.status,
-                    foldedGrounding = loser.grounding - survivorGrounding,
-                    foldedProvenanceRefs = loser.provenanceEntries
-                        .map { it.locator.key() }
-                        .distinct() - survivorProvenanceRefs,
-                    foldedSourceIds = loser.sourceIds - survivorSourceIds,
-                    foldedProvenanceEvidenceKeys = loser.provenanceEntries
-                        .map(ProvenanceEvidenceKey::encode)
-                        .distinct() - survivorEvidenceKeys,
-                )
-            }
+            // Each loser's record holds only what it adds to the survivor; see retiredByFold for why.
+            val retired = losers.map { loser -> retiredByFold(loser, survivor) }
             trace("recordDecision") {
                 traceStore.recordDecision(
                     runId,

--- a/dice/src/test/kotlin/com/embabel/dice/projection/memory/DuplicateCollectorStrategyTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/projection/memory/DuplicateCollectorStrategyTest.kt
@@ -18,8 +18,13 @@ package com.embabel.dice.projection.memory
 import com.embabel.agent.core.ContextId
 import com.embabel.agent.rag.service.Cluster
 import com.embabel.common.core.types.SimilarityResult
+import com.embabel.dice.projection.memory.collector.CollectorRunContext
 import com.embabel.dice.proposition.Proposition
 import com.embabel.dice.proposition.PropositionRepository
+import com.embabel.dice.provenance.ProvenanceEntry
+import com.embabel.dice.provenance.ProvenanceEvidenceKey
+import com.embabel.dice.provenance.UriLocator
+import com.embabel.dice.spi.InMemoryCollectorTraceStore
 import com.embabel.dice.spi.MarkReason
 import io.mockk.every
 import io.mockk.mockk
@@ -37,6 +42,7 @@ class DuplicateCollectorStrategyTest {
         text: String,
         confidence: Double = 0.8,
         reinforceCount: Int = 0,
+        provenance: List<ProvenanceEntry> = emptyList(),
     ): Proposition =
         Proposition(
             contextId = contextId,
@@ -45,6 +51,7 @@ class DuplicateCollectorStrategyTest {
             confidence = confidence,
             decay = 0.0,
             reinforceCount = reinforceCount,
+            provenanceEntries = provenance,
         )
 
     private fun cluster(anchor: Proposition, vararg similar: Proposition): Cluster<Proposition> =
@@ -160,6 +167,70 @@ class DuplicateCollectorStrategyTest {
         // a and c are the losers, both pointing at b as survivor.
         assertEquals(setOf(a.id, c.id), first.map { it.propositionId }.toSet())
         assertTrue(first.all { it.reason == MarkReason.Duplicate(b.id) })
+    }
+
+    @Test
+    fun `a traced run records one decision per collapsed component, holding what each loser folds in`() {
+        val shared = ProvenanceEntry(locator = UriLocator("https://example.com/shared"))
+        val extra = ProvenanceEntry(locator = UriLocator("https://example.com/extra"))
+        val strong = proposition("strong", confidence = 0.9, provenance = listOf(shared))
+        val weak = proposition("weak", confidence = 0.3, provenance = listOf(shared, extra))
+        val alone = proposition("alone", confidence = 0.5)
+        val repository = mockk<PropositionRepository>(relaxed = true)
+        every { repository.findClusters(any(), any(), any()) } returns
+            listOf(cluster(strong, weak), Cluster(alone, emptyList()))
+        val trace = InMemoryCollectorTraceStore()
+
+        val marks = DuplicateCollectorStrategy(traceStore = trace)
+            .mark(listOf(strong, weak, alone), repository, CollectorRunContext("run-1", contextId))
+
+        assertEquals(listOf(weak.id), marks.map { it.propositionId })
+        val decision = trace.decisionsFor("run-1").single()
+        assertEquals(strong.id, decision.survivorId)
+        assertEquals("duplicate-merge", decision.action)
+        val retired = decision.retired.single()
+        assertEquals(weak.id, retired.propositionId)
+        // Only the evidence the survivor lacked is written down as folded.
+        assertEquals(listOf(extra.locator.key()), retired.foldedProvenanceRefs)
+        assertEquals(listOf(ProvenanceEvidenceKey.encode(extra)), retired.foldedProvenanceEvidenceKeys)
+        assertEquals(1, trace.edgesFor("run-1").size)
+        assertEquals(0.95, trace.edgesFor("run-1").single().aggregateScore)
+        assertEquals(setOf(strong.id, weak.id), trace.componentsFor("run-1").single { it.memberIds.size == 2 }.memberIds.toSet())
+    }
+
+    @Test
+    fun `members grouped through an anchor outside the snapshot still get their edges recorded`() {
+        // The anchor is not a candidate, so it never joins the component, but the two members it
+        // clustered are unioned through it. The trace has to show the edges that did that.
+        val outside = proposition("outside", confidence = 0.9)
+        val a = proposition("a", confidence = 0.7)
+        val b = proposition("b", confidence = 0.4)
+        val repository = mockk<PropositionRepository>(relaxed = true)
+        every { repository.findClusters(any(), any(), any()) } returns listOf(cluster(outside, a, b))
+        val trace = InMemoryCollectorTraceStore()
+
+        val marks = DuplicateCollectorStrategy(traceStore = trace)
+            .mark(listOf(a, b), repository, CollectorRunContext("run-2", contextId))
+
+        assertEquals(listOf(b.id), marks.map { it.propositionId })
+        assertEquals(setOf(a.id, b.id), trace.componentsFor("run-2").single().memberIds.toSet())
+        val edgeEnds = trace.edgesFor("run-2").map { setOf(it.anchorId, it.memberId) }.toSet()
+        assertEquals(setOf(setOf(outside.id, a.id), setOf(outside.id, b.id)), edgeEnds)
+    }
+
+    @Test
+    fun `a blank run id records no trace`() {
+        val strong = proposition("strong", confidence = 0.9)
+        val weak = proposition("weak", confidence = 0.3)
+        val repository = mockk<PropositionRepository>(relaxed = true)
+        every { repository.findClusters(any(), any(), any()) } returns listOf(cluster(strong, weak))
+        val trace = InMemoryCollectorTraceStore()
+
+        val marks = DuplicateCollectorStrategy(traceStore = trace).mark(listOf(strong, weak), repository, contextId)
+
+        assertEquals(listOf(weak.id), marks.map { it.propositionId })
+        assertTrue(trace.decisionsFor("").isEmpty())
+        assertTrue(trace.edgesFor("").isEmpty())
     }
 
     @Test

--- a/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
+++ b/dice/src/test/kotlin/com/embabel/dice/spi/CollectorUndoCapabilityTest.kt
@@ -16,6 +16,9 @@
 package com.embabel.dice.spi
 
 import com.embabel.agent.core.ContextId
+import com.embabel.agent.rag.service.Cluster
+import com.embabel.common.core.types.SimilarityResult
+import com.embabel.common.core.types.ZeroToOne
 import com.embabel.dice.common.DiceEvent
 import com.embabel.dice.common.DiceEventListener
 import com.embabel.dice.common.PropositionPersisted
@@ -25,12 +28,14 @@ import com.embabel.dice.projection.lineage.CollectorRecordStore
 import com.embabel.dice.projection.lineage.CollectorRun
 import com.embabel.dice.projection.lineage.InMemoryCollectorRecordStore
 import com.embabel.dice.projection.memory.DefaultCollectorRunner
+import com.embabel.dice.projection.memory.DuplicateCollectorStrategy
 import com.embabel.dice.projection.memory.RunAwareCollectorStrategy
 import com.embabel.dice.projection.memory.collector.CollectorRunContext
 import com.embabel.dice.projection.memory.collector.CollectorSurvivorPolicy
 import com.embabel.dice.projection.memory.collector.MultiSignalCollectorStrategy
 import com.embabel.dice.proposition.EventEmittingPropositionRepository
 import com.embabel.dice.proposition.Proposition
+import com.embabel.dice.proposition.PropositionQuery
 import com.embabel.dice.proposition.PropositionRepository
 import com.embabel.dice.proposition.PropositionStatus
 import com.embabel.dice.proposition.PropositionStore
@@ -574,6 +579,88 @@ class CollectorUndoCapabilityTest {
         assertEquals(PropositionStatus.ACTIVE, store.findById(b.id)?.status)
         assertEquals(setOf(uniqueC), store.findById(c.id)?.provenanceEntries?.toSet())
     }
+
+    @Test
+    fun `a collapse the duplicate strategy applied is undone`() {
+        // The strategy withDuplicateDetection installs, run end to end through
+        // DefaultCollectorRunner with the merging policy, then reversed through the guarded undo.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        // Equal confidence and reinforce count, so the id tie-break picks the survivor: it sorts last.
+        val survivor = store.save(
+            proposition("survivor-duplicate", listOf(revisionOne), text = "Acme signed the agreement"),
+        )
+        val loser = store.save(
+            proposition("loser-duplicate", listOf(revisionOne, revisionTwo), text = "Acme signed an agreement"),
+        )
+
+        val runId = duplicateSweep(store, DuplicateCollectorStrategy(traceStore = trace), records, survivor, loser)
+
+        val decision = trace.findDecisionForProposition(loser.id)
+        assertEquals(runId, decision?.runId)
+        assertEquals(survivor.id, decision?.survivorId)
+        assertEquals(
+            listOf(ProvenanceEvidenceKey.encode(revisionTwo)),
+            decision?.retired?.single()?.foldedProvenanceEvidenceKeys,
+        )
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+        assertEquals(
+            listOf(survivor.id),
+            records.findByProposition(loser.id).filter { it.runId == runId }.map { it.mergedIntoId },
+        )
+
+        val result = undo(trace, store, survivor.id, loser.id, records)
+
+        assertEquals(listOf(revisionOne), result?.survivor?.provenanceEntries)
+        assertEquals(listOf(revisionOne), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.ACTIVE, store.findById(loser.id)?.status)
+    }
+
+    @Test
+    fun `a duplicate sweep with no trace store leaves nothing to undo`() {
+        // The audit records say the merge happened, but no decision was written, so the undo has
+        // no record of what moved and answers null without touching either proposition.
+        val store = InMemoryPropositionRepository()
+        val trace = InMemoryCollectorTraceStore()
+        val records = InMemoryCollectorRecordStore()
+        val survivor = store.save(proposition("survivor-untraced", listOf(revisionOne)))
+        val loser = store.save(proposition("loser-untraced", listOf(revisionOne, revisionTwo)))
+
+        val runId = duplicateSweep(store, DuplicateCollectorStrategy(), records, survivor, loser)
+
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+        assertEquals(
+            listOf(survivor.id),
+            records.findByProposition(loser.id).filter { it.runId == runId }.map { it.mergedIntoId },
+        )
+        assertNull(trace.findDecisionForProposition(loser.id))
+
+        assertNull(undo(trace, store, survivor.id, loser.id, records))
+
+        assertEquals(listOf(revisionOne, revisionTwo), store.findById(survivor.id)?.provenanceEntries)
+        assertEquals(PropositionStatus.STALE, store.findById(loser.id)?.status)
+        assertTrue(records.all().none { it.undoneAt != null })
+    }
+
+    /**
+     * Runs the real collector over one pair the duplicate strategy is told are near-duplicates.
+     * The in-memory store has no embeddings to cluster on, so the cluster is handed in.
+     */
+    private fun duplicateSweep(
+        store: InMemoryPropositionRepository,
+        strategy: DuplicateCollectorStrategy,
+        records: InMemoryCollectorRecordStore,
+        survivor: Proposition,
+        loser: Proposition,
+    ): String = DefaultCollectorRunner(
+        repository = ClusteringStore(store, Cluster(survivor, listOf(SimilarityResult.create(loser, 0.95)))),
+        strategies = listOf(strategy),
+        policy = MergingSweepPolicy(),
+        recordStore = records,
+        listener = DiceEventListener.DEV_NULL,
+    ).run(contextId).runId
 
     @Test
     fun `retrying an undo that already succeeded takes nothing further from the survivor`() {
@@ -1566,6 +1653,19 @@ class CollectorUndoCapabilityTest {
     private class NoSubtractionStore(
         delegate: InMemoryPropositionRepository,
     ) : PropositionRepository by delegate
+
+    /** Answers every cluster query with one fixed cluster; everything else goes to the real store. */
+    private class ClusteringStore(
+        delegate: InMemoryPropositionRepository,
+        private val cluster: Cluster<Proposition>,
+    ) : PropositionRepository by delegate {
+
+        override fun findClusters(
+            similarityThreshold: ZeroToOne,
+            topK: Int,
+            query: PropositionQuery,
+        ): List<Cluster<Proposition>> = listOf(cluster)
+    }
 
     /** Counts every write an undo attempts, so "nothing was written" is an assertion. */
     private class CountingStore(

--- a/docs/design/reclamation-and-collector.md
+++ b/docs/design/reclamation-and-collector.md
@@ -113,7 +113,9 @@ in a graph and collapsing each connected component to one survivor. It uses unio
 overlapping pairs (A≈B, B≈C) resolve to a single cluster {A,B,C} rather than fighting over who merges
 with whom — the result is deterministic regardless of the order pairs are discovered. Within a cluster
 the survivor is the strongest member (highest effective confidence, ties broken by id), and everyone
-else is marked `Duplicate`.
+else is marked `Duplicate`. Given a `CollectorTraceStore`, it also records a `CollectorDecision` per
+collapsed cluster (survivor, and what each loser folds in), which is what `undoSingleCollapse` reads;
+without one, a duplicate sweep cannot be undone.
 
 ```mermaid
 flowchart TB


### PR DESCRIPTION
## The bug

A sweep run with `DuplicateCollectorStrategy` wrote `CollectorRecord` rows naming the survivor and no `CollectorDecision`. `undoSingleCollapse` reads the collapse through `CollectorTraceQuery.findDecisionForProposition`, so a cosine collapse was applied and could not be undone. Only `MultiSignalCollectorStrategy` recorded decisions.

Observed live on 2026-09-02: `strategyName: "duplicate"`, trace endpoint `{"decisions":[],"edges":[]}`, unmerge 404 on the first call.

## The change

- `DuplicateCollectorStrategy` takes an optional third constructor argument, `traceStore: CollectorTraceStore?`, under `@JvmOverloads`, and implements `RunAwareCollectorStrategy` so it sees the run id. On a run with a non-blank run id it records the run context, one candidate edge per clustered pair (the repository's cosine score as the single signal), the union-find components, and one `CollectorDecision` per collapsed component with a `RetiredProposition` per loser. A blank run id (the read-only `collect()` path) records nothing. Trace writes are best effort, logged on failure.
- `retiredByFold` (new, `internal`, `collector/FoldedEvidence.kt`) computes what a loser adds to the survivor: exclusive grounding, provenance refs, evidence keys, source ids, prior status. `MultiSignalCollectorStrategy` now calls it too, so the two strategies share one rule.
- `CHANGELOG.md` under Unreleased / Fixed; one sentence in `docs/design/reclamation-and-collector.md`.

**Compatibility: additive.** The one- and two-argument constructors are unchanged. A strategy built without a trace store behaves as before.

## Tests

| Suite | Result |
| --- | --- |
| `CollectorUndoCapabilityTest` (+2: a duplicate-strategy collapse run through `DefaultCollectorRunner` and undone; the untraced sweep leaves nothing to undo) | 32/32 |
| `DuplicateCollectorStrategyTest` (+2: decision contents; blank run id records nothing) | 10/10 |
| `dice` module | 1535 tests, 0 failures |

Live, against Neo4j through a host application on the reinstalled jar: a real sweep collapsed a paraphrase; the trace endpoint returned one decision and one cosine edge; unmerge answered 200 and the member went STALE to ACTIVE with the survivor's evidence untouched and `undoneAt` stamped; a second unmerge answered 404; search listed the restored memory.

## Host follow-up

Dice's autoconfiguration only builds the multi-signal strategy. A host that builds `DuplicateCollectorStrategy` itself passes its `CollectorTraceStore` bean when constructing it.


## Review round

Adversarial review found no blocking issues. One medium finding fixed: when a cluster's anchor sits outside the candidate snapshot, the union-find still groups that cluster's candidate members, and no edge was recorded to explain the component. Edges are now emitted for every clustered pair that reached a candidate, with a unit test for that case.
