### PR TITLE
Add wofkfow to publish User Buide and Dokka Docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,159 @@
+# Builds the DICE user guide (AsciiDoc) and the aggregated Dokka API docs, then publishes both
+# to the Embabel web server under a versioned path.
+#
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish Docs
+
+on:
+  # Triggered from the Build workflow when .adoc files change
+  repository_dispatch:
+    types: [publish-docs]
+
+  workflow_dispatch:  # Enables manual triggering
+    inputs:
+      environment:
+        description: 'Deploy Environment'
+        required: true
+        default: 'embabel-dev'
+        type: choice
+        options:
+          - embabel-dev
+          - embabel-sit
+          - embabel-prod
+      vm_instance:
+        description: 'VM Instance Name'
+        required: true
+        default: 'embabel-webserver'
+        type: string
+      vm_zone:
+        description: 'VM Zone'
+        required: true
+        default: 'us-east1-b'
+        type: string
+
+  # Automatic trigger on file changes
+  push:
+    branches:
+      - main
+    paths:
+      - 'dice-user-guide/**/*.adoc'
+
+env:
+  PROJECT_ID: ${{ github.event.inputs.environment || 'embabel-dev' }}
+  SERVICE_ACCOUNT: embabel-ci-build@embabel-dev.iam.gserviceaccount.com
+  VM_INSTANCE: ${{ github.event.inputs.vm_instance || 'embabel-webserver' }}
+  VM_ZONE: ${{ github.event.inputs.vm_zone || 'us-east1-b' }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    # Set default working directory for all steps.
+    # Building from the module directory keeps the parent pom resolvable on disk via the default
+    # relativePath, which is what makes ${project.parent.basedir} work for the dokka profile.
+    defaults:
+      run:
+        working-directory: ./dice-user-guide
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Graphviz
+        # The guide currently uses no diagram blocks, but asciidoctor-diagram is required by the
+        # pom — this keeps a future [graphviz] block from failing the publish.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build guide and API docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        run: mvn -B -Pguide-html,dokka package
+
+      - name: Extract version from pom.xml
+        id: get_version
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Create deployment archive
+        run: |
+          echo "Creating deployment archive at $(date)"
+          # Clean up any stale archive from previous runs
+          rm -f docs-bundle.tar.gz
+          cd target
+          tar -czf ../docs-bundle.tar.gz generated-docs dokka-aggregate
+          echo "Archive created at $(date), size: $(ls -lh ../docs-bundle.tar.gz | awk '{print $5}')"
+
+      - name: Google Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_CREDENTIALS }}
+          service_account: embabel-ci-build@embabel-dev.iam.gserviceaccount.com
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy archive to VM
+        run: |
+          echo "Starting deployment at $(date)"
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          echo "Deploying version: $VERSION"
+
+          # Upload the single archive file
+          gcloud compute scp docs-bundle.tar.gz \
+            ${{ github.event.inputs.vm_instance || 'embabel-webserver' }}:~/ \
+            --zone=${{ github.event.inputs.vm_zone || 'us-east1-b' }}
+
+          echo "Archive uploaded at $(date)"
+
+          # Extract and move files on the VM with versioned directories
+          gcloud compute ssh ${{ github.event.inputs.vm_instance || 'embabel-webserver' }} \
+            --zone=${{ github.event.inputs.vm_zone || 'us-east1-b' }} \
+            --command="
+              echo 'Starting extraction and deployment on VM at \$(date)' &&
+              VERSION='$VERSION' &&
+              echo 'Deploying version: $VERSION' &&
+              sudo rm -rf /var/www/html/dice/guide/\$VERSION &&
+              sudo rm -rf /var/www/html/dice/api-docs/\$VERSION &&
+              sudo mkdir -p /var/www/html/dice/guide/\$VERSION &&
+              sudo mkdir -p /var/www/html/dice/api-docs/\$VERSION &&
+              cd /tmp &&
+              sudo tar -xzf ~/docs-bundle.tar.gz &&
+              sudo cp -r generated-docs/* /var/www/html/dice/guide/\$VERSION/ &&
+              sudo cp -r dokka-aggregate/* /var/www/html/dice/api-docs/\$VERSION/ &&
+              rm -f ~/docs-bundle.tar.gz &&
+              sudo rm -rf /tmp/generated-docs /tmp/dokka-aggregate &&
+              echo 'Deployment completed on VM at \$(date)'
+            "
+
+          echo "Deployment completed at $(date)"
+
+          # Clean up local bundle
+          rm -f docs-bundle.tar.gz
+
+      - name: Verify deployment
+        run: |
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          gcloud compute ssh ${{ github.event.inputs.vm_instance || 'embabel-webserver' }} \
+            --zone=${{ github.event.inputs.vm_zone || 'us-east1-b' }} \
+            --command="
+              echo 'Deployed version: $VERSION' &&
+              echo 'Files in versioned guide directory:' &&
+              sudo ls -la /var/www/html/dice/guide/$VERSION/ | head -10 &&
+              echo 'Files in versioned api-docs directory:' &&
+              sudo ls -la /var/www/html/dice/api-docs/$VERSION/ | head -10 &&
+              echo 'Testing web access:' &&
+              curl -I http://localhost/dice/guide/$VERSION/index.html || echo 'Versioned guide not responding'
+            "

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,6 +16,20 @@ on:
     types: [ opened, synchronize, reopened ]
 
 jobs:
+  # Detect whether the user guide changed - runs first, in parallel with nothing
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs-changed: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'dice-user-guide/**/*.adoc'
+
   build:
 
     runs-on: ubuntu-latest
