### PR TITLE
chore: upgrade GitHub Actions runtimes

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
       - name: Configure Maven Settings
-        uses: s4u/maven-settings-action@v2.8.0
+        uses: s4u/maven-settings-action@v4.0.0
         with:
           servers: ${{secrets.EMBABEL_ARTIFACTORY}}
       - name: Build and analyze

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions in the DICE build and snapshot deployment workflows to current Node.js 24-compatible releases.

## Changes

- Upgrade `actions/checkout` from v5 to v7 in the build workflow.
- Upgrade `actions/setup-java` from v5 to v6 in the build workflow.
- Upgrade `actions/checkout` from v4 to v7 in the snapshot deployment workflow.
- Upgrade `actions/setup-java` from v4 to v6 in the snapshot deployment workflow.
- Upgrade `s4u/maven-settings-action` from v2.8.0 to v4.0.0.

Existing workflow conditions, inputs, secrets, Maven commands, and deployment behavior remain unchanged.

## Validation

- `actionlint` passed.
- YAML lint passed.
- `git diff --check` passed.
- Verified all upgraded action tags exist and use Node.js 24.
- Confirmed no affected outdated action references remain.
- No Maven build or other heavy test suite was run.