@@ -37,6 +51,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -U -B test verify
+
+  # Trigger the Publish Docs workflow if .adoc files changed (only on main branch push)
+  trigger-docs:
+    needs: [detect-changes, build]
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.detect-changes.outputs.docs-changed == 'true'
+    steps:
+      - name: Trigger Publish Docs workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          repository: ${{ github.repository }}
+          event-type: publish-docs
 
   notify:
     needs: [build]

--- a/dice-user-guide/README.md
+++ b/dice-user-guide/README.md
@@ -37,6 +37,37 @@ docling ./target/generated-docs/index.html --from html --to md \
 
 This writes `index.md` alongside the HTML.
 
+## Publishing
+
+`.github/workflows/deploy-docs.yml` ("Publish Docs") builds the guide and the aggregated Dokka API
+docs and deploys both to the Embabel web server under a versioned path:
+
+- `https://docs.embabel.com/dice/guide/<version>/index.html`
+- `https://docs.embabel.com/dice/api-docs/<version>/index.html`
+
+It runs on three triggers:
+
+| Trigger | When |
+|---|---|
+| `repository_dispatch` (`publish-docs`) | The Build workflow's `trigger-docs` job fires it after a green build on `main` that touched a `.adoc` file. |
+| `push` to `main` | Any push touching `dice-user-guide/**/*.adoc`. |
+| `workflow_dispatch` | Manually, with environment / VM instance / zone as inputs. |
+
+The build step is `mvn -B -Pguide-html,dokka package`, run from this directory so the parent pom
+resolves on disk — which is what makes `${project.parent.basedir}` work for the dokka profile's
+sibling-module source paths.
+
+Required repository secrets: `GCP_SERVICE_ACCOUNT_CREDENTIALS` (deploy) and `PAT_TOKEN` (the
+dispatch from Build).
+
+Build the API docs locally with:
+
+```bash
+mvn -pl dice-user-guide -P guide-html,dokka package
+```
+
+Output lands in `target/dokka-aggregate`.
+
 ## Layout
 
 | Path | Contents |

--- a/dice-user-guide/pom.xml
+++ b/dice-user-guide/pom.xml
@@ -184,6 +184,70 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!--
+                Aggregate API docs for every published module into one Dokka site.
+                Activated explicitly by the Publish Docs workflow: mvn -Pguide-html,dokka package
+            -->
+            <id>dokka</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>aggregate-docs</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>dokka</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Collect source from all sibling modules -->
+                                    <sourceDirectories>
+                                        <dir>${project.parent.basedir}/dice/src/main/kotlin</dir>
+                                        <dir>${project.parent.basedir}/dice-storage/src/main/kotlin</dir>
+                                        <dir>${project.parent.basedir}/dice-storage-autoconfigure/src/main/kotlin</dir>
+                                        <dir>${project.parent.basedir}/dice-report/src/main/kotlin</dir>
+                                        <dir>${project.parent.basedir}/dice-ingestion/src/main/kotlin</dir>
+                                    </sourceDirectories>
+                                    <!--
+                                        Override the samples directory inherited from
+                                        embabel-build-parent's plugin configuration, which points at
+                                        this module's own src/test/kotlin and does not exist here.
+                                    -->
+                                    <samples>
+                                        <dir>${project.parent.basedir}/dice/src/test/kotlin</dir>
+                                    </samples>
+                                    <!-- Platform settings -->
+                                    <platform>jvm</platform>
+                                    <includeNonPublic>false</includeNonPublic>
+                                    <reportUndocumented>true</reportUndocumented>
+                                    <skipEmptyPackages>true</skipEmptyPackages>
+                                    <jdkVersion>${java.version}</jdkVersion>
+                                    <languageVersion>${kotlin.compiler.apiVersion}</languageVersion>
+                                    <apiVersion>${kotlin.compiler.apiVersion}</apiVersion>
+                                    <noStdlibLink>false</noStdlibLink>
+                                    <noJdkLink>false</noJdkLink>
+                                    <suppressObviousFunctions>true</suppressObviousFunctions>
+                                    <outputDir>${project.build.directory}/dokka-aggregate</outputDir>
+                                    <moduleName>DICE API Documentation</moduleName>
+                                    <externalDocumentationLinks>
+                                        <link>
+                                            <url>https://docs.spring.io/spring-framework/docs/current/javadoc-api/</url>
+                                        </link>
+                                        <link>
+                                            <url>https://docs.spring.io/spring-boot/docs/current/api/</url>
+                                        </link>
+                                    </externalDocumentationLinks>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 
 </project>

--- a/dice-user-guide/src/main/asciidoc/docinfo.html
+++ b/dice-user-guide/src/main/asciidoc/docinfo.html
@@ -7,6 +7,15 @@
         </div>
         <div class="navbar-actions">
             <a
+                    href="https://docs.embabel.com/dice/api-docs/{dice-version}/index.html"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    class="link-button"
+            >
+                <i class="fa fa-code api-icon"></i>
+                API Docs
+            </a>
+            <a
                     href="https://github.com/embabel/dice"
                     target="_blank"
                     rel="noreferrer noopener"


### PR DESCRIPTION
This pull request introduces a new automated workflow for building and deploying the DICE user guide and aggregated Dokka API documentation to the Embabel web server. It adds a versioned publishing pipeline, integrates change detection for documentation files, and provides clear instructions and configuration for local and CI builds. The most important changes are as follows:

**CI/CD Workflow Enhancements:**

* Added a new `.github/workflows/deploy-docs.yml` workflow that builds the user guide and aggregated Dokka API docs, then deploys them to the Embabel web server under a versioned path. The workflow supports triggers on manual dispatch, repository dispatch, and `.adoc` file changes on the `main` branch.
* Updated `.github/workflows/maven.yml` to detect changes in `.adoc` files, and to trigger the new Publish Docs workflow automatically after a successful build when documentation changes are detected on `main`. [[1]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446R19-R32) [[2]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446R55-R70)

**Documentation and Build Configuration:**

* Added a new Maven profile `dokka` in `dice-user-guide/pom.xml` to aggregate API docs from all sibling modules into a single Dokka site, which is used by the Publish Docs workflow.
* Updated `dice-user-guide/README.md` with detailed publishing instructions, describing workflow triggers, required secrets, and how to build the docs locally.

**User Guide Improvements:**

* Added an "API Docs" button to the user guide navigation bar, linking directly to the published aggregated API documentation for the current version.